### PR TITLE
[#476] Properly handle objects with array properties in the query string

### DIFF
--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -463,15 +463,14 @@ func bindParamsToExplodedObject(paramName string, values url.Values, dest interf
 		}
 
 		// At this point, we look up field name in the parameter list.
-		fieldVal, found := values[fieldName]
-		if found {
-			if len(fieldVal) != 1 {
-				return fmt.Errorf("field '%s' specified multiple times for param '%s'", fieldName, paramName)
-			}
-			err := BindStringToObject(fieldVal[0], v.Field(i).Addr().Interface())
-			if err != nil {
-				return fmt.Errorf("could not bind query arg '%s' to request object: %s'", paramName, err)
-			}
+		_, found := values[fieldName]
+		if !found {
+			continue
+		}
+
+		err := BindQueryParameter("form", true, false, fieldName, values, v.Field(i).Addr().Interface())
+		if err != nil {
+			return fmt.Errorf("could not bind query arg '%s' to request object: %s'", paramName, err)
 		}
 	}
 	return nil

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -455,6 +455,35 @@ func TestBindParamsToExplodedObject(t *testing.T) {
 	err = bindParamsToExplodedObject("explodedObject", values, &optDstTime)
 	assert.NoError(t, err)
 	assert.EqualValues(t, &now, optDstTime.Time)
+
+}
+
+// covers slice case
+func TestBindParamsToExplodedObjectComplex(t *testing.T) {
+
+	type Form struct {
+		Ids     *[]string `json:"ids,omitempty"`
+		Limit   *int      `json:"limit,omitempty"`
+		Offset  *int      `json:"offset,omitempty"`
+		OrderBy *[]string `json:"orderBy,omitempty"`
+	}
+
+	var dest Form
+	values := url.Values{
+		"orderBy": []string{"any", "pseudo"},
+		"limit":   []string{"100"},
+		"ids":     []string{"1"},
+	}
+	expLimit := 100
+	expected := Form{
+		Limit:   &expLimit,
+		OrderBy: &[]string{"any", "pseudo"},
+		Ids:     &[]string{"1"},
+	}
+	err := bindParamsToExplodedObject("explodedObject", values, &dest)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, dest)
+
 }
 
 func TestBindStyledParameterWithLocation(t *testing.T) {


### PR DESCRIPTION
Closes #476
This PR fixes a bug when you get the `Invalid format for parameter paramName: field 'fieldName' specified multiple times for param 'paramName'` error when using an object parameter with an array property.

A bit of context:
I have a query parameter of `type: object` with `style: form` and `explode: true` (called `QueryFilters`), and it contains a property of `type: array` (called `orderBy`).

Here's my Swagger file:
```yml
openapi: 3.0.3

info:
  title: example
  version: 1.0.0

paths:
  /users:
    get:
      parameters:
        - $ref: "#/components/parameters/QueryFilters"
      responses:
        200:
          description: ok

components:
  parameters:
    QueryFilters:
      name: queryFilters
      in: query
      style: form
      schema:
        type: object
        properties:
          limit:
            type: integer
          orderBy:
            type: array
            items:
              type: string
            example: [ "createdAt asc", "updatedAt desc" ]
```

I run `oapi-codegen --package=api --generate=types,chi-server openapi.yaml > api.go`, and it produces a correct struct:

```go
// QueryFilters defines model for QueryFilters.
type QueryFilters struct {
	Limit   *int      `json:"limit,omitempty"`
	OrderBy *[]string `json:"orderBy,omitempty"`
}
```

And the following middleware code:

```go
// GetUsers operation middleware
func (siw *ServerInterfaceWrapper) GetUsers(w http.ResponseWriter, r *http.Request) {
	ctx := r.Context()

	var err error

	// Parameter object where we will unmarshal all parameters from the context
	var params GetUsersParams

	// ------------- Optional query parameter "queryFilters" -------------
	if paramValue := r.URL.Query().Get("queryFilters"); paramValue != "" {

	}

	err = runtime.BindQueryParameter("form", true, false, "queryFilters", r.URL.Query(), &params.QueryFilters)
	if err != nil {
		http.Error(w, fmt.Sprintf("Invalid format for parameter queryFilters: %s", err), http.StatusBadRequest)
		return
	}

	var handler = func(w http.ResponseWriter, r *http.Request) {
		siw.Handler.GetUsers(w, r, params)
	}

	for _, middleware := range siw.HandlerMiddlewares {
		handler = middleware(handler)
	}

	handler(w, r.WithContext(ctx))
}
```

But then I send a request like `GET hostname:port/users?orderBy=foo&orderBy=bar`, and I get this error:
`Invalid format for parameter queryFilters: field 'orderBy' specified multiple times for param 'queryFilters'`, which I shouldn't get since everything's according to the OpenAPI spec.
https://swagger.io/specification/#data-type-format