### PR TITLE
Prevent clashes in generated camel-case identifiers

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -61,9 +61,15 @@ func ToCamelCase(str string) string {
 
 	n := ""
 	capNext := true
-	for _, v := range s {
+	for i, v := range s {
 		if unicode.IsUpper(v) {
+			if i > 0 && capNext {
+				n += "_"
+			}
 			n += string(v)
+			if i == 0 && capNext {
+				n += "_"
+			}
 		}
 		if unicode.IsDigit(v) {
 			n += string(v)
@@ -504,6 +510,7 @@ func SchemaHasAdditionalProperties(schema *openapi3.Schema) bool {
 	}
 	return false
 }
+
 // This converts a path, like Object/field1/nestedField into a go
 // type name.
 func PathToTypeName(path []string) string {

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -22,7 +22,8 @@ import (
 
 func TestStringOps(t *testing.T) {
 	// Test that each substitution works
-	assert.Equal(t, "WordWordWORDWordWordWordWordWordWordWordWordWordWord", ToCamelCase("word.word-WORD+Word_word~word(Word)Word{Word}Word[Word]Word:Word;"), "Camel case conversion failed")
+	assert.Equal(t, "WordWord_WORD_WordWordWord_Word_Word_Word_Word_Word_Word_Word", ToCamelCase("word.word-WORD+Word_word~word(Word)Word{Word}Word[Word]Word:Word;"), "Camel case conversion failed")
+	assert.Equal(t, "W_ordWord", ToCamelCase("Word.word"), "Second camel case conversion failed")
 
 	// Make sure numbers don't interact in a funny way.
 	assert.Equal(t, "Number1234", ToCamelCase("number-1234"), "Number Camelcasing not working.")


### PR DESCRIPTION
Fixes #452

Draft PR to demonstrate one way to resolve the case-sensitivity related clashes