### PR TITLE
build: build against Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         - "1.21"
         - "1.22"
         - "1.23"
+        - "1.24"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -12,6 +12,7 @@ jobs:
         - "1.21"
         - "1.22"
         - "1.23"
+        - "1.24"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,7 @@ jobs:
         - "1.21"
         - "1.22"
         - "1.23"
+        - "1.24"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -12,6 +12,7 @@ jobs:
         - "1.21"
         - "1.22"
         - "1.23"
+        - "1.24"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4


### PR DESCRIPTION
Now it's out, we should make sure folks using the project on the newest
version are still supported.

