### PR TITLE
Fix #867 by intercepting spec loading

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -281,7 +281,7 @@ func main() {
 		return
 	}
 
-	swagger, err := util.LoadSwagger(flag.Arg(0))
+	swagger, err := util.LoadOpenAPI(flag.Arg(0))
 	if err != nil {
 		errExit("error loading swagger spec in %s\n: %s\n", flag.Arg(0), err)
 	}

--- a/cmd/oapi-codegen/oapi-codegen_test.go
+++ b/cmd/oapi-codegen/oapi-codegen_test.go
@@ -15,7 +15,7 @@ func TestLoader(t *testing.T) {
 
 	for _, v := range paths {
 
-		swagger, err := util.LoadSwagger(v)
+		swagger, err := util.LoadOpenAPI(v)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -97,7 +97,7 @@ func TestExtPropGoTypeSkipOptionalPointer(t *testing.T) {
 		},
 	}
 	spec := "test_specs/x-go-type-skip-optional-pointer.yaml"
-	swagger, err := util.LoadSwagger(spec)
+	swagger, err := util.LoadOpenAPI(spec)
 	require.NoError(t, err)
 
 	// Run our code generation:
@@ -134,7 +134,7 @@ func TestGoTypeImport(t *testing.T) {
 		},
 	}
 	spec := "test_specs/x-go-type-import-pet.yaml"
-	swagger, err := util.LoadSwagger(spec)
+	swagger, err := util.LoadOpenAPI(spec)
 	require.NoError(t, err)
 
 	// Run our code generation:
@@ -182,7 +182,7 @@ func TestRemoteExternalReference(t *testing.T) {
 		},
 	}
 	spec := "test_specs/remote-external-reference.yaml"
-	swagger, err := util.LoadSwagger(spec)
+	swagger, err := util.LoadOpenAPI(spec)
 	require.NoError(t, err)
 
 	// Run our code generation:

--- a/pkg/util/loader.go
+++ b/pkg/util/loader.go
@@ -1,13 +1,18 @@
 package util
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"gopkg.in/yaml.v2"
 )
 
+// Deprecated: LoadSwagger loads an OpenAPI 3.0 definition from a file or a
+// URL. Use LoadOpenAPI instead.
 func LoadSwagger(filePath string) (swagger *openapi3.T, err error) {
-
 	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = true
 
@@ -19,9 +24,98 @@ func LoadSwagger(filePath string) (swagger *openapi3.T, err error) {
 	}
 }
 
-// Deprecated: In kin-openapi v0.126.0 (https://github.com/getkin/kin-openapi/tree/v0.126.0?tab=readme-ov-file#v01260) the Circular Reference Counter functionality was removed, instead resolving all references with backtracking, to avoid needing to provide a limit to reference counts.
+// LoadOpenAPI loads an OpenAPI spec, and hooks into the kin loader to parse
+// version information from the spec.
+func LoadOpenAPI(filePath string) (openapi *openapi3.T, err error) {
+	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = true
+
+	// We're using a shim to intercept the loads being done by the kin-openapi
+	// loader. We're going to peek inside and try to find version information
+	// about the file.
+	var ls loaderShim
+	loader.ReadFromURIFunc = ls.InterceptLoad
+
+	u, err := url.Parse(filePath)
+	if err == nil && u.Scheme != "" && u.Host != "" {
+		// The shim needs a URL to compare with, since it can be called multiple
+		// times durin a load when resolving multiple refs.
+		ls.srcURL = u
+		return loader.LoadFromURI(u)
+	} else {
+		// In the case where the URL failed to parse, we'll construct one explicitly
+		// in the same way that Kin does. LoadFromFile simply calls LoadFromURI
+		// internally.
+		ls.srcURL = &url.URL{Path: filePath}
+		return loader.LoadFromFile(filePath)
+	}
+}
+
+type loaderShim struct {
+	srcURL  *url.URL
+	version string
+}
+
+// openAPIorSwaggerVersion is used to parse either OpenAPI or Swagger version
+// from a JSON or YAML file.
+type openAPIorSwaggerVersion struct {
+	Swagger string `json:"swagger" yaml:"swagger"`
+	OpenAPI string `json:"openapi" yaml:"openapi"`
+}
+
+var ErrSwagger2NotSupported = errors.New("swagger version 2.0 is not supported")
+var ErrOpenAPI31NotSupported = errors.New("OpenAPI version 3.1 is not yet supported")
+
+func (l *loaderShim) InterceptLoad(loader *openapi3.Loader, url *url.URL) ([]byte, error) {
+	buf, err := openapi3.DefaultReadFromURI(loader, url)
+	if err != nil {
+		return buf, err
+	}
+
+	if l.srcURL.Scheme == url.Scheme && l.srcURL.Host == url.Host && l.srcURL.Path == url.Path {
+		var versionInfo openAPIorSwaggerVersion
+		// We've found our file of interest. Parse it and figure out a version. We'll parse as
+		// YAML since this handles JSON too.
+		err = yaml.Unmarshal(buf, &versionInfo)
+		// If we failed to unmarshal we don't react, maintaining previous behavior of
+		// trying to process the file.
+		if err != nil {
+			return buf, nil
+		}
+
+		version := versionInfo.OpenAPI
+		if version == "" {
+			version = versionInfo.Swagger
+		}
+
+		// Try to extract the major, minor. Openapi will have patch level, swagger won't
+		versionParts := strings.Split(version, ".")
+		if len(versionParts) < 2 {
+			return buf, nil
+		}
+		major := versionParts[0]
+		minor := versionParts[1]
+		if major == "2" {
+			// TODO: we can actually use openapi2conv to convert swagger2 to OpenAPI 3
+			return nil, ErrSwagger2NotSupported
+		}
+		if major != "3" {
+			return nil, fmt.Errorf("OpenAPI/Swagger %v is not supported", version)
+		}
+		// Now, we know we've got major 3.
+		if minor != "0" {
+			return nil, ErrOpenAPI31NotSupported
+		}
+	}
+
+	return buf, nil
+}
+
+// Deprecated: In kin-openapi v0.126.0 (https://github.com/getkin/kin-openapi/tree/v0.126.0?tab=readme-ov-file#v01260) the
+// Circular Reference Counter functionality was removed, instead resolving all references with backtracking, to avoid
+// needing to provide a limit to reference counts.
 //
-// This is now identital in method as `LoadSwagger`.
+// This is now identical in method as `LoadSwagger`.
 func LoadSwaggerWithCircularReferenceCount(filePath string, _ int) (swagger *openapi3.T, err error) {
-	return LoadSwagger(filePath)
+	return LoadOpenAPI(filePath)
 }


### PR DESCRIPTION
This change adds a shim into the Kin loader which attempts to find an `openapi` or `swagger` version key in the spec, and returns an error if it's an unsupported version. in the case where the version can't be detected, we do nothing and behave as previously, failing in the parsing step.