### PR TITLE
Use aliases for response type references

### DIFF
--- a/examples/petstore-expanded/strict/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-server.gen.go
@@ -343,7 +343,7 @@ type AddPetResponseObject interface {
 	VisitAddPetResponse(w http.ResponseWriter) error
 }
 
-type AddPet200JSONResponse Pet
+type AddPet200JSONResponse = Pet
 
 func (response AddPet200JSONResponse) VisitAddPetResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -400,7 +400,7 @@ type FindPetByIDResponseObject interface {
 	VisitFindPetByIDResponse(w http.ResponseWriter) error
 }
 
-type FindPetByID200JSONResponse Pet
+type FindPetByID200JSONResponse = Pet
 
 func (response FindPetByID200JSONResponse) VisitFindPetByIDResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/test/issues/issue-1093/api/parent/parent.gen.go
+++ b/internal/test/issues/issue-1093/api/parent/parent.gen.go
@@ -92,7 +92,7 @@ type GetPetsResponseObject interface {
 	VisitGetPetsResponse(w http.ResponseWriter) error
 }
 
-type GetPets200JSONResponse Pet
+type GetPets200JSONResponse = Pet
 
 func (response GetPets200JSONResponse) VisitGetPetsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/test/issues/issue-1208-1209/issue-multi-json.gen.go
+++ b/internal/test/issues/issue-1208-1209/issue-multi-json.gen.go
@@ -340,8 +340,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/test", wrapper.Test)
 }
 
-type BazApplicationBarPlusJSONResponse Bar
-type BazApplicationFooPlusJSONResponse Foo
+type BazApplicationBarPlusJSONResponse = Bar
+type BazApplicationFooPlusJSONResponse = Foo
 
 type TestRequestObject struct {
 }
@@ -350,7 +350,7 @@ type TestResponseObject interface {
 	VisitTestResponse(w http.ResponseWriter) error
 }
 
-type Test200ApplicationBarPlusJSONResponse Bar
+type Test200ApplicationBarPlusJSONResponse = Bar
 
 func (response Test200ApplicationBarPlusJSONResponse) VisitTestResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/bar+json")
@@ -359,7 +359,7 @@ func (response Test200ApplicationBarPlusJSONResponse) VisitTestResponse(w http.R
 	return json.NewEncoder(w).Encode(response)
 }
 
-type Test200ApplicationFooPlusJSONResponse Foo
+type Test200ApplicationFooPlusJSONResponse = Foo
 
 func (response Test200ApplicationFooPlusJSONResponse) VisitTestResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/foo+json")

--- a/internal/test/issues/issue-1378/bionicle/bionicle.gen.go
+++ b/internal/test/issues/issue-1378/bionicle/bionicle.gen.go
@@ -198,7 +198,7 @@ type GetBionicleNameResponseObject interface {
 	VisitGetBionicleNameResponse(w http.ResponseWriter) error
 }
 
-type GetBionicleName200JSONResponse Bionicle
+type GetBionicleName200JSONResponse = Bionicle
 
 func (response GetBionicleName200JSONResponse) VisitGetBionicleNameResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/test/issues/issue-removed-external-ref/gen/spec_ext/issue.gen.go
+++ b/internal/test/issues/issue-removed-external-ref/gen/spec_ext/issue.gen.go
@@ -159,7 +159,7 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	return r
 }
 
-type PascalJSONResponse PascalSchema
+type PascalJSONResponse = PascalSchema
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {

--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -551,7 +551,7 @@ type JSONExampleResponseObject interface {
 	VisitJSONExampleResponse(w http.ResponseWriter) error
 }
 
-type JSONExample200JSONResponse Example
+type JSONExample200JSONResponse = Example
 
 func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -658,7 +658,7 @@ type MultipleRequestAndResponseTypesResponseObject interface {
 	VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error
 }
 
-type MultipleRequestAndResponseTypes200JSONResponse Example
+type MultipleRequestAndResponseTypes200JSONResponse = Example
 
 func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -667,7 +667,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 	return json.NewEncoder(w).Encode(response)
 }
 
