### PR TITLE
Update speakeasy URL on oapi-codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -3982,7 +3982,7 @@ We are currently generously sponsored by the following folks, each of whom provi
 </p>
 
 <p align="center">
-	<a href="https://speakeasyapi.dev?utm_source=oapi-codegen+repo&utm_medium=github+sponsorship">
+	<a href="https://speakeasy.com?utm_source=oapi-codegen+repo&utm_medium=github+sponsorship">
 		<picture>
 		  <source media="(prefers-color-scheme: light)" srcset=".github/sponsors/speakeasy-light.svg">
 		  <source media="(prefers-color-scheme: dark)" srcset=".github/sponsors/speakeasy-dark.svg">


### PR DESCRIPTION
Speakeasy is now found at speakeasy.com!