### PR TITLE
refactor: replace fmt.Errorf by errors.New when possible

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -439,7 +440,7 @@ func updateConfigFromFlags(cfg *configuration) error {
 		cfg.OutputOptions.ResponseTypeSuffix = flagResponseTypeSuffix
 	}
 	if flagAliasTypes {
-		return fmt.Errorf("--alias-types isn't supported any more")
+		return errors.New("--alias-types isn't supported any more")
 	}
 
 	if cfg.OutputFile == "" {

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -143,7 +144,7 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 	}
 
 	if nameNormalizerFunction != NameNormalizerFunctionToCamelCaseWithInitialisms && len(opts.OutputOptions.AdditionalInitialisms) > 0 {
-		return "", fmt.Errorf("you have specified `additional-initialisms`, but the `name-normalizer` is not set to `ToCamelCaseWithInitialisms`. Please specify `name-normalizer: ToCamelCaseWithInitialisms` or remove the `additional-initialisms` configuration")
+		return "", errors.New("you have specified `additional-initialisms`, but the `name-normalizer` is not set to `ToCamelCaseWithInitialisms`. Please specify `name-normalizer: ToCamelCaseWithInitialisms` or remove the `additional-initialisms` configuration")
 	}
 
 	globalState.initialismsMap = makeInitialismsMap(opts.OutputOptions.AdditionalInitialisms)

--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -105,7 +105,7 @@ func mergeOpenapiSchemas(s1, s2 openapi3.Schema, allOf bool) (openapi3.Schema, e
 		var merged openapi3.Schema
 		merged, err = mergeAllOf(s1.AllOf)
 		if err != nil {
-			return openapi3.Schema{}, fmt.Errorf("error transitive merging AllOf on schema 1")
+			return openapi3.Schema{}, errors.New("error transitive merging AllOf on schema 1")
 		}
 		s1 = merged
 	}
@@ -113,7 +113,7 @@ func mergeOpenapiSchemas(s1, s2 openapi3.Schema, allOf bool) (openapi3.Schema, e
 		var merged openapi3.Schema
 		merged, err = mergeAllOf(s2.AllOf)
 		if err != nil {
-			return openapi3.Schema{}, fmt.Errorf("error transitive merging AllOf on schema 2")
+			return openapi3.Schema{}, errors.New("error transitive merging AllOf on schema 2")
 		}
 		s2 = merged
 	}

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -16,6 +16,7 @@ package codegen
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -660,11 +661,11 @@ func generateDefaultOperationID(opName string, requestPath string, toCamelCaseFu
 	var operationId = strings.ToLower(opName)
 
 	if opName == "" {
-		return "", fmt.Errorf("operation name cannot be an empty string")
+		return "", errors.New("operation name cannot be an empty string")
 	}
 
 	if requestPath == "" {
-		return "", fmt.Errorf("request path cannot be an empty string")
+		return "", errors.New("request path cannot be an empty string")
 	}
 
 	for _, part := range strings.Split(requestPath, "/") {


### PR DESCRIPTION
Replace `fmt.Errorf` by (more efficient) `errors.New` when formatting options are not exploited.

(found with [revive](https://github.com/mgechev/revive))