### PR TITLE
Handle leading underscores in property names

### DIFF
--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -22,16 +22,16 @@ import (
 
 // Defines values for Bar.
 const (
-	BarBar     Bar = "Bar"
-	BarEmpty   Bar = ""
-	BarFoo     Bar = "Foo"
-	BarFoo1    Bar = " Foo"
-	BarFoo2    Bar = " Foo "
-	BarFoo3    Bar = "_Foo_"
-	BarFooBar  Bar = "Foo Bar"
-	BarFooBar1 Bar = "Foo-Bar"
-	BarN1      Bar = "1"
-	BarN1Foo   Bar = "1Foo"
+	BarBar           Bar = "Bar"
+	BarEmpty         Bar = ""
+	BarFoo           Bar = "Foo"
+	BarFoo1          Bar = " Foo"
+	BarFoo2          Bar = " Foo "
+	BarFooBar        Bar = "Foo Bar"
+	BarFooBar1       Bar = "Foo-Bar"
+	BarN1            Bar = "1"
+	BarN1Foo         Bar = "1Foo"
+	BarUnderscoreFoo Bar = "_Foo_"
 )
 
 // Bar defines model for Bar.

--- a/internal/test/issues/issue-illegal_enum_names/issue_test.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue_test.go
@@ -54,6 +54,6 @@ func TestIllegalEnumNames(t *testing.T) {
 	require.Equal(t, `"1Foo"`, constDefs["BarN1Foo"])
 	require.Equal(t, `" Foo"`, constDefs["BarFoo1"])
 	require.Equal(t, `" Foo "`, constDefs["BarFoo2"])
-	require.Equal(t, `"_Foo_"`, constDefs["BarFoo3"])
+	require.Equal(t, `"_Foo_"`, constDefs["BarUnderscoreFoo"])
 	require.Equal(t, `"1"`, constDefs["BarN1"])
 }

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -805,6 +805,8 @@ func typeNamePrefix(name string) (prefix string) {
 			prefix += "Caret"
 		case '%':
 			prefix += "Percent"
+		case '_':
+			prefix += "Underscore"
 		default:
 			// Prepend "N" to schemas starting with a number
 			if prefix == "" && unicode.IsDigit(r) {

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -599,7 +599,7 @@ func TestSchemaNameToTypeName(t *testing.T) {
 		"@timestamp,":  "Timestamp",
 		"&now":         "AndNow",
 		"~":            "Tilde",
-		"_foo":         "Foo",
+		"_foo":         "UnderscoreFoo",
 		"=3":           "Equal3",
 		"#Tag":         "HashTag",
 		".com":         "DotCom",


### PR DESCRIPTION
I'm working with a spec that has something like:

```
      properties:
        _version:
          type: string
        version:
          type: int
```

Now surely there's some better naming they could have used whilst designing the response, but that's not in my control. As it is, oapi-codegen generates a duplicate `Version` field for both of these properties. 

This PR updates the name prefix to add an `Underscore` prefix in this case, de-duplicating the field names. 