### PR TITLE
fix(fiber-middleware): return 400 if required query parameters are missing

### DIFF
--- a/pkg/codegen/templates/fiber/fiber-middleware.tmpl
+++ b/pkg/codegen/templates/fiber/fiber-middleware.tmpl
@@ -73,8 +73,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *fiber.Ctx) error {
         {{end}}
         }{{if .Required}} else {
             err = fmt.Errorf("Query argument {{.ParamName}} is required, but not found")
-            c.Status(fiber.StatusBadRequest).JSON(err)
-            return err
+            return fiber.NewError(fiber.StatusBadRequest, err.Error())
         }{{end}}
       {{end}}
       {{if .IsStyled}}


### PR DESCRIPTION
This should resolve https://github.com/oapi-codegen/oapi-codegen/issues/1100