### PR TITLE
build: ensure separately named "Check results" steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Check results
+    name: Check build results
     needs: [build]
     steps:
       - run: |

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -33,7 +33,7 @@ jobs:
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Check results
+    name: Check generation results
     needs: [build]
     steps:
       - run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Check results
+    name: Check linting results
     needs: [build]
     steps:
       - run: |

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -33,7 +33,7 @@ jobs:
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Check results
+    name: Check tidy results
     needs: [build]
     steps:
       - run: |


### PR DESCRIPTION
This makes sure these are now 4 separate checks, which can be
independently added, which ensures that all stages run successfully
before an auto-merge applies.

Previously, we've had cases where a PR can be automerged before all
checks execute, as GitHub sees that one of the `Check results` steps has
passed, and expects all of them have.
