### PR TITLE
feat(std-http): accept `Mux` interface instead of `*http.ServeMux`

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ type ServerInterface interface {
 	GetPing(w http.ResponseWriter, r *http.Request)
 }
 
-func HandlerFromMux(si ServerInterface, m *http.ServeMux) http.Handler {
+func HandlerFromMux(si ServerInterface, m ServeMux) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{
 		BaseRouter: m,
 	})

--- a/examples/authenticated-api/stdhttp/api/api.gen.go
+++ b/examples/authenticated-api/stdhttp/api/api.gen.go
@@ -540,21 +540,27 @@ func Handler(si ServerInterface) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{})
 }
 
+// ServeMux is an abstraction of http.ServeMux.
+type ServeMux interface {
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+}
+
 type StdHTTPServerOptions struct {
 	BaseURL          string
-	BaseRouter       *http.ServeMux
+	BaseRouter       ServeMux
 	Middlewares      []MiddlewareFunc
 	ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, err error)
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
-func HandlerFromMux(si ServerInterface, m *http.ServeMux) http.Handler {
+func HandlerFromMux(si ServerInterface, m ServeMux) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{
 		BaseRouter: m,
 	})
 }
 
-func HandlerFromMuxWithBaseURL(si ServerInterface, m *http.ServeMux, baseURL string) http.Handler {
+func HandlerFromMuxWithBaseURL(si ServerInterface, m ServeMux, baseURL string) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{
 		BaseURL:    baseURL,
 		BaseRouter: m,

--- a/examples/minimal-server/stdhttp/api/ping.gen.go
+++ b/examples/minimal-server/stdhttp/api/ping.gen.go
@@ -119,21 +119,27 @@ func Handler(si ServerInterface) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{})
 }
 
+// ServeMux is an abstraction of http.ServeMux.
+type ServeMux interface {
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+}
+
 type StdHTTPServerOptions struct {
 	BaseURL          string
-	BaseRouter       *http.ServeMux
+	BaseRouter       ServeMux
 	Middlewares      []MiddlewareFunc
 	ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, err error)
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
-func HandlerFromMux(si ServerInterface, m *http.ServeMux) http.Handler {
+func HandlerFromMux(si ServerInterface, m ServeMux) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{
 		BaseRouter: m,
 	})
 }
 
-func HandlerFromMuxWithBaseURL(si ServerInterface, m *http.ServeMux, baseURL string) http.Handler {
+func HandlerFromMuxWithBaseURL(si ServerInterface, m ServeMux, baseURL string) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{
 		BaseURL:    baseURL,
 		BaseRouter: m,

--- a/examples/petstore-expanded/stdhttp/api/petstore.gen.go
+++ b/examples/petstore-expanded/stdhttp/api/petstore.gen.go
@@ -259,21 +259,27 @@ func Handler(si ServerInterface) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{})
 }
 
+// ServeMux is an abstraction of http.ServeMux.
+type ServeMux interface {
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+}
+
 type StdHTTPServerOptions struct {
 	BaseURL          string
-	BaseRouter       *http.ServeMux
+	BaseRouter       ServeMux
 	Middlewares      []MiddlewareFunc
 	ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, err error)
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
-func HandlerFromMux(si ServerInterface, m *http.ServeMux) http.Handler {
+func HandlerFromMux(si ServerInterface, m ServeMux) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{
 		BaseRouter: m,
 	})
 }
 
-func HandlerFromMuxWithBaseURL(si ServerInterface, m *http.ServeMux, baseURL string) http.Handler {
+func HandlerFromMuxWithBaseURL(si ServerInterface, m ServeMux, baseURL string) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{
 		BaseURL:    baseURL,
 		BaseRouter: m,

--- a/internal/test/strict-server/stdhttp/server.gen.go
+++ b/internal/test/strict-server/stdhttp/server.gen.go
@@ -376,21 +376,27 @@ func Handler(si ServerInterface) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{})
 }
 
+// ServeMux is an abstraction of http.ServeMux.
+type ServeMux interface {
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+}
+
 type StdHTTPServerOptions struct {
 	BaseURL          string
-	BaseRouter       *http.ServeMux
+	BaseRouter       ServeMux
 	Middlewares      []MiddlewareFunc
 	ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, err error)
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
-func HandlerFromMux(si ServerInterface, m *http.ServeMux) http.Handler {
+func HandlerFromMux(si ServerInterface, m ServeMux) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{
 		BaseRouter: m,
 	})
 }
 
-func HandlerFromMuxWithBaseURL(si ServerInterface, m *http.ServeMux, baseURL string) http.Handler {
+func HandlerFromMuxWithBaseURL(si ServerInterface, m ServeMux, baseURL string) http.Handler {
 	return HandlerWithOptions(si, StdHTTPServerOptions{
 		BaseURL:    baseURL,
 		BaseRouter: m,

--- a/pkg/codegen/templates/stdhttp/std-http-handler.tmpl
+++ b/pkg/codegen/templates/stdhttp/std-http-handler.tmpl
@@ -3,21 +3,27 @@ func Handler(si ServerInterface) http.Handler {
   return HandlerWithOptions(si, StdHTTPServerOptions{})
 }
 
+// ServeMux is an abstraction of http.ServeMux.
+type ServeMux interface {
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+}
+
 type StdHTTPServerOptions struct {
     BaseURL          string
-    BaseRouter       *http.ServeMux
+    BaseRouter       ServeMux
     Middlewares      []MiddlewareFunc
     ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, err error)
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
-func HandlerFromMux(si ServerInterface, m *http.ServeMux) http.Handler {
+func HandlerFromMux(si ServerInterface, m ServeMux) http.Handler {
     return HandlerWithOptions(si, StdHTTPServerOptions {
         BaseRouter: m,
     })
 }
 
-func HandlerFromMuxWithBaseURL(si ServerInterface, m *http.ServeMux, baseURL string) http.Handler {
+func HandlerFromMuxWithBaseURL(si ServerInterface, m ServeMux, baseURL string) http.Handler {
     return HandlerWithOptions(si, StdHTTPServerOptions {
         BaseURL: baseURL,
         BaseRouter: m,


### PR DESCRIPTION
# Description
As described on Issue #1718, I'm implementing receiving Mux as interface instead of *http.ServeMux.
Following the open-closed principle, it will allow the library to be more customizable for the developers.