### PR TITLE
Refactor: Pass request context instead of gin.Context in handler template

### DIFF
--- a/pkg/codegen/templates/strict/strict-gin.tmpl
+++ b/pkg/codegen/templates/strict/strict-gin.tmpl
@@ -84,7 +84,7 @@ type strictHandler struct {
         {{end}}{{/* range .Bodies */}}
 
         handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-            return sh.ssi.{{.OperationId}}(ctx, request.({{$opid | ucFirst}}RequestObject))
+            return sh.ssi.{{.OperationId}}(ctx.Request.Context(), request.({{$opid | ucFirst}}RequestObject))
         }
         for _, middleware := range sh.middlewares {
             handler = middleware(handler, "{{.OperationId}}")


### PR DESCRIPTION
### Refactor: Pass request context instead of gin.Context in handler template

#### Description:
This PR modifies the handler function template to use `ctx.Request.Context()` instead of passing `ctx` directly. This change improves compatibility with middleware that modifies the request context, ensuring better integration with Go's standard `context.Context` handling.

#### Why this change?
- Using `gin.Context` directly makes it harder to propagate context values through middleware.
- Switching to `ctx.Request.Context()` aligns with best practices for handling request-scoped data.
- This change avoids potential issues when working with custom middleware that relies on `context.WithValue`.

#### Impact:
✅ **No breaking changes**: The function signature remains the same.  
✅ **Better compatibility** with existing Go context patterns.  

#### Checklist:
- [x] Ran `make tidy`, `make test`, `make generate`, and `make lint`
- [x] Verified that existing test cases pass
- [x] Ensured minimal impact on generated code  

---

**Maintainer Notes:**  
This change is unlikely to cause backward compatibility issues since it only affects the way context is passed within the handler function. Let me know if any additional tests or adjustments are required. 🚀