### PR TITLE
refactor: use generic function sliceContains

### DIFF
--- a/pkg/codegen/merge_schemas_v1.go
+++ b/pkg/codegen/merge_schemas_v1.go
@@ -100,7 +100,7 @@ func GenStructFromAllOf(allOf []*openapi3.SchemaRef, path []string) (string, err
 				}
 
 				additionalPropertiesPart := fmt.Sprintf("AdditionalProperties map[string]%s `json:\"-\"`", addPropsType)
-				if !StringInArray(additionalPropertiesPart, objectParts) {
+				if !sliceContains(objectParts, additionalPropertiesPart) {
 					objectParts = append(objectParts, additionalPropertiesPart)
 				}
 			}

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -306,21 +306,21 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 					switch {
 
 					// HAL+JSON:
-					case StringInArray(contentTypeName, contentTypesHalJSON):
+					case sliceContains(contentTypesHalJSON, contentTypeName):
 						typeName = fmt.Sprintf("HALJSON%s", nameNormalizer(responseName))
 					case "application/json" == contentTypeName:
 						// if it's the standard application/json
 						typeName = fmt.Sprintf("JSON%s", nameNormalizer(responseName))
 					// Vendored JSON
-					case StringInArray(contentTypeName, contentTypesJSON) || util.IsMediaTypeJson(contentTypeName):
+					case sliceContains(contentTypesJSON, contentTypeName) || util.IsMediaTypeJson(contentTypeName):
 						baseTypeName := fmt.Sprintf("%s%s", nameNormalizer(contentTypeName), nameNormalizer(responseName))
 
 						typeName = strings.ReplaceAll(baseTypeName, "Json", "JSON")
 					// YAML:
-					case StringInArray(contentTypeName, contentTypesYAML):
+					case sliceContains(contentTypesYAML, contentTypeName):
 						typeName = fmt.Sprintf("YAML%s", nameNormalizer(responseName))
 					// XML:
-					case StringInArray(contentTypeName, contentTypesXML):
+					case sliceContains(contentTypesXML, contentTypeName):
 						typeName = fmt.Sprintf("XML%s", nameNormalizer(responseName))
 					default:
 						continue

--- a/pkg/codegen/prune.go
+++ b/pkg/codegen/prune.go
@@ -6,15 +6,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
-
 type RefWrapper struct {
 	Ref       string
 	HasValue  bool
@@ -402,7 +393,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 
 	for key := range swagger.Components.Schemas {
 		ref := fmt.Sprintf("#/components/schemas/%s", key)
-		if !stringInSlice(ref, refs) {
+		if !sliceContains(refs, ref) {
 			countRemoved++
 			delete(swagger.Components.Schemas, key)
 		}
@@ -410,7 +401,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 
 	for key := range swagger.Components.Parameters {
 		ref := fmt.Sprintf("#/components/parameters/%s", key)
-		if !stringInSlice(ref, refs) {
+		if !sliceContains(refs, ref) {
 			countRemoved++
 			delete(swagger.Components.Parameters, key)
 		}
@@ -421,7 +412,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 
 	// for key, _ := range swagger.Components.SecuritySchemes {
 	// 	ref := fmt.Sprintf("#/components/securitySchemes/%s", key)
-	// 	if !stringInSlice(ref, refs) {
+	// 	if !sliceContains(refs, ref) {
 	// 		countRemoved++
 	// 		delete(swagger.Components.SecuritySchemes, key)
 	// 	}
@@ -429,7 +420,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 
 	for key := range swagger.Components.RequestBodies {
 		ref := fmt.Sprintf("#/components/requestBodies/%s", key)
-		if !stringInSlice(ref, refs) {
+		if !sliceContains(refs, ref) {
 			countRemoved++
 			delete(swagger.Components.RequestBodies, key)
 		}
@@ -437,7 +428,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 
 	for key := range swagger.Components.Responses {
 		ref := fmt.Sprintf("#/components/responses/%s", key)
-		if !stringInSlice(ref, refs) {
+		if !sliceContains(refs, ref) {
 			countRemoved++
 			delete(swagger.Components.Responses, key)
 		}
@@ -445,7 +436,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 
 	for key := range swagger.Components.Headers {
 		ref := fmt.Sprintf("#/components/headers/%s", key)
-		if !stringInSlice(ref, refs) {
+		if !sliceContains(refs, ref) {
 			countRemoved++
 			delete(swagger.Components.Headers, key)
 		}
@@ -453,7 +444,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 
 	for key := range swagger.Components.Examples {
 		ref := fmt.Sprintf("#/components/examples/%s", key)
-		if !stringInSlice(ref, refs) {
+		if !sliceContains(refs, ref) {
 			countRemoved++
 			delete(swagger.Components.Examples, key)
 		}
@@ -461,7 +452,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 
 	for key := range swagger.Components.Links {
 		ref := fmt.Sprintf("#/components/links/%s", key)
-		if !stringInSlice(ref, refs) {
+		if !sliceContains(refs, ref) {
 			countRemoved++
 			delete(swagger.Components.Links, key)
 		}
@@ -469,7 +460,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 
 	for key := range swagger.Components.Callbacks {
 		ref := fmt.Sprintf("#/components/callbacks/%s", key)
-		if !stringInSlice(ref, refs) {
+		if !sliceContains(refs, ref) {
 			countRemoved++
 			delete(swagger.Components.Callbacks, key)
 		}

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -397,7 +397,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 					return Schema{}, fmt.Errorf("error generating Go schema for property '%s': %w", pName, err)
 				}
 
-				required := StringInArray(pName, schema.Required)
+				required := sliceContains(schema.Required, pName)
 
 				if (pSchema.HasAdditionalProperties || len(pSchema.UnionElements) != 0) && pSchema.RefType == "" {
 					// If we have fields present which have additional properties or union values,

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -146,7 +146,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 		SortedMapKeys := SortedMapKeys(responseRef.Value.Content)
 		jsonCount := 0
 		for _, contentTypeName := range SortedMapKeys {
-			if StringInArray(contentTypeName, contentTypesJSON) || util.IsMediaTypeJson(contentTypeName) {
+			if sliceContains(contentTypesJSON, contentTypeName) || util.IsMediaTypeJson(contentTypeName) {
 				jsonCount++
 			}
 		}
@@ -163,7 +163,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			switch {
 
 			// JSON:
-			case StringInArray(contentTypeName, contentTypesJSON) || util.IsMediaTypeJson(contentTypeName):
+			case sliceContains(contentTypesJSON, contentTypeName) || util.IsMediaTypeJson(contentTypeName):
 				if typeDefinition.ContentTypeName == contentTypeName {
 					caseAction := fmt.Sprintf("var dest %s\n"+
 						"if err := json.Unmarshal(bodyBytes, &dest); err != nil { \n"+
@@ -183,7 +183,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 				}
 
 			// YAML:
-			case StringInArray(contentTypeName, contentTypesYAML):
+			case sliceContains(contentTypesYAML, contentTypeName):
 				if typeDefinition.ContentTypeName == contentTypeName {
 					caseAction := fmt.Sprintf("var dest %s\n"+
 						"if err := yaml.Unmarshal(bodyBytes, &dest); err != nil { \n"+
@@ -197,7 +197,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 				}
 
 			// XML:
-			case StringInArray(contentTypeName, contentTypesXML):
+			case sliceContains(contentTypesXML, contentTypeName):
 				if typeDefinition.ContentTypeName == contentTypeName {
 					caseAction := fmt.Sprintf("var dest %s\n"+
 						"if err := xml.Unmarshal(bodyBytes, &dest); err != nil { \n"+

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -401,13 +401,8 @@ func schemaXOrder(v *openapi3.SchemaRef) (int64, bool) {
 
 // StringInArray checks whether the specified string is present in an array
 // of strings
-func StringInArray(str string, array []string) bool {
-	for _, elt := range array {
-		if elt == str {
-			return true
-		}
-	}
-	return false
+func StringInArray(array []string, str string) bool {
+	return sliceContains(array, str)
 }
 
 // RefPathToObjName returns the name of referenced object without changes.


### PR DESCRIPTION
This PR refactors the code to utilize the generic function `sliceContains` from the `pkg/codegen` package.

Upon migration to Go 1.21, `sliceContains` can be substituted with [slices.Contains](https://pkg.go.dev/slices#Contains).