### PR TITLE
chore: correct Release Drafter branch

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Since the new repo (+ new branch name) we've not been running Release
Drafter.
