### PR TITLE
fix(extensions): use the `x-order` from next to `$ref`, if present

### DIFF
--- a/internal/test/extensions/x-order/issue.gen.go
+++ b/internal/test/extensions/x-order/issue.gen.go
@@ -18,6 +18,10 @@ type Port = int
 
 // PortInterval defines model for PortInterval.
 type PortInterval struct {
-	Start Port `json:"start"`
-	End   Port `json:"end"`
+	Start   Port             `json:"start"`
+	End     Port             `json:"end"`
+	VeryEnd *LowPriorityPort `json:"very_end,omitempty"`
 }
+
+// LowPriorityPort defines model for LowPriorityPort.
+type LowPriorityPort = int

--- a/internal/test/extensions/x-order/issue.gen.go
+++ b/internal/test/extensions/x-order/issue.gen.go
@@ -12,3 +12,12 @@ type DateInterval struct {
 	Start *openapi_types.Date `json:"start,omitempty"`
 	End   *openapi_types.Date `json:"end,omitempty"`
 }
+
+// Port defines model for Port.
+type Port = int
+
+// PortInterval defines model for PortInterval.
+type PortInterval struct {
+	Start Port `json:"start"`
+	End   Port `json:"end"`
+}

--- a/internal/test/extensions/x-order/spec.yaml
+++ b/internal/test/extensions/x-order/spec.yaml
@@ -21,9 +21,9 @@ components:
         - start
         - end
       properties:
-        start:
-          $ref: '#/components/schemas/Port'
-          x-order: 1
         end:
           $ref: '#/components/schemas/Port'
           x-order: 2
+        start:
+          $ref: '#/components/schemas/Port'
+          x-order: 1

--- a/internal/test/extensions/x-order/spec.yaml
+++ b/internal/test/extensions/x-order/spec.yaml
@@ -13,3 +13,17 @@ components:
           type: string
           format: date
           x-order: 1
+    Port:
+      type: integer
+    PortInterval:
+      type: object
+      required:
+        - start
+        - end
+      properties:
+        start:
+          $ref: '#/components/schemas/Port'
+          x-order: 1
+        end:
+          $ref: '#/components/schemas/Port'
+          x-order: 2

--- a/internal/test/extensions/x-order/spec.yaml
+++ b/internal/test/extensions/x-order/spec.yaml
@@ -15,6 +15,9 @@ components:
           x-order: 1
     Port:
       type: integer
+    LowPriorityPort:
+      type: integer
+      x-order: 50
     PortInterval:
       type: object
       required:
@@ -24,6 +27,8 @@ components:
         end:
           $ref: '#/components/schemas/Port'
           x-order: 2
+        very_end:
+          $ref: '#/components/schemas/LowPriorityPort'
         start:
           $ref: '#/components/schemas/Port'
           x-order: 1

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -388,6 +388,7 @@ func schemaXOrder(v *openapi3.SchemaRef) (int64, bool) {
 		return 0, false
 	}
 
+	// YAML parsing picks up the x-order as a float64
 	if order, ok := v.Value.Extensions[extOrder].(float64); ok {
 		return int64(order), true
 	}

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -380,6 +380,7 @@ func schemaXOrder(v *openapi3.SchemaRef) (int64, bool) {
 		return 0, false
 	}
 
+	// YAML parsing picks up the x-order as a float64
 	if order, ok := v.Extensions[extOrder].(float64); ok {
 		return int64(order), true
 	}
@@ -387,6 +388,8 @@ func schemaXOrder(v *openapi3.SchemaRef) (int64, bool) {
 	if v.Value == nil {
 		return 0, false
 	}
+
+	// if v.Value is set, then this is actually a `$ref`, and we should check if there's an x-order set on that
 
 	// YAML parsing picks up the x-order as a float64
 	if order, ok := v.Value.Extensions[extOrder].(float64); ok {

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -361,18 +361,8 @@ func SortedSchemaKeys(dict map[string]*openapi3.SchemaRef) []string {
 		keys[i], orders[key] = key, int64(len(dict))
 		i++
 
-		if v == nil || v.Value == nil {
-			continue
-		}
-
-		ext := v.Value.Extensions[extOrder]
-		if ext == nil {
-			continue
-		}
-
-		// YAML parsing picks up the x-order as a float64
-		if order, ok := ext.(float64); ok {
-			orders[key] = int64(order)
+		if order, ok := schemaXOrder(v); ok {
+			orders[key] = order
 		}
 	}
 
@@ -383,6 +373,26 @@ func SortedSchemaKeys(dict map[string]*openapi3.SchemaRef) []string {
 		return keys[i] < keys[j]
 	})
 	return keys
+}
+
+func schemaXOrder(v *openapi3.SchemaRef) (int64, bool) {
+	if v == nil {
+		return 0, false
+	}
+
+	if order, ok := v.Extensions[extOrder].(float64); ok {
+		return int64(order), true
+	}
+
+	if v.Value == nil {
+		return 0, false
+	}
+
+	if order, ok := v.Value.Extensions[extOrder].(float64); ok {
+		return int64(order), true
+	}
+
+	return 0, false
 }
 
 // StringInArray checks whether the specified string is present in an array


### PR DESCRIPTION
This is part 2 of the fix for https://github.com/oapi-codegen/oapi-codegen/issues/1611.

The issues is that something like the below doesn't work.
```
type: object
properties:
 start_port:
   $ref: "#/components/schemas/port"
   x-order: 1
 end_port:
   $ref: "#/components/schemas/port"
   x-order: 2
```

First problem was the kin-openapi does not actually capture these values from the yaml/json. This fixed in https://github.com/getkin/kin-openapi/pull/901, release in v0.126.0 and pulled in here in https://github.com/oapi-codegen/oapi-codegen/pull/1689

This is the second part which actually considers this value in the sort and officially fixes https://github.com/oapi-codegen/oapi-codegen/issues/1611.  It first checks for "next to $ref" then if there is an `x-order` in the schema referenced. 