### PR TITLE
Support x-go-type-skip-optional-pointer in client query

### DIFF
--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -210,7 +210,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
 
             {{end}}
             {{if .IsStyled}}
-            if queryFrag, err := runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationQuery, {{if not .Required}}*{{end}}params.{{.GoName}}); err != nil {
+            if queryFrag, err := runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationQuery, {{if and (not .Required) (not .Schema.SkipOptionalPointer)}}*{{end}}params.{{.GoName}}); err != nil {
                 return nil, err
             } else if parsed, err := url.ParseQuery(queryFrag); err != nil {
                return nil, err
@@ -310,3 +310,4 @@ func (c *{{ $clientTypeName }}) applyEditors(ctx context.Context, req *http.Requ
     }
     return nil
 }
+


### PR DESCRIPTION
Hello.
We've tried to use x-go-type-skip-optional-pointer with optional slices in our code base. But generated client code became invalid. Original template makes dereference of pure slice.
I've added an extra check for this case, for query parameters. Other param locations may need the same check.
Note, that supporting optional not-nilable types (ex int) with x-go-type-skip-optional-pointer  requires extra work. As `if params.{{.GoName}} != nil` check will not compile. But zero value semantic is not well defined in this case.