### PR TITLE
fix: TestRefPathToGoType failing when shuffle tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ generate:
 
 test:
 	# for the root module, explicitly run the step, to prevent recursive calls
-	go test -cover ./...
+	go test -shuffle=on -cover ./...
 	# then, for all child modules, use a module-managed `Makefile`
 	git ls-files '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $$(dirname {}) && make test'
 

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -232,12 +232,17 @@ components:
 }
 
 func TestRefPathToGoType(t *testing.T) {
-	old := globalState.importMapping
+	oldMapping := globalState.importMapping
+	oldSpec := globalState.spec
 	globalState.importMapping = constructImportMapping(map[string]string{
 		"doc.json":                    "externalref0",
 		"http://deepmap.com/doc.json": "externalref1",
 	})
-	defer func() { globalState.importMapping = old }()
+	globalState.spec = &openapi3.T{}
+	defer func() {
+		globalState.importMapping = oldMapping
+		globalState.spec = oldSpec
+	}()
 
 	tests := []struct {
 		name   string


### PR DESCRIPTION
This PR fixes `TestRefPathToGoType` which failed when test [shuffling](https://pkg.go.dev/cmd/go/internal/test) enabled:
```
	-shuffle off,on,N
	    Randomize the execution order of tests and benchmarks.
	    It is off by default. If -shuffle is set to on, then it will seed
	    the randomizer using the system clock. If -shuffle is set to an
	    integer N, then N will be used as the seed value. In both cases,
	    the seed will be reported for reproducibility.
```

Additionally, you can reproduce panic by running the command:

```
go test  -run ^TestRefPathToGoType ./...
```

<details>
<summary>The full error</summary>

```
+ go test -shuffle=on -cover ./...
?       github.com/deepmap/oapi-codegen/v2/pkg/ecdsafile        [no test files]
?       github.com/deepmap/oapi-codegen/v2/pkg/securityprovider [no test files]
ok      github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen     1.030s  coverage: 0.0% of statements
-test.shuffle 1706383600410948000
--- FAIL: TestRefPathToGoType (0.00s)
    --- FAIL: TestRefPathToGoType/local-schemas (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x104e1d378]

goroutine 37 [running]:
testing.tRunner.func1.2({0x104fd7280, 0x1053b0d40})
        /opt/homebrew/Cellar/go/1.21.5/libexec/src/testing/testing.go:1545 +0x1c4
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.21.5/libexec/src/testing/testing.go:1548 +0x360
panic({0x104fd7280?, 0x1053b0d40?})
        /opt/homebrew/Cellar/go/1.21.5/libexec/src/runtime/panic.go:914 +0x218
github.com/deepmap/oapi-codegen/v2/pkg/codegen.findSchemaNameByRefPath({0x104e540ee?, 0x18?}, 0x104f5a6d0?)
        /Users/Oleksandr_Redko/src/github.com/deepmap/oapi-codegen/pkg/codegen/utils.go:892 +0x48
github.com/deepmap/oapi-codegen/v2/pkg/codegen.refPathToGoType({0x104e540ee, 0x18}, 0x1)
        /Users/Oleksandr_Redko/src/github.com/deepmap/oapi-codegen/pkg/codegen/utils.go:388 +0x23c
github.com/deepmap/oapi-codegen/v2/pkg/codegen.RefPathToGoType(...)
        /Users/Oleksandr_Redko/src/github.com/deepmap/oapi-codegen/pkg/codegen/utils.go:370
github.com/deepmap/oapi-codegen/v2/pkg/codegen.TestRefPathToGoType.func2(0x0?)
        /Users/Oleksandr_Redko/src/github.com/deepmap/oapi-codegen/pkg/codegen/utils_test.go:276 +0x64
testing.tRunner(0x140002181a0, 0x14000119340)
        /opt/homebrew/Cellar/go/1.21.5/libexec/src/testing/testing.go:1595 +0xe8
created by testing.(*T).Run in goroutine 36
        /opt/homebrew/Cellar/go/1.21.5/libexec/src/testing/testing.go:1648 +0x33c
FAIL    github.com/deepmap/oapi-codegen/v2/pkg/codegen  0.522s
ok      github.com/deepmap/oapi-codegen/v2/pkg/util     0.540s  coverage: 55.6% of statements
FAIL
```

</details>