### PR TITLE
build: remove patch version pinning on `go` directive

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/oapi-codegen/oapi-codegen/v2/examples
 
-go 1.21.13
+go 1.21.0
 
 replace github.com/oapi-codegen/oapi-codegen/v2 => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oapi-codegen/oapi-codegen/v2
 
-go 1.21.13
+go 1.21.0
 
 require (
 	github.com/getkin/kin-openapi v0.127.0

--- a/internal/test/go.mod
+++ b/internal/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/oapi-codegen/oapi-codegen/v2/internal/test
 
-go 1.21.13
+go 1.21.0
 
 replace github.com/oapi-codegen/oapi-codegen/v2 => ../../
 


### PR DESCRIPTION
Originally added in f77bd7b1b84a7f215eb43d4cecc1ba10927326ef, we wanted
to pin the version to ensure that we were targeting the latest version
of Go 1.21.

However, there's no real value here, and as noted in [0] it can be
causing issues for some users.

There's nothing explicitly in Go 1.21.x that we need to pin to, just
that we need support for Go 1.21, so we can use Speakeasy's
`openapi-overlay` library.

Therefore we can relax the patch-version requirement, which will
alleviate issues for consumers.

[0]: https://github.com/osbuild/image-builder/pull/1352

