### PR TITLE
chore: make it possible to provide detailed config validation errors

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -30,6 +30,78 @@ type Configuration struct {
 	NoVCSVersionOverride *string `yaml:"-"`
 }
 
+// Validate checks whether Configuration represent a valid configuration
+func (o Configuration) Validate() error {
+	if o.PackageName == "" {
+		return errors.New("package name must be specified")
+	}
+
+	// Only one server type should be specified at a time.
+	nServers := 0
+	if o.Generate.IrisServer {
+		nServers++
+	}
+	if o.Generate.ChiServer {
+		nServers++
+	}
+	if o.Generate.FiberServer {
+		nServers++
+	}
+	if o.Generate.EchoServer {
+		nServers++
+	}
+	if o.Generate.GorillaServer {
+		nServers++
+	}
+	if o.Generate.StdHTTPServer {
+		nServers++
+	}
+	if o.Generate.GinServer {
+		nServers++
+	}
+	if nServers > 1 {
+		return errors.New("only one server type is supported at a time")
+	}
+
+	var errs []error
+	if problems := o.Generate.Validate(); problems != nil {
+		for k, v := range problems {
+			errs = append(errs, fmt.Errorf("`generate` configuration for %v was incorrect: %v", k, v))
+		}
+	}
+
+	if problems := o.Compatibility.Validate(); problems != nil {
+		for k, v := range problems {
+			errs = append(errs, fmt.Errorf("`compatibility-options` configuration for %v was incorrect: %v", k, v))
+		}
+	}
+
+	if problems := o.OutputOptions.Validate(); problems != nil {
+		for k, v := range problems {
+			errs = append(errs, fmt.Errorf("`output-options` configuration for %v was incorrect: %v", k, v))
+		}
+	}
+
+	err := errors.Join(errs...)
+	if err != nil {
+		return fmt.Errorf("failed to validate configuration: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateDefaults sets reasonable default values for unset fields in Configuration
+func (o Configuration) UpdateDefaults() Configuration {
+	if reflect.ValueOf(o.Generate).IsZero() {
+		o.Generate = GenerateOptions{
+			EchoServer:   true,
+			Models:       true,
+			EmbeddedSpec: true,
+		}
+	}
+	return o
+}
+
 // GenerateOptions specifies which supported output formats to generate.
 type GenerateOptions struct {
 	// IrisServer specifies whether to generate iris server boilerplate
@@ -152,77 +224,5 @@ type OutputOptions struct {
 }
 
 func (oo OutputOptions) Validate() map[string]string {
-	return nil
-}
-
-// UpdateDefaults sets reasonable default values for unset fields in Configuration
-func (o Configuration) UpdateDefaults() Configuration {
-	if reflect.ValueOf(o.Generate).IsZero() {
-		o.Generate = GenerateOptions{
-			EchoServer:   true,
-			Models:       true,
-			EmbeddedSpec: true,
-		}
-	}
-	return o
-}
-
-// Validate checks whether Configuration represent a valid configuration
-func (o Configuration) Validate() error {
-	if o.PackageName == "" {
-		return errors.New("package name must be specified")
-	}
-
-	// Only one server type should be specified at a time.
-	nServers := 0
-	if o.Generate.IrisServer {
-		nServers++
-	}
-	if o.Generate.ChiServer {
-		nServers++
-	}
-	if o.Generate.FiberServer {
-		nServers++
-	}
-	if o.Generate.EchoServer {
-		nServers++
-	}
-	if o.Generate.GorillaServer {
-		nServers++
-	}
-	if o.Generate.StdHTTPServer {
-		nServers++
-	}
-	if o.Generate.GinServer {
-		nServers++
-	}
-	if nServers > 1 {
-		return errors.New("only one server type is supported at a time")
-	}
-
-	var errs []error
-	if problems := o.Generate.Validate(); problems != nil {
-		for k, v := range problems {
-			errs = append(errs, fmt.Errorf("`generate` configuration for %v was incorrect: %v", k, v))
-		}
-	}
-
-	if problems := o.Compatibility.Validate(); problems != nil {
-		for k, v := range problems {
-			errs = append(errs, fmt.Errorf("`compatibility-options` configuration for %v was incorrect: %v", k, v))
-		}
-	}
-
-	if problems := o.OutputOptions.Validate(); problems != nil {
-		for k, v := range problems {
-			errs = append(errs, fmt.Errorf("`output-options` configuration for %v was incorrect: %v", k, v))
-		}
-	}
-
-	err := errors.Join(errs...)
-	if err != nil {
-		return fmt.Errorf("failed to validate configuration: %w", err)
-	}
-
 	return nil
 }


### PR DESCRIPTION
- **chore: make it possible to provide detailed config validation errors**
- **refactor: move `Configuration` methods closer to struct**
