### PR TITLE
template,echo: add ability to use per-handler middlewares

### DIFF
--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -904,67 +904,128 @@ type ServerInterfaceWrapper struct {
 	Handler ServerInterface
 }
 
+// SetContextPostBoth sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextPostBoth(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // PostBoth converts echo context to params.
 func (w *ServerInterfaceWrapper) PostBoth(ctx echo.Context) error {
 	var err error
+
+	w.SetContextPostBoth(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.PostBoth(ctx)
 	return err
 }
 
+// SetContextGetBoth sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetBoth(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetBoth converts echo context to params.
 func (w *ServerInterfaceWrapper) GetBoth(ctx echo.Context) error {
 	var err error
+
+	w.SetContextGetBoth(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetBoth(ctx)
 	return err
 }
 
+// SetContextPostJson sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextPostJson(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // PostJson converts echo context to params.
 func (w *ServerInterfaceWrapper) PostJson(ctx echo.Context) error {
 	var err error
+
+	w.SetContextPostJson(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.PostJson(ctx)
 	return err
 }
 
+// SetContextGetJson sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetJson(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Set(OpenIdScopes, []string{"json.read", "json.admin"})
+		return next(ctx)
+	}
+}
+
 // GetJson converts echo context to params.
 func (w *ServerInterfaceWrapper) GetJson(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(OpenIdScopes, []string{"json.read", "json.admin"})
+	w.SetContextGetJson(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetJson(ctx)
 	return err
 }
 
+// SetContextPostOther sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextPostOther(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // PostOther converts echo context to params.
 func (w *ServerInterfaceWrapper) PostOther(ctx echo.Context) error {
 	var err error
+
+	w.SetContextPostOther(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.PostOther(ctx)
 	return err
 }
 
+// SetContextGetOther sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetOther(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetOther converts echo context to params.
 func (w *ServerInterfaceWrapper) GetOther(ctx echo.Context) error {
 	var err error
+
+	w.SetContextGetOther(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetOther(ctx)
 	return err
 }
 
+// SetContextGetJsonWithTrailingSlash sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetJsonWithTrailingSlash(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Set(OpenIdScopes, []string{"json.read", "json.admin"})
+		return next(ctx)
+	}
+}
+
 // GetJsonWithTrailingSlash converts echo context to params.
 func (w *ServerInterfaceWrapper) GetJsonWithTrailingSlash(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(OpenIdScopes, []string{"json.read", "json.admin"})
+	w.SetContextGetJsonWithTrailingSlash(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetJsonWithTrailingSlash(ctx)
@@ -1016,13 +1077,13 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, opts Reg
 		Handler: si,
 	}
 
-	router.POST(opts.BaseURL+"/with_both_bodies", wrapper.PostBoth, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/with_both_responses", wrapper.GetBoth, opts.Middlewares...)
-	router.POST(opts.BaseURL+"/with_json_body", wrapper.PostJson, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/with_json_response", wrapper.GetJson, opts.Middlewares...)
-	router.POST(opts.BaseURL+"/with_other_body", wrapper.PostOther, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/with_other_response", wrapper.GetOther, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/with_trailing_slash/", wrapper.GetJsonWithTrailingSlash, opts.Middlewares...)
+	router.POST(opts.BaseURL+"/with_both_bodies", wrapper.PostBoth, append([]echo.MiddlewareFunc{wrapper.SetContextPostBoth}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/with_both_responses", wrapper.GetBoth, append([]echo.MiddlewareFunc{wrapper.SetContextGetBoth}, opts.Middlewares...)...)
+	router.POST(opts.BaseURL+"/with_json_body", wrapper.PostJson, append([]echo.MiddlewareFunc{wrapper.SetContextPostJson}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/with_json_response", wrapper.GetJson, append([]echo.MiddlewareFunc{wrapper.SetContextGetJson}, opts.Middlewares...)...)
+	router.POST(opts.BaseURL+"/with_other_body", wrapper.PostOther, append([]echo.MiddlewareFunc{wrapper.SetContextPostOther}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/with_other_response", wrapper.GetOther, append([]echo.MiddlewareFunc{wrapper.SetContextGetOther}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/with_trailing_slash/", wrapper.GetJsonWithTrailingSlash, append([]echo.MiddlewareFunc{wrapper.SetContextGetJsonWithTrailingSlash}, opts.Middlewares...)...)
 
 }
 

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -324,9 +324,18 @@ type ServerInterfaceWrapper struct {
 	Handler ServerInterface
 }
 
+// SetContextExampleGet sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextExampleGet(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // ExampleGet converts echo context to params.
 func (w *ServerInterfaceWrapper) ExampleGet(ctx echo.Context) error {
 	var err error
+
+	w.SetContextExampleGet(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.ExampleGet(ctx)
@@ -378,7 +387,7 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, opts Reg
 		Handler: si,
 	}
 
-	router.GET(opts.BaseURL+"/example", wrapper.ExampleGet, opts.Middlewares...)
+	router.GET(opts.BaseURL+"/example", wrapper.ExampleGet, append([]echo.MiddlewareFunc{wrapper.SetContextExampleGet}, opts.Middlewares...)...)
 
 }
 

--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -276,9 +276,18 @@ type ServerInterfaceWrapper struct {
 	Handler ServerInterface
 }
 
+// SetContextGetFoo sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetFoo(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetFoo converts echo context to params.
 func (w *ServerInterfaceWrapper) GetFoo(ctx echo.Context) error {
 	var err error
+
+	w.SetContextGetFoo(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetFoo(ctx)
@@ -330,7 +339,7 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, opts Reg
 		Handler: si,
 	}
 
-	router.GET(opts.BaseURL+"/foo", wrapper.GetFoo, opts.Middlewares...)
+	router.GET(opts.BaseURL+"/foo", wrapper.GetFoo, append([]echo.MiddlewareFunc{wrapper.SetContextGetFoo}, opts.Middlewares...)...)
 
 }
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -2609,6 +2609,13 @@ type ServerInterfaceWrapper struct {
 	Handler ServerInterface
 }
 
+// SetContextGetContentObject sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetContentObject(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetContentObject converts echo context to params.
 func (w *ServerInterfaceWrapper) GetContentObject(ctx echo.Context) error {
 	var err error
@@ -2620,14 +2627,25 @@ func (w *ServerInterfaceWrapper) GetContentObject(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Error unmarshaling parameter 'param' as JSON")
 	}
 
+	w.SetContextGetContentObject(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetContentObject(ctx, param)
 	return err
 }
 
+// SetContextGetCookie sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetCookie(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetCookie converts echo context to params.
 func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 	var err error
+
+	w.SetContextGetCookie(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetCookieParams
@@ -2730,9 +2748,18 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 	return err
 }
 
+// SetContextGetHeader sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetHeader(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetHeader converts echo context to params.
 func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 	var err error
+
+	w.SetContextGetHeader(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetHeaderParams
@@ -2864,6 +2891,13 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 	return err
 }
 
+// SetContextGetLabelExplodeArray sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetLabelExplodeArray(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetLabelExplodeArray converts echo context to params.
 func (w *ServerInterfaceWrapper) GetLabelExplodeArray(ctx echo.Context) error {
 	var err error
@@ -2875,9 +2909,18 @@ func (w *ServerInterfaceWrapper) GetLabelExplodeArray(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
+	w.SetContextGetLabelExplodeArray(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetLabelExplodeArray(ctx, param)
 	return err
+}
+
+// SetContextGetLabelExplodeObject sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetLabelExplodeObject(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetLabelExplodeObject converts echo context to params.
@@ -2891,9 +2934,18 @@ func (w *ServerInterfaceWrapper) GetLabelExplodeObject(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
+	w.SetContextGetLabelExplodeObject(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetLabelExplodeObject(ctx, param)
 	return err
+}
+
+// SetContextGetLabelNoExplodeArray sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetLabelNoExplodeArray(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetLabelNoExplodeArray converts echo context to params.
@@ -2907,9 +2959,18 @@ func (w *ServerInterfaceWrapper) GetLabelNoExplodeArray(ctx echo.Context) error 
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
+	w.SetContextGetLabelNoExplodeArray(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetLabelNoExplodeArray(ctx, param)
 	return err
+}
+
+// SetContextGetLabelNoExplodeObject sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetLabelNoExplodeObject(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetLabelNoExplodeObject converts echo context to params.
@@ -2923,9 +2984,18 @@ func (w *ServerInterfaceWrapper) GetLabelNoExplodeObject(ctx echo.Context) error
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
+	w.SetContextGetLabelNoExplodeObject(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetLabelNoExplodeObject(ctx, param)
 	return err
+}
+
+// SetContextGetMatrixExplodeArray sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetMatrixExplodeArray(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetMatrixExplodeArray converts echo context to params.
@@ -2939,9 +3009,18 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodeArray(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
+	w.SetContextGetMatrixExplodeArray(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetMatrixExplodeArray(ctx, id)
 	return err
+}
+
+// SetContextGetMatrixExplodeObject sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetMatrixExplodeObject(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetMatrixExplodeObject converts echo context to params.
@@ -2955,9 +3034,18 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodeObject(ctx echo.Context) error 
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
+	w.SetContextGetMatrixExplodeObject(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetMatrixExplodeObject(ctx, id)
 	return err
+}
+
+// SetContextGetMatrixNoExplodeArray sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetMatrixNoExplodeArray(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetMatrixNoExplodeArray converts echo context to params.
@@ -2971,9 +3059,18 @@ func (w *ServerInterfaceWrapper) GetMatrixNoExplodeArray(ctx echo.Context) error
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
+	w.SetContextGetMatrixNoExplodeArray(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetMatrixNoExplodeArray(ctx, id)
 	return err
+}
+
+// SetContextGetMatrixNoExplodeObject sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetMatrixNoExplodeObject(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetMatrixNoExplodeObject converts echo context to params.
@@ -2987,9 +3084,18 @@ func (w *ServerInterfaceWrapper) GetMatrixNoExplodeObject(ctx echo.Context) erro
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
+	w.SetContextGetMatrixNoExplodeObject(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetMatrixNoExplodeObject(ctx, id)
 	return err
+}
+
+// SetContextGetPassThrough sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetPassThrough(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetPassThrough converts echo context to params.
@@ -3000,14 +3106,25 @@ func (w *ServerInterfaceWrapper) GetPassThrough(ctx echo.Context) error {
 
 	param = ctx.Param("param")
 
+	w.SetContextGetPassThrough(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetPassThrough(ctx, param)
 	return err
 }
 
+// SetContextGetDeepObject sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetDeepObject(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetDeepObject converts echo context to params.
 func (w *ServerInterfaceWrapper) GetDeepObject(ctx echo.Context) error {
 	var err error
+
+	w.SetContextGetDeepObject(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetDeepObjectParams
@@ -3023,9 +3140,18 @@ func (w *ServerInterfaceWrapper) GetDeepObject(ctx echo.Context) error {
 	return err
 }
 
+// SetContextGetQueryForm sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetQueryForm(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetQueryForm converts echo context to params.
 func (w *ServerInterfaceWrapper) GetQueryForm(ctx echo.Context) error {
 	var err error
+
+	w.SetContextGetQueryForm(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetQueryFormParams
@@ -3103,6 +3229,13 @@ func (w *ServerInterfaceWrapper) GetQueryForm(ctx echo.Context) error {
 	return err
 }
 
+// SetContextGetSimpleExplodeArray sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetSimpleExplodeArray(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
+}
+
 // GetSimpleExplodeArray converts echo context to params.
 func (w *ServerInterfaceWrapper) GetSimpleExplodeArray(ctx echo.Context) error {
 	var err error
@@ -3114,9 +3247,18 @@ func (w *ServerInterfaceWrapper) GetSimpleExplodeArray(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
+	w.SetContextGetSimpleExplodeArray(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetSimpleExplodeArray(ctx, param)
 	return err
+}
+
+// SetContextGetSimpleExplodeObject sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetSimpleExplodeObject(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetSimpleExplodeObject converts echo context to params.
@@ -3130,9 +3272,18 @@ func (w *ServerInterfaceWrapper) GetSimpleExplodeObject(ctx echo.Context) error 
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
+	w.SetContextGetSimpleExplodeObject(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetSimpleExplodeObject(ctx, param)
 	return err
+}
+
+// SetContextGetSimpleNoExplodeArray sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetSimpleNoExplodeArray(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetSimpleNoExplodeArray converts echo context to params.
@@ -3146,9 +3297,18 @@ func (w *ServerInterfaceWrapper) GetSimpleNoExplodeArray(ctx echo.Context) error
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
+	w.SetContextGetSimpleNoExplodeArray(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetSimpleNoExplodeArray(ctx, param)
 	return err
+}
+
+// SetContextGetSimpleNoExplodeObject sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetSimpleNoExplodeObject(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetSimpleNoExplodeObject converts echo context to params.
@@ -3162,9 +3322,18 @@ func (w *ServerInterfaceWrapper) GetSimpleNoExplodeObject(ctx echo.Context) erro
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
+	w.SetContextGetSimpleNoExplodeObject(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetSimpleNoExplodeObject(ctx, param)
 	return err
+}
+
+// SetContextGetSimplePrimitive sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetSimplePrimitive(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetSimplePrimitive converts echo context to params.
@@ -3178,9 +3347,18 @@ func (w *ServerInterfaceWrapper) GetSimplePrimitive(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
+	w.SetContextGetSimplePrimitive(func(ctx echo.Context) error { return nil })(ctx)
+
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetSimplePrimitive(ctx, param)
 	return err
+}
+
+// SetContextGetStartingWithNumber sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextGetStartingWithNumber(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		return next(ctx)
+	}
 }
 
 // GetStartingWithNumber converts echo context to params.
@@ -3190,6 +3368,8 @@ func (w *ServerInterfaceWrapper) GetStartingWithNumber(ctx echo.Context) error {
 	var n1param string
 
 	n1param = ctx.Param("1param")
+
+	w.SetContextGetStartingWithNumber(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetStartingWithNumber(ctx, n1param)
@@ -3241,26 +3421,26 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, opts Reg
 		Handler: si,
 	}
 
-	router.GET(opts.BaseURL+"/contentObject/:param", wrapper.GetContentObject, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/cookie", wrapper.GetCookie, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/header", wrapper.GetHeader, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/labelExplodeArray/:param", wrapper.GetLabelExplodeArray, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/labelExplodeObject/:param", wrapper.GetLabelExplodeObject, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/labelNoExplodeArray/:param", wrapper.GetLabelNoExplodeArray, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/labelNoExplodeObject/:param", wrapper.GetLabelNoExplodeObject, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/matrixExplodeArray/:id", wrapper.GetMatrixExplodeArray, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/matrixExplodeObject/:id", wrapper.GetMatrixExplodeObject, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/matrixNoExplodeArray/:id", wrapper.GetMatrixNoExplodeArray, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/matrixNoExplodeObject/:id", wrapper.GetMatrixNoExplodeObject, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/passThrough/:param", wrapper.GetPassThrough, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/queryDeepObject", wrapper.GetDeepObject, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/queryForm", wrapper.GetQueryForm, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/simpleExplodeArray/:param", wrapper.GetSimpleExplodeArray, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/simpleExplodeObject/:param", wrapper.GetSimpleExplodeObject, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/simpleNoExplodeArray/:param", wrapper.GetSimpleNoExplodeArray, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/simpleNoExplodeObject/:param", wrapper.GetSimpleNoExplodeObject, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/simplePrimitive/:param", wrapper.GetSimplePrimitive, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/startingWithNumber/:1param", wrapper.GetStartingWithNumber, opts.Middlewares...)
+	router.GET(opts.BaseURL+"/contentObject/:param", wrapper.GetContentObject, append([]echo.MiddlewareFunc{wrapper.SetContextGetContentObject}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/cookie", wrapper.GetCookie, append([]echo.MiddlewareFunc{wrapper.SetContextGetCookie}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/header", wrapper.GetHeader, append([]echo.MiddlewareFunc{wrapper.SetContextGetHeader}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/labelExplodeArray/:param", wrapper.GetLabelExplodeArray, append([]echo.MiddlewareFunc{wrapper.SetContextGetLabelExplodeArray}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/labelExplodeObject/:param", wrapper.GetLabelExplodeObject, append([]echo.MiddlewareFunc{wrapper.SetContextGetLabelExplodeObject}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/labelNoExplodeArray/:param", wrapper.GetLabelNoExplodeArray, append([]echo.MiddlewareFunc{wrapper.SetContextGetLabelNoExplodeArray}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/labelNoExplodeObject/:param", wrapper.GetLabelNoExplodeObject, append([]echo.MiddlewareFunc{wrapper.SetContextGetLabelNoExplodeObject}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/matrixExplodeArray/:id", wrapper.GetMatrixExplodeArray, append([]echo.MiddlewareFunc{wrapper.SetContextGetMatrixExplodeArray}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/matrixExplodeObject/:id", wrapper.GetMatrixExplodeObject, append([]echo.MiddlewareFunc{wrapper.SetContextGetMatrixExplodeObject}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/matrixNoExplodeArray/:id", wrapper.GetMatrixNoExplodeArray, append([]echo.MiddlewareFunc{wrapper.SetContextGetMatrixNoExplodeArray}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/matrixNoExplodeObject/:id", wrapper.GetMatrixNoExplodeObject, append([]echo.MiddlewareFunc{wrapper.SetContextGetMatrixNoExplodeObject}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/passThrough/:param", wrapper.GetPassThrough, append([]echo.MiddlewareFunc{wrapper.SetContextGetPassThrough}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/queryDeepObject", wrapper.GetDeepObject, append([]echo.MiddlewareFunc{wrapper.SetContextGetDeepObject}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/queryForm", wrapper.GetQueryForm, append([]echo.MiddlewareFunc{wrapper.SetContextGetQueryForm}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/simpleExplodeArray/:param", wrapper.GetSimpleExplodeArray, append([]echo.MiddlewareFunc{wrapper.SetContextGetSimpleExplodeArray}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/simpleExplodeObject/:param", wrapper.GetSimpleExplodeObject, append([]echo.MiddlewareFunc{wrapper.SetContextGetSimpleExplodeObject}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/simpleNoExplodeArray/:param", wrapper.GetSimpleNoExplodeArray, append([]echo.MiddlewareFunc{wrapper.SetContextGetSimpleNoExplodeArray}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/simpleNoExplodeObject/:param", wrapper.GetSimpleNoExplodeObject, append([]echo.MiddlewareFunc{wrapper.SetContextGetSimpleNoExplodeObject}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/simplePrimitive/:param", wrapper.GetSimplePrimitive, append([]echo.MiddlewareFunc{wrapper.SetContextGetSimplePrimitive}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/startingWithNumber/:1param", wrapper.GetStartingWithNumber, append([]echo.MiddlewareFunc{wrapper.SetContextGetStartingWithNumber}, opts.Middlewares...)...)
 
 }
 

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -1038,37 +1038,69 @@ type ServerInterfaceWrapper struct {
 	Handler ServerInterface
 }
 
+// SetContextEnsureEverythingIsReferenced sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextEnsureEverythingIsReferenced(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Set(Access_tokenScopes, []string{""})
+		return next(ctx)
+	}
+}
+
 // EnsureEverythingIsReferenced converts echo context to params.
 func (w *ServerInterfaceWrapper) EnsureEverythingIsReferenced(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	w.SetContextEnsureEverythingIsReferenced(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.EnsureEverythingIsReferenced(ctx)
 	return err
 }
 
+// SetContextIssue127 sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextIssue127(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Set(Access_tokenScopes, []string{""})
+		return next(ctx)
+	}
+}
+
 // Issue127 converts echo context to params.
 func (w *ServerInterfaceWrapper) Issue127(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	w.SetContextIssue127(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue127(ctx)
 	return err
 }
 
+// SetContextIssue185 sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextIssue185(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Set(Access_tokenScopes, []string{""})
+		return next(ctx)
+	}
+}
+
 // Issue185 converts echo context to params.
 func (w *ServerInterfaceWrapper) Issue185(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	w.SetContextIssue185(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue185(ctx)
 	return err
+}
+
+// SetContextIssue209 sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextIssue209(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Set(Access_tokenScopes, []string{""})
+		return next(ctx)
+	}
 }
 
 // Issue209 converts echo context to params.
@@ -1082,11 +1114,19 @@ func (w *ServerInterfaceWrapper) Issue209(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter str: %s", err))
 	}
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	w.SetContextIssue209(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue209(ctx, str)
 	return err
+}
+
+// SetContextIssue30 sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextIssue30(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Set(Access_tokenScopes, []string{""})
+		return next(ctx)
+	}
 }
 
 // Issue30 converts echo context to params.
@@ -1100,11 +1140,19 @@ func (w *ServerInterfaceWrapper) Issue30(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter fallthrough: %s", err))
 	}
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	w.SetContextIssue30(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue30(ctx, pFallthrough)
 	return err
+}
+
+// SetContextIssue41 sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextIssue41(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Set(Access_tokenScopes, []string{""})
+		return next(ctx)
+	}
 }
 
 // Issue41 converts echo context to params.
@@ -1118,18 +1166,26 @@ func (w *ServerInterfaceWrapper) Issue41(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1param: %s", err))
 	}
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	w.SetContextIssue41(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue41(ctx, n1param)
 	return err
 }
 
+// SetContextIssue9 sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContextIssue9(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Set(Access_tokenScopes, []string{""})
+		return next(ctx)
+	}
+}
+
 // Issue9 converts echo context to params.
 func (w *ServerInterfaceWrapper) Issue9(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	w.SetContextIssue9(func(ctx echo.Context) error { return nil })(ctx)
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params Issue9Params
@@ -1190,13 +1246,13 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, opts Reg
 		Handler: si,
 	}
 
-	router.GET(opts.BaseURL+"/ensure-everything-is-referenced", wrapper.EnsureEverythingIsReferenced, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/issues/127", wrapper.Issue127, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/issues/185", wrapper.Issue185, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/issues/209/$:str", wrapper.Issue209, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/issues/30/:fallthrough", wrapper.Issue30, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/issues/41/:1param", wrapper.Issue41, opts.Middlewares...)
-	router.GET(opts.BaseURL+"/issues/9", wrapper.Issue9, opts.Middlewares...)
+	router.GET(opts.BaseURL+"/ensure-everything-is-referenced", wrapper.EnsureEverythingIsReferenced, append([]echo.MiddlewareFunc{wrapper.SetContextEnsureEverythingIsReferenced}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/issues/127", wrapper.Issue127, append([]echo.MiddlewareFunc{wrapper.SetContextIssue127}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/issues/185", wrapper.Issue185, append([]echo.MiddlewareFunc{wrapper.SetContextIssue185}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/issues/209/$:str", wrapper.Issue209, append([]echo.MiddlewareFunc{wrapper.SetContextIssue209}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/issues/30/:fallthrough", wrapper.Issue30, append([]echo.MiddlewareFunc{wrapper.SetContextIssue30}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/issues/41/:1param", wrapper.Issue41, append([]echo.MiddlewareFunc{wrapper.SetContextIssue41}, opts.Middlewares...)...)
+	router.GET(opts.BaseURL+"/issues/9", wrapper.Issue9, append([]echo.MiddlewareFunc{wrapper.SetContextIssue9}, opts.Middlewares...)...)
 
 }
 

--- a/pkg/codegen/templates/echo/echo-register.tmpl
+++ b/pkg/codegen/templates/echo/echo-register.tmpl
@@ -45,6 +45,6 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, opts Reg
 		Handler: si,
 	}
 {{end}}
-{{range .}}router.{{.Method}}(opts.BaseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.OperationId}}, opts.Middlewares...)
+{{range .}}router.{{.Method}}(opts.BaseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.OperationId}}, append([]echo.MiddlewareFunc{wrapper.SetContext{{.OperationId}}}, opts.Middlewares...)...)
 {{end}}
 }

--- a/pkg/codegen/templates/echo/echo-wrappers.tmpl
+++ b/pkg/codegen/templates/echo/echo-wrappers.tmpl
@@ -3,7 +3,18 @@ type ServerInterfaceWrapper struct {
     Handler ServerInterface
 }
 
-{{range .}}{{$opid := .OperationId}}// {{$opid}} converts echo context to params.
+{{range .}}{{$opid := .OperationId -}}
+// SetContext{{.OperationId}} sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContext{{.OperationId}} (next echo.HandlerFunc) echo.HandlerFunc {
+    return func(ctx echo.Context) error {
+{{- range .SecurityDefinitions}}
+        ctx.Set({{.ProviderName | sanitizeGoIdentity | ucFirst}}Scopes, {{toStringArray .Scopes}})
+{{- end}}
+        return next(ctx)
+    }
+}
+
+// {{$opid}} converts echo context to params.
 func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     var err error
 {{range .PathParams}}// ------------- Path parameter "{{.ParamName}}" -------------
@@ -25,9 +36,12 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{end}}
 {{end}}
 
-{{range .SecurityDefinitions}}
-    ctx.Set({{.ProviderName | sanitizeGoIdentity | ucFirst}}Scopes, {{toStringArray .Scopes}})
-{{end}}
+    {{- /* This rather ugly bit calls the per-handler middleware in order
+           to maintain backward-compatibility: if the Register functions
+           aren't called by the user, we still need to set the context
+           keys like authentication scopes that would normally get
+           set as part of the per-handler middleware. */}}
+    w.SetContext{{.OperationId}}(func (ctx echo.Context) error { return nil })(ctx)
 
 {{if .RequiresParamObject}}
     // Parameter object where we will unmarshal all parameters from the context

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -781,7 +781,7 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, opts Reg
 		Handler: si,
 	}
 {{end}}
-{{range .}}router.{{.Method}}(opts.BaseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.OperationId}}, opts.Middlewares...)
+{{range .}}router.{{.Method}}(opts.BaseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.OperationId}}, append([]echo.MiddlewareFunc{wrapper.SetContext{{.OperationId}}}, opts.Middlewares...)...)
 {{end}}
 }
 `,
@@ -790,7 +790,18 @@ type ServerInterfaceWrapper struct {
     Handler ServerInterface
 }
 
-{{range .}}{{$opid := .OperationId}}// {{$opid}} converts echo context to params.
+{{range .}}{{$opid := .OperationId -}}
+// SetContext{{.OperationId}} sets route-specific data (like authentication scopes) in the echo Context.
+func (w *ServerInterfaceWrapper) SetContext{{.OperationId}} (next echo.HandlerFunc) echo.HandlerFunc {
+    return func(ctx echo.Context) error {
+{{- range .SecurityDefinitions}}
+        ctx.Set({{.ProviderName | sanitizeGoIdentity | ucFirst}}Scopes, {{toStringArray .Scopes}})
+{{- end}}
+        return next(ctx)
+    }
+}
+
+// {{$opid}} converts echo context to params.
 func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     var err error
 {{range .PathParams}}// ------------- Path parameter "{{.ParamName}}" -------------
@@ -812,9 +823,12 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{end}}
 {{end}}
 
-{{range .SecurityDefinitions}}
-    ctx.Set({{.ProviderName | sanitizeGoIdentity | ucFirst}}Scopes, {{toStringArray .Scopes}})
-{{end}}
+    {{- /* This rather ugly bit calls the per-handler middleware in order
+           to maintain backward-compatibility: if the Register functions
+           aren't called by the user, we still need to set the context
+           keys like authentication scopes that would normally get
+           set as part of the per-handler middleware. */}}
+    w.SetContext{{.OperationId}}(func (ctx echo.Context) error { return nil })(ctx)
 
 {{if .RequiresParamObject}}
     // Parameter object where we will unmarshal all parameters from the context


### PR DESCRIPTION
This is essentially the same thing as #259, but for echo.

I could not find a way to access the OAuth scope of the route from the normal
middlewares, as the value gets set by ServerInterfaceWrapper. With this change,
it's now possible to add a middleware to check that the scope is valid prior
to running the actual handler.

This commit introduces a new Middlewares field to ServerInterfaceWrapper,
which is a slice of echo.MiddlewareFunc, that gets registered as per-handler
middlewares. It also adds a new registration function, RegisterHandlersWithOptions,
to allow users to specify these middlewares.