### PR TITLE
docs(sponsors): clarify Elastic's 4h/mo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4136,7 +4136,19 @@ Please consider sponsoring us through GitHub Sponsors either [on the organisatio
 
 See [this blog post from Tidelift](https://blog.tidelift.com/paying-maintainers-the-howto) for more details on how to talk to your company about sponsoring maintainers of (Open Source) projects you depend on.
 
-We are currently generously sponsored by the following folks, each of whom provide sponsorship for 1 hour of work a month:
+We are currently sponsored for 4 hours of work a month by Elastic:
+
+<p align="center">
+	<a href="https://elastic.co?utm_source=oapi-codegen+repo&utm_medium=github+sponsorship">
+		<picture>
+		  <source media="(prefers-color-scheme: light)" srcset=".github/sponsors/elastic-light.svg">
+		  <source media="(prefers-color-scheme: dark)" srcset=".github/sponsors/elastic-dark.svg">
+		  <img alt="Elastic logo" src=".github/sponsors/elastic-dark.svg" height="100px">
+		</picture>
+	</a>
+</p>
+
+In addition, we are also generously sponsored by the following folks, each of whom provide sponsorship for 1 hour of work a month:
 
 <p align="center">
 	<a href="https://www.devzero.io/lp/dev-environment?utm_campaign=github&utm_source=oapi-codegen%20repo&utm_medium=github%20sponsorship">
@@ -4154,16 +4166,6 @@ We are currently generously sponsored by the following folks, each of whom provi
 		  <source media="(prefers-color-scheme: light)" srcset=".github/sponsors/speakeasy-light.svg">
 		  <source media="(prefers-color-scheme: dark)" srcset=".github/sponsors/speakeasy-dark.svg">
 		  <img alt="Speakeasy logo" src=".github/sponsors/speakeasy-dark.svg" height="100px">
-		</picture>
-	</a>
-</p>
-
-<p align="center">
-	<a href="https://elastic.co?utm_source=oapi-codegen+repo&utm_medium=github+sponsorship">
-		<picture>
-		  <source media="(prefers-color-scheme: light)" srcset=".github/sponsors/elastic-light.svg">
-		  <source media="(prefers-color-scheme: dark)" srcset=".github/sponsors/elastic-dark.svg">
-		  <img alt="Elastic logo" src=".github/sponsors/elastic-dark.svg" height="100px">
 		</picture>
 	</a>
 </p>


### PR DESCRIPTION
This makes it a little bit clearer that Elastic's 4h/mo of in-work
support that I'm able to do is different to the GitHub Sponsor'd support
we receive from others.

This isn't something that other sponsors can do right now, so we should
make it clearer that Elastic's at a higher level.

But we are _super appreciative_ of all of our sponsors!

