### PR TITLE
Fix pkgname for external response in Fiber strict server

### DIFF
--- a/pkg/codegen/templates/strict/strict-fiber-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-fiber-interface.tmpl
@@ -26,7 +26,7 @@
         {{$fixedStatusCode := .HasFixedStatusCode -}}
         {{$isRef := .IsRef -}}
         {{$isExternalRef := .IsExternalRef -}}
-        {{$ref := .Ref  | ucFirst -}}
+        {{$ref := .Ref  | ucFirstWithPkgName -}}
         {{$headers := .Headers -}}
 
         {{if (and $hasHeaders (not $isRef)) -}}


### PR DESCRIPTION
In Fiber strict server, when the response definition in another spec file is referenced from the operation, fix that the first letter of the package name in generated codes is capitalized incorrectly.

This PR fix #1405.
