### PR TITLE
Return a struct from `gin`'s RegisterHandlers instead of an interface

### DIFF
--- a/examples/petstore-expanded/gin/api/petstore.go
+++ b/examples/petstore-expanded/gin/api/petstore.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --config=types.cfg.yaml ../../petstore-expanded.yaml
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --config=server.cfg.yaml ../../petstore-expanded.yaml
+
 package api
 
 import (

--- a/examples/petstore-expanded/gin/api/server.cfg.yaml
+++ b/examples/petstore-expanded/gin/api/server.cfg.yaml
@@ -1,4 +1,4 @@
-output: examples/petstore-expanded/gin/api/petstore-server.gen.go
+output: petstore-server.gen.go
 generate:
   - gin
   - spec

--- a/examples/petstore-expanded/gin/api/types.cfg.yaml
+++ b/examples/petstore-expanded/gin/api/types.cfg.yaml
@@ -1,4 +1,4 @@
-output: examples/petstore-expanded/gin/api/petstore-types.gen.go
+output: petstore-types.gen.go
 generate:
   - types
 package: api

--- a/examples/petstore-expanded/gin/petstore.go
+++ b/examples/petstore-expanded/gin/petstore.go
@@ -36,7 +36,10 @@ func NewGinPetServer(petStore *api.PetStore, port int) *http.Server {
 	r.Use(middleware.OapiRequestValidator(swagger))
 
 	// We now register our petStore above as the handler for the interface
-	r = api.RegisterHandlers(r, petStore)
+	apiRoutes := api.RegisterHandlers(r, petStore)
+
+	// Then we attach the registered handlers to the Gin Engine
+	r.Use(apiRoutes.Handlers...)
 
 	s := &http.Server{
 		Handler: r,

--- a/pkg/codegen/templates/gin/gin-register.tmpl
+++ b/pkg/codegen/templates/gin/gin-register.tmpl
@@ -8,12 +8,12 @@ type GinServerOptions struct {
 type MiddlewareFunc = gin.HandlerFunc
 
 // RegisterHandlers creates http.Handler with routing matching OpenAPI spec.
-func RegisterHandlers(router gin.IRouter, si ServerInterface) gin.IRouter {
+func RegisterHandlers(router gin.IRouter, si ServerInterface) *gin.RouterGroup {
   return RegisterHandlersWithOptions(router, si, GinServerOptions{})
 }
 
 // RegisterHandlersWithOptions creates http.Handler with additional options
-func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options GinServerOptions) gin.IRouter {
+func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options GinServerOptions) *gin.RouterGroup {
 {{if .}}wrapper := ServerInterfaceWrapper{
 Handler: si,
 }
@@ -24,5 +24,5 @@ router = router.Group("/", options.Middlewares...)
 {{range .}}
 router.{{.Method }}(options.BaseURL+"{{.Path | swaggerUriToGinUri }}", wrapper.{{.OperationId}})
 {{end}}
-return router
+return router.(*gin.RouterGroup)
 }


### PR DESCRIPTION
This change provides an alternative to https://github.com/deepmap/oapi-codegen/pull/554 based on the discussions in https://github.com/deepmap/oapi-codegen/pull/530.

For setting up a Gin engine, we want to handle the `IRouter` interface when registering handlers, but as this only thinly wraps a `*gin.GroupRouter`, we can return a `*gin.GroupRouter` from the registration function.

We _could_ refactor the `RegisterHandlers` and `RegisterHandlersWithOptions` to just take a `*gin.GroupRouter` to begin with, I'm not really sure what we gain by using the `IRouter` interface here. Does anyone have opinions on doing that?