### PR TITLE
Generate schema properties in the original order

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/oapi-codegen/oapi-codegen/v2
 
 go 1.20
 
+replace github.com/getkin/kin-openapi => github.com/diamondburned/kin-openapi v0.92.1-0.20240812092412-a5b8ae983de2
+
 require (
 	github.com/getkin/kin-openapi v0.126.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/getkin/kin-openapi v0.126.0 h1:c2cSgLnAsS0xYfKsgt5oBV6MYRM/giU8/RtwUY4wyfY=
-github.com/getkin/kin-openapi v0.126.0/go.mod h1:7mONz8IwmSRg6RttPu6v8U/OJ+gr+J99qSFNjPGSQqw=
+github.com/diamondburned/kin-openapi v0.92.1-0.20240812092412-a5b8ae983de2 h1:t2t/uIpi6OkUKIDCWz2YD5VmTFSUYBrQbryi8ZjMUQw=
+github.com/diamondburned/kin-openapi v0.92.1-0.20240812092412-a5b8ae983de2/go.mod h1:z5cmU5eqK8Unl7sQCgDdJi44msx2m5Hbaro0V6HTqMw=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=
 github.com/go-openapi/jsonpointer v0.21.0/go.mod h1:IUyH9l/+uyhIYQ/PXVA41Rexl+kOkAPDdXEYns6fzUY=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -387,7 +387,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 			}
 
 			// We've got an object with some properties.
-			for _, pName := range SortedSchemaKeys(schema.Properties) {
+			for _, pName := range schema.PropertyKeys {
 				p := schema.Properties[pName]
 				propertyPath := append(path, pName)
 				pSchema, err := GenerateGoSchema(p, propertyPath)


### PR DESCRIPTION
This commit temporarily switches to a fork of kin-openapi that provides
the original ordering of the Properties object. This provides a way for
this tool to generate the properties in the original order as they were
written in the YAML file.
