### PR TITLE
Properly create models for allOf schemas with properties additionally defined

### DIFF
--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -9,20 +9,20 @@ import (
 
 // MergeSchemas merges all the fields in the schemas supplied into one giant schema.
 // The idea is that we merge all fields together into one schema.
-func MergeSchemas(sc *openapi3.Schema, path []string) (Schema, error) {
+func MergeSchemas(schema *openapi3.Schema, path []string) (Schema, error) {
 	// If someone asked for the old way, for backward compatibility, return the
 	// old style result.
 	if globalState.options.Compatibility.OldMergeSchemas {
-		return mergeSchemas_V1(sc.AllOf, path)
+		return mergeSchemas_V1(schema.AllOf, path)
 	}
-	return mergeSchemas(sc, path)
+	return mergeSchemas(schema, path)
 }
 
-func mergeSchemas(sc *openapi3.Schema, path []string) (Schema, error) {
-	allOf := sc.AllOf
+func mergeSchemas(baseSchema *openapi3.Schema, path []string) (Schema, error) {
+	allOf := baseSchema.AllOf
 	n := len(allOf)
 
-	schema := *sc
+	schema := *baseSchema
 	schema.AllOf = nil
 
 	for i := 0; i < n; i++ {

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -235,7 +235,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	// so that in a RESTful paradigm, the Create operation can return
 	// (object, id), so that other operations can refer to (id)
 	if schema.AllOf != nil {
-		mergedSchema, err := MergeSchemas(schema.AllOf, path)
+		mergedSchema, err := MergeSchemas(schema, path)
 		if err != nil {
 			return Schema{}, fmt.Errorf("error merging schemas: %w", err)
 		}


### PR DESCRIPTION
The types generator does not properly create structure types for models of the following format. The properties defined directly on the model are not included in the output struct:

```
SessionIdentity:
  required:
  - websocket_url
  type: object
  allOf:
     - $ref: '#/components/schemas/SessionData'
  properties:
    websocket_url:
      type: string
      description: websocket url
```

This is because models that contain an allOf are constructed by merging the properties of all base types together. However, properties which are defined on the actual model itself are not considered. This PR addresses the problem by including the actual schema instance during allOf merging.