### PR TITLE
Avoid naming conflicts

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -394,6 +394,7 @@ func GenerateTypesForParameters(t *template.Template, params map[string]*openapi
 	var types []TypeDefinition
 	for _, paramName := range SortedParameterKeys(params) {
 		paramOrRef := params[paramName]
+		paramName += componentNameSuffixParameters
 
 		goType, err := paramToGoType(paramOrRef.Value, nil)
 		if err != nil {
@@ -427,6 +428,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 
 	for _, responseName := range SortedResponsesKeys(responses) {
 		responseOrRef := responses[responseName]
+		responseName += componentNameSuffixResponses
 
 		// We have to generate the response object. We're only going to
 		// handle application/json media types here. Other responses should
@@ -466,6 +468,7 @@ func GenerateTypesForRequestBodies(t *template.Template, bodies map[string]*open
 
 	for _, bodyName := range SortedRequestBodyKeys(bodies) {
 		bodyOrRef := bodies[bodyName]
+		bodyName += componentNameSuffixRequestBodies
 
 		// As for responses, we will only generate Go code for JSON bodies,
 		// the other body formats are up to the user.

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -205,10 +205,19 @@ func StringInArray(str string, array []string) bool {
 	return false
 }
 
+// these suffixes are used for avoiding naming conflicts in code generation, because all four
+// component types will be generated in the same package
+const (
+	componentNameSuffixParameters    = "Param"
+	componentNameSuffixResponses     = "Response"
+	componentNameSuffixRequestBodies = "Request"
+)
+
 // This function takes a $ref value and converts it to a Go typename.
 // #/components/schemas/Foo -> Foo
 // #/components/parameters/Bar -> Bar
 // #/components/responses/Baz -> Baz
+// #/components/requestBodies/Baz -> Baz
 // Remote components (document.json#/Foo) are supported if they present in --import-mapping
 // URL components (http://deepmap.com/schemas/document.json#Foo) are supported if they present in --import-mapping
 //
@@ -217,6 +226,14 @@ func RefPathToGoType(refPath string) (string, error) {
 		pathParts := strings.Split(refPath, "/")
 		if depth := len(pathParts); depth != 4 {
 			return "", fmt.Errorf("Parameter nesting is deeper than supported: %s has %d", refPath, depth)
+		}
+		switch pathParts[2] {
+		case "parameters":
+			pathParts[3] += componentNameSuffixParameters
+		case "responses":
+			pathParts[3] += componentNameSuffixResponses
+		case "requestBodies":
+			pathParts[3] += componentNameSuffixRequestBodies
 		}
 		return SchemaNameToTypeName(pathParts[3]), nil
 	}


### PR DESCRIPTION
Similar to https://github.com/deepmap/oapi-codegen/pull/200 but simply adding suffixes and also fixed component references