### PR TITLE
feat: opai-codegen#1912 add optional default format for numbers

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -248,6 +248,9 @@ type OutputOptions struct {
 
 	// ClientResponseBytesFunction decides whether to enable the generation of a `Bytes()` method on response objects for `ClientWithResponses`
 	ClientResponseBytesFunction bool `yaml:"client-response-bytes-function,omitempty"`
+
+	// DefaultNumberFormat is the default format to use for numbers when no format is specified in the OpenAPI schema. If not specified or empty, the default format is `float`.
+	DefaultNumberFormat string `yaml:"default-number-format,omitempty"`
 }
 
 func (oo OutputOptions) Validate() map[string]string {

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -608,10 +608,17 @@ func oapiSchemaToGoType(schema *openapi3.Schema, path []string, outSchema *Schem
 		}
 		outSchema.DefineViaAlias = true
 	} else if t.Is("number") {
-		// We default to float for "number"
+		// We default to float for "number", unless overridden by config
+		if f == "" {
+			if globalState.options.OutputOptions.DefaultNumberFormat != "" {
+				f = globalState.options.OutputOptions.DefaultNumberFormat
+			} else {
+				f = "float"
+			}
+		}
 		if f == "double" {
 			outSchema.GoType = "float64"
-		} else if f == "float" || f == "" {
+		} else if f == "float" {
 			outSchema.GoType = "float32"
 		} else {
 			return fmt.Errorf("invalid number format: %s", f)


### PR DESCRIPTION
adds `default-number-format` to output options to allow configuring the default format used for `type: number` (without this, it defaults to 32-bit `float`)