### PR TITLE
Handles whether a request body is set as required or not in the specification.

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -131,6 +131,8 @@ type OutputOptions struct {
 	InitialismOverrides bool `yaml:"initialism-overrides,omitempty"`
 	// Whether to generate nullable type for nullable fields
 	NullableType bool `yaml:"nullable-type,omitempty"`
+	// RequiredRequestBody do stuff
+	RequiredRequestBody bool `yaml:"required-request-body,omitempty"`
 
 	// DisableTypeAliasesForType allows defining which OpenAPI `type`s will explicitly not use type aliases
 	// Currently supports:

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -361,6 +361,23 @@ func (o OperationDefinition) HasMaskedRequestContentTypes() bool {
 	return false
 }
 
+func (o OperationDefinition) NeedsContentTypeCheck() bool {
+	if len(o.Bodies) > 1 {
+		return true
+	}
+	// if we don't want to handle request bodies being required or not, we skip the rest of this function.
+	if !globalState.options.OutputOptions.RequiredRequestBody {
+		return false
+	}
+	for _, body := range o.Bodies {
+		if !body.Required {
+			return true
+		}
+	}
+
+	return false
+}
+
 // RequestBodyDefinition describes a request body
 type RequestBodyDefinition struct {
 	// Is this body required, or optional?
@@ -408,6 +425,17 @@ func (r RequestBodyDefinition) Suffix() string {
 		return ""
 	}
 	return "With" + r.NameTag + "Body"
+}
+
+// IsRequired returns if a request body is required
+// if we don't want to handle request bodies being required or not, we mark them all as not required
+// otherwise it is the value set in the open api specification
+func (r RequestBodyDefinition) IsRequired() bool {
+	if !globalState.options.OutputOptions.RequiredRequestBody {
+		return false
+	}
+
+	return r.Required
 }
 
 // IsSupportedByClient returns true if we support this content type for client. Otherwise only generic method will ge generated

--- a/pkg/codegen/templates/strict/strict-http.tmpl
+++ b/pkg/codegen/templates/strict/strict-http.tmpl
@@ -45,16 +45,16 @@ type strictHandler struct {
             request.ContentType = r.Header.Get("Content-Type")
         {{end -}}
 
-        {{$multipleBodies := gt (len .Bodies) 1 -}}
+        {{$needsContentTypeCheck := .NeedsContentTypeCheck -}}
         {{range .Bodies -}}
-            {{if $multipleBodies}}if strings.HasPrefix(r.Header.Get("Content-Type"), "{{.ContentType}}") { {{end}}
+            {{if $needsContentTypeCheck}}if strings.HasPrefix(r.Header.Get("Content-Type"), "{{.ContentType}}") { {{end}}
                 {{if .IsJSON }}
                     var body {{$opid}}{{.NameTag}}RequestBody
                     if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
                         sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
                         return
                     }
-                    request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = &body
+                    request.{{if $needsContentTypeCheck}}{{.NameTag}}{{end}}Body = {{if not .IsRequired}}&{{end}}body
                 {{else if eq .NameTag "Formdata" -}}
                     if err := r.ParseForm(); err != nil {
                         sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode formdata: %w", err))
@@ -65,14 +65,14 @@ type strictHandler struct {
                         sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't bind formdata: %w", err))
                         return
                     }
-                    request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = &body
+                    request.{{if $needsContentTypeCheck}}{{.NameTag}}{{end}}Body = {{if not .IsRequired}}&{{end}}body
                 {{else if eq .NameTag "Multipart" -}}
                     {{if eq .ContentType "multipart/form-data" -}}
                     if reader, err := r.MultipartReader(); err != nil {
                         sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode multipart body: %w", err))
                         return
                     } else {
-                        request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = reader
+                        request.{{if $needsContentTypeCheck}}{{.NameTag}}{{end}}Body = reader
                     }
                     {{else -}}
                     if _, params, err := mime.ParseMediaType(r.Header.Get("Content-Type")); err != nil {
@@ -82,7 +82,7 @@ type strictHandler struct {
                         sh.options.RequestErrorHandlerFunc(w, r, http.ErrMissingBoundary)
                         return
                     } else {
-                        request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = multipart.NewReader(r.Body, boundary)
+                        request.{{if $needsContentTypeCheck}}{{.NameTag}}{{end}}Body = multipart.NewReader(r.Body, boundary)
                     }
                     {{end -}}
                 {{else if eq .NameTag "Text" -}}
@@ -92,11 +92,11 @@ type strictHandler struct {
                         return
                     }
                     body := {{$opid}}{{.NameTag}}RequestBody(data)
-                    request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = &body
+                    request.{{if $needsContentTypeCheck}}{{.NameTag}}{{end}}Body = {{if not .IsRequired}}&{{end}}body
                 {{else -}}
-                    request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = r.Body
+                    request.{{if $needsContentTypeCheck}}{{.NameTag}}{{end}}Body = r.Body
                 {{end}}{{/* if eq .NameTag "JSON" */ -}}
-            {{if $multipleBodies}}}{{end}}
+            {{if $needsContentTypeCheck}}}{{end}}
         {{end}}{{/* range .Bodies */}}
 
         handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {

--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -10,9 +10,9 @@
         {{if .HasMaskedRequestContentTypes -}}
             ContentType string
         {{end -}}
-        {{$multipleBodies := gt (len .Bodies) 1 -}}
+        {{$needsContentTypeCheck := .NeedsContentTypeCheck -}}
         {{range .Bodies -}}
-            {{if $multipleBodies}}{{.NameTag}}{{end}}Body {{if eq .NameTag "Multipart"}}*multipart.Reader{{else if ne .NameTag ""}}*{{$opid}}{{.NameTag}}RequestBody{{else}}io.Reader{{end}}
+            {{if $needsContentTypeCheck}}{{.NameTag}}{{end}}Body {{if eq .NameTag "Multipart"}}{{if not .IsRequired}}*{{end}}multipart.Reader{{else if ne .NameTag ""}}{{if not .IsRequired}}*{{end}}{{$opid}}{{.NameTag}}RequestBody{{else}}io.Reader{{end}}
         {{end -}}
     }
 

--- a/pkg/codegen/test_specs/required-body.yaml
+++ b/pkg/codegen/test_specs/required-body.yaml
@@ -1,0 +1,61 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /requiredrequests/:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                one:
+                  type: string
+              required:
+                - one
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                properties:
+                  two:
+                    type: string
+  /requests/:
+    post:
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                one:
+                  type: string
+              required:
+                - one
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                properties:
+                  two:
+                    type: string
+


### PR DESCRIPTION
As briefly discussed [there](https://github.com/deepmap/oapi-codegen/issues/1584)

The current behavior of the code generation is a mix between always required and always optional bodies.
However the open api specification is pretty clear about that requirement of body
see https://spec.openapis.org/oas/v3.1.0#fixed-fields-10 or https://swagger.io/docs/specification/describing-request-body/

> Request bodies are optional by default. 

this PR aims to bring the code generation closer to the intent of the open api specification.

using this spec as an example
```yaml
  /requiredrequests/:
    post:
      requestBody:
        required: true
        content:
....
  /requests/:
    post:
      requestBody:
        required: false
```

### type declaration

The issue here is that a body is always optional, using a pointer to convey this intent.

#### current behavior:

```go
type PostRequiredrequestsRequestObject struct {
	Body *PostRequiredrequestsJSONRequestBody
}
```

a required type will always be a pointer.

#### suggested behavior:

```go
type PostRequiredrequestsRequestObject struct {
	Body PostRequiredrequestsJSONRequestBody
}
```

we drop the ptr since the body was marqued as required in the open api specification.

as seen here, the type generation is considering a request body as being always optional.

### strict function handler

The issue here is that a body is always required.

#### current behavior
```go
var request PostRequestsRequestObject

var body PostRequestsJSONRequestBody
if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
	sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
	return
}
request.Body = &body
```

#### suggested behavior:
```go
var request PostRequestsRequestObject

if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {

	var body PostRequestsJSONRequestBody
	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
		return
	}
	request.JSONBody = &body
}

```

since the api specification states that the body is not required,  which is the default value for the required attribute, we need to check that the body is given to us before trying to decode it.

this may not be a great way to check that the body is there, since a user of the api could set the content type header and not setting a body.

I think this proposed change should be at one point the default behavior of the code generation as it is the default behavior of the open api specification

wdyt ?

- [ ] implements the same behavior for all the strict server
- [ ] body check detection using content type header may be a bit si bit simplistic