-type MultipleRequestAndResponseTypes200FormdataResponse Example
+type MultipleRequestAndResponseTypes200FormdataResponse = Example
 
 func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
@@ -927,7 +927,7 @@ type URLEncodedExampleResponseObject interface {
 	VisitURLEncodedExampleResponse(w http.ResponseWriter) error
 }
 
-type URLEncodedExample200FormdataResponse Example
+type URLEncodedExample200FormdataResponse = Example
 
 func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -285,7 +285,7 @@ type JSONExampleResponseObject interface {
 	VisitJSONExampleResponse(w http.ResponseWriter) error
 }
 
-type JSONExample200JSONResponse Example
+type JSONExample200JSONResponse = Example
 
 func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -392,7 +392,7 @@ type MultipleRequestAndResponseTypesResponseObject interface {
 	VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error
 }
 
-type MultipleRequestAndResponseTypes200JSONResponse Example
+type MultipleRequestAndResponseTypes200JSONResponse = Example
 
 func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -401,7 +401,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 	return json.NewEncoder(w).Encode(response)
 }
 
-type MultipleRequestAndResponseTypes200FormdataResponse Example
+type MultipleRequestAndResponseTypes200FormdataResponse = Example
 
 func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
@@ -661,7 +661,7 @@ type URLEncodedExampleResponseObject interface {
 	VisitURLEncodedExampleResponse(w http.ResponseWriter) error
 }
 
-type URLEncodedExample200FormdataResponse Example
+type URLEncodedExample200FormdataResponse = Example
 
 func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")

--- a/internal/test/strict-server/fiber/server.gen.go
+++ b/internal/test/strict-server/fiber/server.gen.go
@@ -256,7 +256,7 @@ type JSONExampleResponseObject interface {
 	VisitJSONExampleResponse(ctx *fiber.Ctx) error
 }
 
-type JSONExample200JSONResponse Example
+type JSONExample200JSONResponse = Example
 
 func (response JSONExample200JSONResponse) VisitJSONExampleResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/json")
@@ -363,7 +363,7 @@ type MultipleRequestAndResponseTypesResponseObject interface {
 	VisitMultipleRequestAndResponseTypesResponse(ctx *fiber.Ctx) error
 }
 
-type MultipleRequestAndResponseTypes200JSONResponse Example
+type MultipleRequestAndResponseTypes200JSONResponse = Example
 
 func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/json")
@@ -372,7 +372,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 	return ctx.JSON(&response)
 }
 
-type MultipleRequestAndResponseTypes200FormdataResponse Example
+type MultipleRequestAndResponseTypes200FormdataResponse = Example
 
 func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -632,7 +632,7 @@ type URLEncodedExampleResponseObject interface {
 	VisitURLEncodedExampleResponse(ctx *fiber.Ctx) error
 }
 
-type URLEncodedExample200FormdataResponse Example
+type URLEncodedExample200FormdataResponse = Example
 
 func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -350,7 +350,7 @@ type JSONExampleResponseObject interface {
 	VisitJSONExampleResponse(w http.ResponseWriter) error
 }
 
-type JSONExample200JSONResponse Example
+type JSONExample200JSONResponse = Example
 
 func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -457,7 +457,7 @@ type MultipleRequestAndResponseTypesResponseObject interface {
 	VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error
 }
 
-type MultipleRequestAndResponseTypes200JSONResponse Example
+type MultipleRequestAndResponseTypes200JSONResponse = Example
 
 func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -466,7 +466,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 	return json.NewEncoder(w).Encode(response)
 }
 
-type MultipleRequestAndResponseTypes200FormdataResponse Example
+type MultipleRequestAndResponseTypes200FormdataResponse = Example
 
 func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
@@ -726,7 +726,7 @@ type URLEncodedExampleResponseObject interface {
 	VisitURLEncodedExampleResponse(w http.ResponseWriter) error
 }
 
-type URLEncodedExample200FormdataResponse Example
+type URLEncodedExample200FormdataResponse = Example
 
 func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")

