### PR TITLE
build: check results of matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,17 @@ jobs:
 
       - name: Build
         run: go build ./cmd/oapi-codegen
+
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Check results
+    needs: [build]
+    steps:
+      - run: |
+          result="${{ needs.build.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -29,3 +29,17 @@ jobs:
 
       - name: Check for no untracked files
         run: git status && git diff-index --exit-code -p HEAD --
+
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Check results
+    needs: [build]
+    steps:
+      - run: |
+          result="${{ needs.build.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,3 +26,17 @@ jobs:
         env:
           # A combination of our GitHub Actions setup, with the Go toolchain, leads to inconsistencies in calling `go env`, in particular with Go 1.21, where having (the default) `GOTOOLCHAIN=auto` results in build failures
           GOTOOLCHAIN: local
+
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Check results
+    needs: [build]
+    steps:
+      - run: |
+          result="${{ needs.build.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -29,3 +29,17 @@ jobs:
         env:
           # A combination of our GitHub Actions setup, with the Go toolchain, leads to inconsistencies in calling `go env`, in particular with Go 1.21, where having (the default) `GOTOOLCHAIN=auto` results in build failures
           GOTOOLCHAIN: local
+
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Check results
+    needs: [build]
+    steps:
+      - run: |
+          result="${{ needs.build.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi


### PR DESCRIPTION
This makes sure that we can add these as required status checks, which
we can't easily do with a matrix job due to the differing names for each
version used.

Via [0].

[0]: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
