### PR TITLE
fix error handler signature

### DIFF
--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -18,7 +18,7 @@ import (
 )
 
 // ErrorHandler is called when there is an error in validation
-type ErrorHandler func(w http.ResponseWriter, message string, statusCode int)
+type ErrorHandler func(w http.ResponseWriter, err error, statusCode int)
 
 // MultiErrorHandler is called when oapi returns a MultiError type
 type MultiErrorHandler func(openapi3.MultiError) (int, error)
@@ -56,7 +56,7 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 			// validate request
 			if statusCode, err := validateRequest(r, router, options); err != nil {
 				if options != nil && options.ErrorHandler != nil {
-					options.ErrorHandler(w, err.Error(), statusCode)
+					options.ErrorHandler(w, err, statusCode)
 				} else {
 					http.Error(w, err.Error(), statusCode)
 				}

--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -264,8 +264,8 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	// Set up an authenticator to check authenticated function. It will allow
 	// access to "someScope", but disallow others.
 	options := Options{
-		ErrorHandler: func(w http.ResponseWriter, message string, statusCode int) {
-			http.Error(w, "test: "+message, statusCode)
+		ErrorHandler: func(w http.ResponseWriter, err error, statusCode int) {
+			http.Error(w, "test: "+err.Error(), statusCode)
 		},
 		Options: openapi3filter.Options{
 			AuthenticationFunc: func(c context.Context, input *openapi3filter.AuthenticationInput) error {


### PR DESCRIPTION
Hello,
I have modified the ErrorHandler method signature.

Changed to receive err instead of receiving error message as string.

This is because an error message cannot set an appropriate error object to a response such as api when handling multi errors.

This is an existing breaking change.

However, it seems that there are many cases where the update work does not take that much and there are more merits.

Could you please consider including it in the next minor version?