### PR TITLE
Generate enum types from schemas in paths

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -45,6 +45,15 @@ type ThingWithID struct {
 	Name string `json:"name"`
 }
 
+// N200 defines model for 200.
+type N200 = []ThingWithID
+
+// N201 defines model for 201.
+type N201 = []ThingWithID
+
+// POST defines model for POST.
+type POST = Thing
+
 // AddThingJSONRequestBody defines body for AddThing for application/json ContentType.
 type AddThingJSONRequestBody = Thing
 

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -51,6 +51,15 @@ type Pet struct {
 // Empty defines model for .
 type Empty = int32
 
+// N200 defines model for 200.
+type N200 = []Pet
+
+// Default defines model for default.
+type Default = Error
+
+// POST defines model for POST.
+type POST = NewPet
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -48,6 +48,9 @@ type Pet struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
+// Empty defines model for .
+type Empty = int32
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/examples/petstore-expanded/echo/api/models/models.gen.go
+++ b/examples/petstore-expanded/echo/api/models/models.gen.go
@@ -33,6 +33,9 @@ type Pet struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
+// Empty defines model for .
+type Empty = int32
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/examples/petstore-expanded/echo/api/models/models.gen.go
+++ b/examples/petstore-expanded/echo/api/models/models.gen.go
@@ -33,6 +33,15 @@ type Pet struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
+// N200 defines model for 200.
+type N200 = Pet
+
+// Default defines model for default.
+type Default = Error
+
+// POST defines model for POST.
+type POST = NewPet
+
 // Empty defines model for .
 type Empty = int32
 

--- a/examples/petstore-expanded/gin/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/gin/api/petstore-types.gen.go
@@ -33,6 +33,9 @@ type Pet struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
+// Empty defines model for .
+type Empty = int32
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/examples/petstore-expanded/gin/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/gin/api/petstore-types.gen.go
@@ -36,6 +36,15 @@ type Pet struct {
 // Empty defines model for .
 type Empty = int32
 
+// N200 defines model for 200.
+type N200 = []Pet
+
+// Default defines model for default.
+type Default = Error
+
+// POST defines model for POST.
+type POST = NewPet
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/examples/petstore-expanded/gorilla/api/petstore.gen.go
+++ b/examples/petstore-expanded/gorilla/api/petstore.gen.go
@@ -48,6 +48,15 @@ type Pet struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
+// N200 defines model for 200.
+type N200 = Pet
+
+// Default defines model for default.
+type Default = Error
+
+// POST defines model for POST.
+type POST = NewPet
+
 // Empty defines model for .
 type Empty = int32
 

--- a/examples/petstore-expanded/gorilla/api/petstore.gen.go
+++ b/examples/petstore-expanded/gorilla/api/petstore.gen.go
@@ -48,6 +48,9 @@ type Pet struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
+// Empty defines model for .
+type Empty = int32
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -47,6 +47,9 @@ type Pet struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
+// Empty defines model for .
+type Empty = int32
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -50,6 +50,15 @@ type Pet struct {
 // Empty defines model for .
 type Empty = int32
 
+// N200 defines model for 200.
+type N200 = []Pet
+
+// Default defines model for default.
+type Default = Error
+
+// POST defines model for POST.
+type POST = NewPet
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/examples/petstore-expanded/strict/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-types.gen.go
@@ -33,6 +33,9 @@ type Pet struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
+// Empty defines model for .
+type Empty = int32
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/examples/petstore-expanded/strict/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-types.gen.go
@@ -36,6 +36,15 @@ type Pet struct {
 // Empty defines model for .
 type Empty = int32
 
+// N200 defines model for 200.
+type N200 = []Pet
+
+// Default defines model for default.
+type Default = Error
+
+// POST defines model for POST.
+type POST = NewPet
+
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by

--- a/internal/test/all_of/v1/openapi.gen.go
+++ b/internal/test/all_of/v1/openapi.gen.go
@@ -38,6 +38,10 @@ type PersonWithID struct {
 	ID int64 `json:"ID"`
 }
 
+// This is a person record as returned from a Create endpoint. It contains
+// all the fields of a Person, with an additional resource UUID.
+type Default = PersonWithID
+
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 

--- a/internal/test/all_of/v2/openapi.gen.go
+++ b/internal/test/all_of/v2/openapi.gen.go
@@ -38,6 +38,10 @@ type PersonWithID struct {
 	LastName           string `json:"LastName"`
 }
 
+// This is a person record as returned from a Create endpoint. It contains
+// all the fields of a Person, with an additional resource UUID.
+type Default = PersonWithID
+
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -31,6 +31,9 @@ type SchemaObject struct {
 	Role      string `json:"role"`
 }
 
+// POST defines model for POST.
+type POST = SchemaObject
+
 // PostBothJSONRequestBody defines body for PostBoth for application/json ContentType.
 type PostBothJSONRequestBody = SchemaObject
 

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -339,9 +339,87 @@ type EnumParam3 string
 // a parameter
 type RenamedParameterObject string
 
+// RenamedResponseObject defines model for ResponseObject.
+type RenamedResponseObject struct {
+	Field SchemaObject `json:"Field"`
+}
+
+// RenamedRequestBody defines model for RequestBody.
+type RenamedRequestBody struct {
+	Field SchemaObject `json:"Field"`
+}
+
+// N200 defines model for 200.
+type N200 struct {
+	// simple anyOf case
+	AnyOf1 *AnyOfObject1 `json:"anyOf1,omitempty"`
+
+	// Has additional properties with schema for dictionaries
+	Five *AdditionalPropertiesObject5 `json:"five,omitempty"`
+
+	// Has anonymous field which has additional properties
+	Four      *AdditionalPropertiesObject4 `json:"four,omitempty"`
+	JsonField *ObjectWithJsonField         `json:"jsonField,omitempty"`
+
+	// Has additional properties of type int
+	One *AdditionalPropertiesObject1 `json:"one,omitempty"`
+
+	// oneOf with references and no disciminator
+	OneOf1 *OneOfObject1 `json:"oneOf1,omitempty"`
+
+	// fixed properties, variable required - will compile, but not much sense
+	OneOf10 *OneOfObject10 `json:"oneOf10,omitempty"`
+
+	// additional properties of oneOf
+	OneOf11 *OneOfObject11 `json:"oneOf11,omitempty"`
+
+	// allOf of oneOfs
+	OneOf12 *OneOfObject12 `json:"oneOf12,omitempty"`
+
+	// oneOf with inline elements
+	OneOf2 *OneOfObject2 `json:"oneOf2,omitempty"`
+
+	// inline OneOf
+	OneOf3 *OneOfObject3 `json:"oneOf3,omitempty"`
+
+	// oneOf plus fixed type - custom marshaling/unmarshaling
+	OneOf4 *OneOfObject4 `json:"oneOf4,omitempty"`
+
+	// oneOf with disciminator but no mapping
+	OneOf5 *OneOfObject5 `json:"oneOf5,omitempty"`
+
+	// oneOf with discriminator and mapping
+	OneOf6 *OneOfObject6 `json:"oneOf6,omitempty"`
+
+	// array of oneOf
+	OneOf7 *OneOfObject7 `json:"oneOf7,omitempty"`
+
+	// oneOf with fixed properties
+	OneOf8 *OneOfObject8 `json:"oneOf8,omitempty"`
+
+	// oneOf with fixed descriminator
+	OneOf9 *OneOfObject9 `json:"oneOf9,omitempty"`
+
+	// Array of object with additional properties
+	Six *AdditionalPropertiesObject6 `json:"six,omitempty"`
+
+	// Allows any additional property
+	Three *AdditionalPropertiesObject3 `json:"three,omitempty"`
+
+	// Does not allow additional properties
+	Two *AdditionalPropertiesObject2 `json:"two,omitempty"`
+}
+
 // Empty defines model for .
 type Empty struct {
 	Inner map[string]string `json:"inner"`
+}
+
+// POST defines model for POST.
+type POST struct {
+	Inner                map[string]int         `json:"inner"`
+	Name                 string                 `json:"name"`
+	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
 // EnsureEverythingIsReferencedJSONBody defines parameters for EnsureEverythingIsReferenced.
@@ -749,6 +827,85 @@ func (a *AdditionalPropertiesObject4_Inner) UnmarshalJSON(b []byte) error {
 func (a AdditionalPropertiesObject4_Inner) MarshalJSON() ([]byte, error) {
 	var err error
 	object := make(map[string]json.RawMessage)
+
+	object["name"], err = json.Marshal(a.Name)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'name': %w", err)
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for POST. Returns the specified
+// element and whether it was found
+func (a POST) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for POST
+func (a *POST) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for POST to handle AdditionalProperties
+func (a *POST) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["inner"]; found {
+		err = json.Unmarshal(raw, &a.Inner)
+		if err != nil {
+			return fmt.Errorf("error reading 'inner': %w", err)
+		}
+		delete(object, "inner")
+	}
+
+	if raw, found := object["name"]; found {
+		err = json.Unmarshal(raw, &a.Name)
+		if err != nil {
+			return fmt.Errorf("error reading 'name': %w", err)
+		}
+		delete(object, "name")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for POST to handle AdditionalProperties
+func (a POST) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	object["inner"], err = json.Marshal(a.Inner)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'inner': %w", err)
+	}
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -339,14 +339,9 @@ type EnumParam3 string
 // a parameter
 type RenamedParameterObject string
 
-// RenamedResponseObject defines model for ResponseObject.
-type RenamedResponseObject struct {
-	Field SchemaObject `json:"Field"`
-}
-
-// RenamedRequestBody defines model for RequestBody.
-type RenamedRequestBody struct {
-	Field SchemaObject `json:"Field"`
+// Empty defines model for .
+type Empty struct {
+	Inner map[string]string `json:"inner"`
 }
 
 // EnsureEverythingIsReferencedJSONBody defines parameters for EnsureEverythingIsReferenced.

--- a/internal/test/enum/enums.yaml
+++ b/internal/test/enum/enums.yaml
@@ -1,0 +1,146 @@
+openapi: 3.0.0
+info:
+  description: example
+  title: example-api
+  version: 0.0.1
+components:
+  schemas:
+    componentSchema:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - component_schema_online
+            - component_schema_offline
+          example: 'component_schema_online'
+  responses:
+    componentResponse:
+      description: Example
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                enum:
+                  - component_response_online
+                  - component_response_offline
+                example: 'component_response_online'
+  requestBodies:
+    componentRequestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                enum:
+                  - component_body_online
+                  - component_body_offline
+                example: 'component_body_online'
+  parameters:
+    componentParameter:
+      name: status
+      in: path
+      required: true
+      schema:
+        type: object
+        properties:
+          status:
+            type: string
+            enum:
+              - component_parameter_online
+              - component_parameter_offline
+            example: 'component_parameter_online'
+paths:
+  '/path':
+    get:
+      responses:
+        '200':
+          description: Example
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - path_response_online
+                      - path_response_offline
+                    example: 'path_response_online'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - path_body_online
+                    - path_body_offline
+                  example: 'path_body_online'
+  '/path/{status}':
+    get:
+      parameters:
+        - name: status
+          in: path
+          required: true
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                enum:
+                  - path_parameter_online
+                  - path_parameter_offline
+                example: 'path_parameter_online'
+      responses:
+        '200':
+          description: Example
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - path_response_online
+                      - path_response_offline
+                    example: 'path_response_online'
+  '/path2':
+    get:
+      responses:
+        '200':
+          $ref: "#/components/responses/componentResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - path_body_online
+                    - path_body_offline
+                  example: 'path_body_online'
+  '/path3/{status}':
+    get:
+      parameters:
+        # Support for this is half-baked, it doesn't emit the enums
+        - $ref: "#/components/parameters/componentParameter"
+      responses:
+        '200':
+          description: Example
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/componentSchema"
+      requestBody:
+        $ref: "#/components/requestBodies/componentRequestBody"

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -43,6 +43,9 @@ type PetNames struct {
 	Names []string `json:"names"`
 }
 
+// Empty defines model for .
+type Empty = string
+
 // ValidatePetsJSONRequestBody defines body for ValidatePets for application/json ContentType.
 type ValidatePetsJSONRequestBody = PetNames
 

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -46,6 +46,15 @@ type PetNames struct {
 // Empty defines model for .
 type Empty = string
 
+// N200 defines model for 200.
+type N200 = Pet
+
+// Default defines model for default.
+type Default = Error
+
+// POST defines model for POST.
+type POST = PetNames
+
 // ValidatePetsJSONRequestBody defines body for ValidatePets for application/json ContentType.
 type ValidatePetsJSONRequestBody = PetNames
 

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -34,6 +34,9 @@ type Value struct {
 	StringValue *string     `json:"stringValue,omitempty"`
 }
 
+// N200 defines model for 200.
+type N200 = Document
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
 

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -21,6 +21,9 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// Empty defines model for .
+type Empty = string
+
 // GetFooParams defines parameters for GetFoo.
 type GetFooParams struct {
 	// base64. bytes. chi. context. echo. errors. fmt. gzip. http. io. ioutil. json. openapi3.

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -24,6 +24,9 @@ import (
 // Empty defines model for .
 type Empty = string
 
+// N200 defines model for 200.
+type N200 = string
+
 // GetFooParams defines parameters for GetFoo.
 type GetFooParams struct {
 	// base64. bytes. chi. context. echo. errors. fmt. gzip. http. io. ioutil. json. openapi3.

--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -36,6 +36,9 @@ const (
 // Bar defines model for Bar.
 type Bar string
 
+// N200 defines model for 200.
+type N200 = []Bar
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -40,6 +40,9 @@ type Object struct {
 	Role      string `json:"role"`
 }
 
+// Empty defines model for .
+type Empty = ComplexObject
+
 // GetCookieParams defines parameters for GetCookie.
 type GetCookieParams struct {
 	// primitive

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -71,6 +71,23 @@ type NullableProperties struct {
 // StringInPath defines model for StringInPath.
 type StringInPath = string
 
+// N200 defines model for 200.
+type N200 struct {
+	AnyType1 *AnyType1 `json:"anyType1,omitempty"`
+
+	// AnyType2 represents any type.
+	//
+	// This should be an interface{}
+	AnyType2         *AnyType2         `json:"anyType2,omitempty"`
+	CustomStringType *CustomStringType `foo:"bar" json:"customStringType,omitempty"`
+}
+
+// Default defines model for default.
+type Default = GenericObject
+
+// GET defines model for GET.
+type GET = NullableProperties
+
 // This schema name starts with a number
 type Empty = N5StartsWithNumber
 

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -71,6 +71,9 @@ type NullableProperties struct {
 // StringInPath defines model for StringInPath.
 type StringInPath = string
 
+// This schema name starts with a number
+type Empty = N5StartsWithNumber
+
 // Issue9JSONBody defines parameters for Issue9.
 type Issue9JSONBody = interface{}
 

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -83,13 +83,8 @@ type SomeObject struct {
 // Argument defines model for argument.
 type Argument = string
 
-// ResponseWithReference defines model for ResponseWithReference.
-type ResponseWithReference = SomeObject
-
-// SimpleResponse defines model for SimpleResponse.
-type SimpleResponse struct {
-	Name string `json:"name"`
-}
+// Empty defines model for .
+type Empty = int32
 
 // GetWithArgsParams defines parameters for GetWithArgs.
 type GetWithArgsParams struct {

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -83,8 +83,28 @@ type SomeObject struct {
 // Argument defines model for argument.
 type Argument = string
 
+// ResponseWithReference defines model for ResponseWithReference.
+type ResponseWithReference = SomeObject
+
+// SimpleResponse defines model for SimpleResponse.
+type SimpleResponse struct {
+	Name string `json:"name"`
+}
+
+// N200 defines model for 200.
+type N200 = EveryTypeOptional
+
 // Empty defines model for .
 type Empty = int32
+
+// POST defines model for POST.
+type POST = EveryTypeRequired
+
+// PUT defines model for PUT.
+type PUT struct {
+	Id   *int    `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
+}
 
 // GetWithArgsParams defines parameters for GetWithArgs.
 type GetWithArgsParams struct {

--- a/internal/test/strict-server/chi/types.gen.go
+++ b/internal/test/strict-server/chi/types.gen.go
@@ -8,6 +8,15 @@ type Example struct {
 	Value *string `json:"value,omitempty"`
 }
 
+// Reusableresponse defines model for reusableresponse.
+type Reusableresponse = Example
+
+// N200 defines model for 200.
+type N200 = Example
+
+// POST defines model for POST.
+type POST = Example
+
 // Empty defines model for .
 type Empty = int
 

--- a/internal/test/strict-server/chi/types.gen.go
+++ b/internal/test/strict-server/chi/types.gen.go
@@ -8,8 +8,8 @@ type Example struct {
 	Value *string `json:"value,omitempty"`
 }
 
-// Reusableresponse defines model for reusableresponse.
-type Reusableresponse = Example
+// Empty defines model for .
+type Empty = int
 
 // MultipleRequestAndResponseTypesTextBody defines parameters for MultipleRequestAndResponseTypes.
 type MultipleRequestAndResponseTypesTextBody = string

--- a/internal/test/strict-server/client/client.gen.go
+++ b/internal/test/strict-server/client/client.gen.go
@@ -22,6 +22,15 @@ type Example struct {
 	Value *string `json:"value,omitempty"`
 }
 
+// Reusableresponse defines model for reusableresponse.
+type Reusableresponse = Example
+
+// N200 defines model for 200.
+type N200 = Example
+
+// POST defines model for POST.
+type POST = Example
+
 // Empty defines model for .
 type Empty = int
 

--- a/internal/test/strict-server/client/client.gen.go
+++ b/internal/test/strict-server/client/client.gen.go
@@ -22,8 +22,8 @@ type Example struct {
 	Value *string `json:"value,omitempty"`
 }
 
-// Reusableresponse defines model for reusableresponse.
-type Reusableresponse = Example
+// Empty defines model for .
+type Empty = int
 
 // MultipleRequestAndResponseTypesTextBody defines parameters for MultipleRequestAndResponseTypes.
 type MultipleRequestAndResponseTypesTextBody = string

--- a/internal/test/strict-server/echo/types.gen.go
+++ b/internal/test/strict-server/echo/types.gen.go
@@ -8,6 +8,15 @@ type Example struct {
 	Value *string `json:"value,omitempty"`
 }
 
+// Reusableresponse defines model for reusableresponse.
+type Reusableresponse = Example
+
+// N200 defines model for 200.
+type N200 = Example
+
+// POST defines model for POST.
+type POST = Example
+
 // Empty defines model for .
 type Empty = int
 

--- a/internal/test/strict-server/echo/types.gen.go
+++ b/internal/test/strict-server/echo/types.gen.go
@@ -8,8 +8,8 @@ type Example struct {
 	Value *string `json:"value,omitempty"`
 }
 
-// Reusableresponse defines model for reusableresponse.
-type Reusableresponse = Example
+// Empty defines model for .
+type Empty = int
 
 // MultipleRequestAndResponseTypesTextBody defines parameters for MultipleRequestAndResponseTypes.
 type MultipleRequestAndResponseTypesTextBody = string

--- a/internal/test/strict-server/gin/types.gen.go
+++ b/internal/test/strict-server/gin/types.gen.go
@@ -8,6 +8,15 @@ type Example struct {
 	Value *string `json:"value,omitempty"`
 }
 
+// Reusableresponse defines model for reusableresponse.
+type Reusableresponse = Example
+
+// N200 defines model for 200.
+type N200 = Example
+
+// POST defines model for POST.
+type POST = Example
+
 // Empty defines model for .
 type Empty = int
 

--- a/internal/test/strict-server/gin/types.gen.go
+++ b/internal/test/strict-server/gin/types.gen.go
@@ -8,8 +8,8 @@ type Example struct {
 	Value *string `json:"value,omitempty"`
 }
 
-// Reusableresponse defines model for reusableresponse.
-type Reusableresponse = Example
+// Empty defines model for .
+type Empty = int
 
 // MultipleRequestAndResponseTypesTextBody defines parameters for MultipleRequestAndResponseTypes.
 type MultipleRequestAndResponseTypesTextBody = string

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -589,6 +589,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 				}
 				typeDef.TypeName = SchemaNameToTypeName(refType)
 			}
+			types = append(types, typeDef)
 			types = append(types, typeDef.Schema.GetAdditionalTypeDefs()...)
 		}
 	}
@@ -632,6 +633,7 @@ func GenerateTypesForRequestBodies(t *template.Template, bodies map[string]*open
 				}
 				typeDef.TypeName = SchemaNameToTypeName(refType)
 			}
+			types = append(types, typeDef)
 			types = append(types, typeDef.Schema.GetAdditionalTypeDefs()...)
 		}
 	}


### PR DESCRIPTION
If defining types in the schema within the parameters, responses, or requestBody within the paths of the spec, generate enums for them.

Also gather deeply nested enums in component responses or requestBodies.

Fixes #399 #467 #513 #626