### PR TITLE
Update readme with install instrctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ With `oapi-codegen`, there are a few [Key Design Decisions](#key-design-decision
 
 ## Action Required: The repository for this project has changed
 
-As announced in [May 2024](https://github.com/oapi-codegen/oapi-codegen/discussions/1605), we have moved the project from the deepmap organization to our own organization, and you will need to update your import
-paths to pull updates past this point. You need to do a recursive search/replace from 
+As announced in [May 2024](https://github.com/oapi-codegen/oapi-codegen/discussions/1605), 
+we have moved the project from the deepmap organization to our own organization, and you will need to update your
+import paths to pull updates past this point. You need to do a recursive search/replace from 
 `github.com/oapi-codegen/oapi-codegen/v2` to `github.com/oapi-codegen/oapi-codegen/v2`.
+
+`oapi-codegen` moved to its new home with the version tag `v2.3.0`. If you
+are installing a version prior to `v2.3.0`, please use `github.com/deepmap/oapi-codegen/v2',
+otherwise, use `github.com/oapi-codegen/oapi-codegen/v2`
 
 ## Install
 


### PR DESCRIPTION
There are go.mod module name mismatches now that we've moved repos. Mention this in the readme, and inform that v2.3.0 is the first working version in the new location.