### PR TITLE
Allow typeNamePrefix to be capable of resolving `>` and `<`

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -776,6 +776,10 @@ func typeNamePrefix(name string) (prefix string) {
 			prefix += "Tilde"
 		case '=':
 			prefix += "Equal"
+		case '>':
+			prefix += "Greater"
+		case '<':
+			prefix += "Less"
 		case '#':
 			prefix += "Hash"
 		case '.':

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -777,9 +777,9 @@ func typeNamePrefix(name string) (prefix string) {
 		case '=':
 			prefix += "Equal"
 		case '>':
-			prefix += "Greater"
+			prefix += "GreaterThan"
 		case '<':
-			prefix += "Less"
+			prefix += "LessThan"
 		case '#':
 			prefix += "Hash"
 		case '.':

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -594,6 +594,10 @@ func TestSchemaNameToTypeName(t *testing.T) {
 		"=3":           "Equal3",
 		"#Tag":         "HashTag",
 		".com":         "DotCom",
+		">=":           "GreaterThanEqual",
+		"<=":           "LessThanEqual",
+		"<":            "LessThan",
+		">":            "GreaterThan",
 	} {
 		assert.Equal(t, want, SchemaNameToTypeName(in))
 	}


### PR DESCRIPTION
Hello,
   I have a spec that utilizes property keynames with:

-  `=`
- `>`
- `>=`

`=` correctly resolves to Equals, but `>` and `>=` both resolve to an empty string.

This PR adds support to resolve `>` and `<`