### PR TITLE
build(labels): add autolabeller for "no `main` branch please"

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,0 +1,11 @@
+'auto:no-head-branch':
+  comment: >
+    Thanks for the contribution!
+
+    It looks like this PR was raised from the `main` branch.
+
+    As per [our contributing guidelines](https://github.com/oapi-codegen/oapi-codegen/blob/main/CONTRIBUTING.md#before-you-raise-a-pr), this can make it difficult for us to push changes to your fork - for instance to directly push a change to address a comment that we would raise, or to finalise changes before merge.
+
+    Please re-raise the PR from a branch on your repository that isn't `main` / any protected branches.
+
+    Thank you in advance 🙇🏼

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -1,0 +1,23 @@
+name: 'Label Actions'
+
+on:
+  issues:
+    types: [labeled]
+  discussion:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+  discussions: write
+  pull-requests: write
+
+jobs:
+  reaction:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@102faf474a544be75fbaf4df54e73d3c515a0e65 # v4.0.1
+        with:
+          github-token: ${{ github.token }}


### PR DESCRIPTION
This follows setup from Renovate, as a project with a good setup we can
follow.

We'll add this for Issues, Discussions and PRs for now, even though this
only directly applies to PRs.
