### PR TITLE
refactor: simplify IsPredeclaredGoIdentifier implementation

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -16,6 +16,7 @@ package codegen
 import (
 	"bytes"
 	"fmt"
+	"go/doc"
 	"go/token"
 	"net/url"
 	"reflect"
@@ -30,7 +31,6 @@ import (
 
 var (
 	pathParamRE    *regexp.Regexp
-	predeclaredSet map[string]struct{}
 	separatorSet   map[rune]struct{}
 	nameNormalizer NameNormalizer = ToCamelCase
 )
@@ -98,56 +98,6 @@ var NameNormalizers = NameNormalizerMap{
 
 func init() {
 	pathParamRE = regexp.MustCompile(`{[.;?]?([^{}*]+)\*?}`)
-
-	predeclaredIdentifiers := []string{
-		// Types
-		"bool",
-		"byte",
-		"complex64",
-		"complex128",
-		"error",
-		"float32",
-		"float64",
-		"int",
-		"int8",
-		"int16",
-		"int32",
-		"int64",
-		"rune",
-		"string",
-		"uint",
-		"uint8",
-		"uint16",
-		"uint32",
-		"uint64",
-		"uintptr",
-		// Constants
-		"true",
-		"false",
-		"iota",
-		// Zero value
-		"nil",
-		// Functions
-		"append",
-		"cap",
-		"close",
-		"complex",
-		"copy",
-		"delete",
-		"imag",
-		"len",
-		"make",
-		"new",
-		"panic",
-		"print",
-		"println",
-		"real",
-		"recover",
-	}
-	predeclaredSet = map[string]struct{}{}
-	for _, id := range predeclaredIdentifiers {
-		predeclaredSet[id] = struct{}{}
-	}
 
 	separators := "-#@!$&=.+:;_~ (){}[]"
 	separatorSet = map[rune]struct{}{}
@@ -672,8 +622,7 @@ func IsGoKeyword(str string) bool {
 //
 // See https://golang.org/ref/spec#Predeclared_identifiers
 func IsPredeclaredGoIdentifier(str string) bool {
-	_, exists := predeclaredSet[str]
-	return exists
+	return doc.IsPredeclared(str)
 }
 
 // IsGoIdentity checks if the given string can be used as an identity

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -718,3 +718,25 @@ func Test_replaceInitialism(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPredeclaredGoIdentifier(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{name: "empty string", args: args{s: ""}, want: false},
+		{name: "not predeclared", args: args{s: "foo"}, want: false},
+		{name: "predeclared type", args: args{s: "any"}, want: true},
+		{name: "predeclared const", args: args{s: "true"}, want: true},
+		{name: "predeclared function", args: args{s: "len"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsPredeclaredGoIdentifier(tt.args.s))
+		})
+	}
+}


### PR DESCRIPTION
This PR refactors `codegen.IsPredeclaredGoIdentifier` implementation to use the function [`doc.IsPredeclared`](https://pkg.go.dev/go/doc#IsPredeclared) from std.