--- a/internal/test/strict-server/gorilla/server.gen.go
+++ b/internal/test/strict-server/gorilla/server.gen.go
@@ -474,7 +474,7 @@ type JSONExampleResponseObject interface {
 	VisitJSONExampleResponse(w http.ResponseWriter) error
 }
 
-type JSONExample200JSONResponse Example
+type JSONExample200JSONResponse = Example
 
 func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -581,7 +581,7 @@ type MultipleRequestAndResponseTypesResponseObject interface {
 	VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error
 }
 
-type MultipleRequestAndResponseTypes200JSONResponse Example
+type MultipleRequestAndResponseTypes200JSONResponse = Example
 
 func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -590,7 +590,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 	return json.NewEncoder(w).Encode(response)
 }
 
-type MultipleRequestAndResponseTypes200FormdataResponse Example
+type MultipleRequestAndResponseTypes200FormdataResponse = Example
 
 func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
@@ -850,7 +850,7 @@ type URLEncodedExampleResponseObject interface {
 	VisitURLEncodedExampleResponse(w http.ResponseWriter) error
 }
 
-type URLEncodedExample200FormdataResponse Example
+type URLEncodedExample200FormdataResponse = Example
 
 func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")

--- a/internal/test/strict-server/iris/server.gen.go
+++ b/internal/test/strict-server/iris/server.gen.go
@@ -271,7 +271,7 @@ type JSONExampleResponseObject interface {
 	VisitJSONExampleResponse(ctx iris.Context) error
 }
 
-type JSONExample200JSONResponse Example
+type JSONExample200JSONResponse = Example
 
 func (response JSONExample200JSONResponse) VisitJSONExampleResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json")
@@ -378,7 +378,7 @@ type MultipleRequestAndResponseTypesResponseObject interface {
 	VisitMultipleRequestAndResponseTypesResponse(ctx iris.Context) error
 }
 
-type MultipleRequestAndResponseTypes200JSONResponse Example
+type MultipleRequestAndResponseTypes200JSONResponse = Example
 
 func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json")
@@ -387,7 +387,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 	return ctx.JSON(&response)
 }
 
-type MultipleRequestAndResponseTypes200FormdataResponse Example
+type MultipleRequestAndResponseTypes200FormdataResponse = Example
 
 func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/x-www-form-urlencoded")
@@ -647,7 +647,7 @@ type URLEncodedExampleResponseObject interface {
 	VisitURLEncodedExampleResponse(ctx iris.Context) error
 }
 
-type URLEncodedExample200FormdataResponse Example
+type URLEncodedExample200FormdataResponse = Example
 
 func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/x-www-form-urlencoded")

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -258,6 +258,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 		}
 		return Schema{
 			GoType:         refType,
+			RefType:        refType,
 			Description:    schema.Description,
 			DefineViaAlias: true,
 			OAPISchema:     schema,


### PR DESCRIPTION
Uses type aliases for response schema definitions.

While using a schema like:

```yaml
paths:
  /example:
    get:
      responses:
        200:
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/OneOrAnother"

components:
  schemas:
    One:
      type: object

    Another:
      type: object

    OneOrAnother:
      oneOf:
        - $ref: "#/components/schemas/One"
        - $ref: "#/components/schemas/Another"
```

I noticed that this generated "strict" server code that looked like:

``` go
type OneOrAnother struct {
	union json.RawMessage
}

// ...

type GetExampleResponseObject interface {
	VisitGetExampleResponse(w http.ResponseWriter) error
}

type GetExampleResponseObject OneOrAnother

// ...

func (t OneOrAnother) MarshalJSON() ([]byte, error) {
	b, err := t.union.MarshalJSON()
	return b, err
}

func (t *OneOrAnother) UnmarshalJSON(b []byte) error {
	err := t.union.UnmarshalJSON(b)
	return err
}
```

However this doesn't actually work when doing the serialisation, because the type definition hides the definition of `MarshalJSON()`. Since the `union` field is private, this means the response that is actually serialised is `{}` every time.

Instead, we should just inherit that response from the referenced type definition. I.e. with `type GetExampleResponseObject = OneOrAnother`, the underlying `MarshalJSON` implementation will be picked up instead, and we can serialise the underlying union.