### PR TITLE
Fix loadTemplateOverrides function. It must manage subfolder to allow…

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -174,20 +174,43 @@ func loadTemplateOverrides(templatesDir string) (map[string]string, error) {
 		return templates, nil
 	}
 
-	files, err := ioutil.ReadDir(templatesDir)
+	err := loadTemplateOverridesWithSubfolder(&templates, templatesDir, "")
+
 	if err != nil {
 		return nil, err
 	}
 
-	for _, f := range files {
-		data, err := ioutil.ReadFile(path.Join(templatesDir, f.Name()))
-		if err != nil {
-			return nil, err
-		}
-		templates[f.Name()] = string(data)
+	return templates, nil
+}
+
+func loadTemplateOverridesWithSubfolder(templates *map[string]string, templatesDir string, prefix string) error {
+	files, err := ioutil.ReadDir(templatesDir)
+
+	if err != nil {
+		return err
 	}
 
-	return templates, nil
+	for _, f := range files {
+		fileName := f.Name()
+
+		if len(prefix) > 0 {
+			fileName = fmt.Sprintf("%v/%v", prefix, fileName)
+		}
+
+		if f.IsDir() {
+			loadTemplateOverridesWithSubfolder(templates, path.Join(templatesDir, f.Name()), fileName)
+		} else {
+			data, err := ioutil.ReadFile(path.Join(templatesDir, f.Name()))
+
+			if err != nil {
+				return err
+			}
+
+			(*templates)[fileName] = string(data)
+		}
+	}
+
+	return nil
 }
 
 // configFromFlags parses the flags and the config file. Anything which is

--- a/pkg/codegen/templates/gin/gin-wrappers.tmpl
+++ b/pkg/codegen/templates/gin/gin-wrappers.tmpl
@@ -77,7 +77,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *gin.Context) {
   {{end}}
 
     {{if .HeaderParams}}
-      headers := r.Header
+      headers := c.Request.Header
 
       {{range .HeaderParams}}// ------------- {{if .Required}}Required{{else}}Optional{{end}} header parameter "{{.ParamName}}" -------------
         if valueList, found := headers[http.CanonicalHeaderKey("{{.ParamName}}")]; found {


### PR DESCRIPTION
Improvements made to the loadTemplateOverrides function. 
Now It manages subfolder to allow the override of server template files like 'gin'.
Without the fix It is impossible to override the server template files because, for instance, the 'gin' manager looks for the following keys in the templates map:
- "gin/gin-interface.tmpl"
- "gin/gin-wrappers.tmpl"
- "gin/gin-register.tmpl"

In addition the pull request contains the fix related to https://github.com/deepmap/oapi-codegen/issues/480
