### PR TITLE
fix(oapi-codegen): add missing newline to error when swagger spec load fails (oapi-codegen#1688)

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -30,6 +30,9 @@ import (
 )
 
 func errExit(format string, args ...interface{}) {
+	if !strings.HasSuffix(format, "\n") {
+		format = format + "\n"
+	}
 	_, _ = fmt.Fprintf(os.Stderr, format, args...)
 	os.Exit(1)
 }

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -280,7 +280,7 @@ func main() {
 
 	swagger, err := util.LoadSwaggerWithCircularReferenceCount(flag.Arg(0), opts.Compatibility.CircularReferenceLimit)
 	if err != nil {
-		errExit("error loading swagger spec in %s\n: %s", flag.Arg(0), err)
+		errExit("error loading swagger spec in %s\n: %s\n", flag.Arg(0), err)
 	}
 
 	if strings.HasPrefix(swagger.OpenAPI, "3.1.") {


### PR DESCRIPTION
Before:

```
$ go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.3.0
$ oapi-codegen -generate types,client -package myproject spec.json >/dev/null
error loading swagger spec in spec.json
: map key "SomeMapKey" not found$
```

After:

```
$ go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.3.0
$ oapi-codegen -generate types,client -package myproject spec.json >/dev/null
error loading swagger spec in spec.json
: map key "SomeMapKey" not found
$
```

Closes #1688