### PR TITLE
Change ErrorHandler signature

### DIFF
--- a/pkg/fiber-middleware/oapi_validate.go
+++ b/pkg/fiber-middleware/oapi_validate.go
@@ -106,7 +106,7 @@ func ValidateRequestFromContext(c *fiber.Ctx, router routers.Router, options *Op
 		default:
 			// This should never happen today, but if our upstream code changes,
 			// we don't want to crash the server, so handle the unexpected error.
-			return fmt.Errorf("error validating route: %s", err.Error())
+			return fmt.Errorf("error validating route: %w", err)
 		}
 	}
 
@@ -143,11 +143,11 @@ func ValidateRequestFromContext(c *fiber.Ctx, router routers.Router, options *Op
 			errorLines := strings.Split(e.Error(), "\n")
 			return fmt.Errorf("error in openapi3filter.RequestError: %s", errorLines[0])
 		case *openapi3filter.SecurityRequirementsError:
-			return fmt.Errorf("error in openapi3filter.SecurityRequirementsError: %s", e.Error())
+			return fmt.Errorf("error in openapi3filter.SecurityRequirementsError: %w", e)
 		default:
 			// This should never happen today, but if our upstream code changes,
 			// we don't want to crash the server, so handle the unexpected error.
-			return fmt.Errorf("error validating request: %s", err)
+			return fmt.Errorf("error validating request: %w", err)
 		}
 	}
 	return nil
@@ -190,5 +190,5 @@ func getMultiErrorHandlerFromOptions(options *Options) MultiErrorHandler {
 // of all the errors. This method is called if there are no other
 // methods defined on the options.
 func defaultMultiErrorHandler(me openapi3.MultiError) error {
-	return fmt.Errorf("multiple errors encountered: %s", me)
+	return fmt.Errorf("multiple errors encountered: %w", me)
 }

--- a/pkg/fiber-middleware/oapi_validate.go
+++ b/pkg/fiber-middleware/oapi_validate.go
@@ -47,7 +47,7 @@ func OapiRequestValidator(swagger *openapi3.T) fiber.Handler {
 }
 
 // ErrorHandler is called when there is an error in validation
-type ErrorHandler func(c *fiber.Ctx, message string, statusCode int)
+type ErrorHandler func(c *fiber.Ctx, message error, statusCode int) error
 
 // MultiErrorHandler is called when oapi returns a MultiError type
 type MultiErrorHandler func(openapi3.MultiError) error
@@ -75,9 +75,7 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) fibe
 		err := ValidateRequestFromContext(c, router, options)
 		if err != nil {
 			if options != nil && options.ErrorHandler != nil {
-				options.ErrorHandler(c, err.Error(), http.StatusBadRequest)
-				// in case the handler didn't internally call Abort, stop the chain
-				return nil
+				return options.ErrorHandler(c, err, http.StatusBadRequest)
 			} else {
 				// note: I am not sure if this is the best way to handle this
 				return fiber.NewError(http.StatusBadRequest, err.Error())

--- a/pkg/fiber-middleware/oapi_validate.go
+++ b/pkg/fiber-middleware/oapi_validate.go
@@ -102,7 +102,7 @@ func ValidateRequestFromContext(c *fiber.Ctx, router routers.Router, options *Op
 		case *routers.RouteError:
 			// We've got a bad request, the path requested doesn't match
 			// either server, or path, or something.
-			return errors.New(e.Reason)
+			return e
 		default:
 			// This should never happen today, but if our upstream code changes,
 			// we don't want to crash the server, so handle the unexpected error.

--- a/pkg/fiber-middleware/oapi_validate_test.go
+++ b/pkg/fiber-middleware/oapi_validate_test.go
@@ -80,8 +80,8 @@ func TestOapiRequestValidator(t *testing.T) {
 	// Set up an authenticator to check authenticated function. It will allow
 	// access to "someScope", but disallow others.
 	options := Options{
-		ErrorHandler: func(c *fiber.Ctx, message string, statusCode int) {
-			_ = c.Status(statusCode).SendString("test: " + message)
+		ErrorHandler: func(c *fiber.Ctx, err error, statusCode int) error {
+			return c.Status(statusCode).SendString("test: " + err.Error())
 		},
 		Options: openapi3filter.Options{
 			AuthenticationFunc: func(c context.Context, input *openapi3filter.AuthenticationInput) error {


### PR DESCRIPTION
Similar to #1143, but for fiber
Original issue: #1144 

Due to differences in gin and fiber error handling, `ErrorHandler` option was modified in order to support fiber. Message type was changed to support `errors.Is/As`

```go
// ErrorHandler is called when there is an error in validation
type ErrorHandler func(c *fiber.Ctx, message error, statusCode int) error
```

Usage example: 

```go
fibermiddleware.OapiRequestValidatorWithOptions(swagger, &fibermiddleware.Options{
	ErrorHandler: func(c *fiber.Ctx, message error, statusCode int) error {
                return c.Status(statusCode).JSON(fiber.Map{
			"ok":    false,
			"error": message.Error(),
		}) // .JSON error is returned instead of being logged manually. Fiber middlewares could handle them
	},
})
```