### PR TITLE
feat: Allow resolving references after overlay application

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -290,6 +290,9 @@ func main() {
 	if opts.OutputOptions.Overlay.Strict != nil {
 		overlayOpts.Strict = *opts.OutputOptions.Overlay.Strict
 	}
+	if opts.OutputOptions.Overlay.ResolveRefs != nil {
+		overlayOpts.ResolveRefs = *opts.OutputOptions.Overlay.ResolveRefs
+	}
 
 	swagger, err := util.LoadSwaggerWithOverlay(flag.Arg(0), overlayOpts)
 	if err != nil {

--- a/configuration-schema.json
+++ b/configuration-schema.json
@@ -209,6 +209,11 @@
               "type": "boolean",
               "description": "Strict defines whether the Overlay should be applied in a strict way, highlighting any actions that will not take any effect. This can, however, lead to more work when testing new actions in an Overlay, so can be turned off with this setting.",
               "default": true
+            },
+            "resolve-refs": {
+              "type": "boolean",
+              "description": "ResolveRefs enables reference resolving relative to the base path of the input file after the overlay is applied.",
+              "default": "false"
             }
           },
           "required": [

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -251,4 +251,8 @@ type OutputOptionsOverlay struct {
 	// Strict defines whether the Overlay should be applied in a strict way, highlighting any actions that will not take any effect. This can, however, lead to more work when testing new actions in an Overlay, so can be turned off with this setting.
 	// Defaults to true.
 	Strict *bool `yaml:"strict,omitempty"`
+
+	// ResolveRefs enables reference resolving relative to the base path of the input file after the overlay is applied.
+	// Defaults to false.
+	ResolveRefs *bool `yaml:"resolve-refs,omitempty"`
 }


### PR DESCRIPTION
When working with overlays, oapi-codegen doesn't support external references, even though they are supported for the same file without overlays.

This PR adds a new setting `resolve-refs` to the OverlayOutput configuration. If enabled, the external references are resolved as for a normal file (against the filepath of the spec).