### PR TITLE
add '@' to the prefix handling for Go-Types

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -812,6 +812,8 @@ func typeNamePrefix(name string) (prefix string) {
 			prefix += "Percent"
 		case '_':
 			prefix += "Underscore"
+		case '@':
+			prefix += "At"
 		default:
 			// Prepend "N" to schemas starting with a number
 			if prefix == "" && unicode.IsDigit(r) {

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -596,7 +596,7 @@ func TestSchemaNameToTypeName(t *testing.T) {
 		"123":          "N123",
 		"-1":           "Minus1",
 		"+1":           "Plus1",
-		"@timestamp,":  "Timestamp",
+		"@timestamp,":  "AtTimestamp",
 		"&now":         "AndNow",
 		"~":            "Tilde",
 		"_foo":         "UnderscoreFoo",


### PR DESCRIPTION
With the following OpenAPI-Spec:

```yaml
openapi: 3.0.0
info:
  title: Basic API
  version: 1.0.0
paths:
  /foo:
    get:
      summary: Example showing oapi-codegen issue with @Type
      responses:
        '200':
          description: leads to "type redeclared" error due to two "Type" fields
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Foo'
components:
  schemas:
    Foo:
      type: object
      properties:
        Type:
          type: string
        "@Type":
          type: string
```

oapi-codegen produces a go file 

```go
// Package foo provides primitives to interact with the openapi HTTP API.
//
// Code generated by github.com/oapi-codegen/oapi-codegen/v2 version v2.3.0 DO NOT EDIT.
package foo

// Foo defines model for Foo.
type Foo struct {
	Type *string `json:"@Type,omitempty"`
	Type *string `json:"Type,omitempty"`
}
```

With this PR, '@' is added to the prefix list (with the prefix "At")