### PR TITLE
#1907 set operationId in request context within client.tmpl

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -57,6 +57,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -130,6 +141,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) ListThings(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ListThings")
 	req, err := NewListThingsRequest(c.Server)
 	if err != nil {
 		return nil, err
@@ -142,6 +154,7 @@ func (c *Client) ListThings(ctx context.Context, reqEditors ...RequestEditorFn) 
 }
 
 func (c *Client) AddThingWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "AddThingWithBody")
 	req, err := NewAddThingRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -154,6 +167,7 @@ func (c *Client) AddThingWithBody(ctx context.Context, contentType string, body 
 }
 
 func (c *Client) AddThing(ctx context.Context, body AddThingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "AddThing")
 	req, err := NewAddThingRequest(c.Server, body)
 	if err != nil {
 		return nil, err

--- a/examples/authenticated-api/stdhttp/api/api.gen.go
+++ b/examples/authenticated-api/stdhttp/api/api.gen.go
@@ -58,6 +58,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -131,6 +142,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) ListThings(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ListThings")
 	req, err := NewListThingsRequest(c.Server)
 	if err != nil {
 		return nil, err
@@ -143,6 +155,7 @@ func (c *Client) ListThings(ctx context.Context, reqEditors ...RequestEditorFn) 
 }
 
 func (c *Client) AddThingWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "AddThingWithBody")
 	req, err := NewAddThingRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -155,6 +168,7 @@ func (c *Client) AddThingWithBody(ctx context.Context, contentType string, body 
 }
 
 func (c *Client) AddThing(ctx context.Context, body AddThingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "AddThing")
 	req, err := NewAddThingRequest(c.Server, body)
 	if err != nil {
 		return nil, err

--- a/examples/client/client.gen.go
+++ b/examples/client/client.gen.go
@@ -28,6 +28,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -99,6 +110,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetClient(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetClient")
 	req, err := NewGetClientRequest(c.Server)
 	if err != nil {
 		return nil, err
@@ -111,6 +123,7 @@ func (c *Client) GetClient(ctx context.Context, reqEditors ...RequestEditorFn) (
 }
 
 func (c *Client) UpdateClient(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "UpdateClient")
 	req, err := NewUpdateClientRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/examples/custom-client-type/custom-client-type.gen.go
+++ b/examples/custom-client-type/custom-client-type.gen.go
@@ -28,6 +28,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // CustomClientType which conforms to the OpenAPI3 specification for this service.
 type CustomClientType struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -96,6 +107,7 @@ type ClientInterface interface {
 }
 
 func (c *CustomClientType) GetClient(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetClient")
 	req, err := NewGetClientRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -68,6 +68,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -147,6 +158,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) FindPets(ctx context.Context, params *FindPetsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "FindPets")
 	req, err := NewFindPetsRequest(c.Server, params)
 	if err != nil {
 		return nil, err
@@ -159,6 +171,7 @@ func (c *Client) FindPets(ctx context.Context, params *FindPetsParams, reqEditor
 }
 
 func (c *Client) AddPetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "AddPetWithBody")
 	req, err := NewAddPetRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -171,6 +184,7 @@ func (c *Client) AddPetWithBody(ctx context.Context, contentType string, body io
 }
 
 func (c *Client) AddPet(ctx context.Context, body AddPetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "AddPet")
 	req, err := NewAddPetRequest(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -183,6 +197,7 @@ func (c *Client) AddPet(ctx context.Context, body AddPetJSONRequestBody, reqEdit
 }
 
 func (c *Client) DeletePet(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "DeletePet")
 	req, err := NewDeletePetRequest(c.Server, id)
 	if err != nil {
 		return nil, err
@@ -195,6 +210,7 @@ func (c *Client) DeletePet(ctx context.Context, id int64, reqEditors ...RequestE
 }
 
 func (c *Client) FindPetByID(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "FindPetByID")
 	req, err := NewFindPetByIDRequest(c.Server, id)
 	if err != nil {
 		return nil, err

--- a/internal/test/any_of/codegen/inline/openapi.gen.go
+++ b/internal/test/any_of/codegen/inline/openapi.gen.go
@@ -55,6 +55,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -123,6 +134,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetPets(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetPets")
 	req, err := NewGetPetsRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/any_of/codegen/ref_schema/openapi.gen.go
+++ b/internal/test/any_of/codegen/ref_schema/openapi.gen.go
@@ -154,6 +154,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -222,6 +233,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetPets(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetPets")
 	req, err := NewGetPetsRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/any_of/param/param.gen.go
+++ b/internal/test/any_of/param/param.gen.go
@@ -183,6 +183,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -251,6 +262,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetTest(ctx context.Context, params *GetTestParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetTest")
 	req, err := NewGetTestRequest(c.Server, params)
 	if err != nil {
 		return nil, err

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -46,6 +46,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -141,6 +152,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) PostBothWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "PostBothWithBody")
 	req, err := NewPostBothRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -153,6 +165,7 @@ func (c *Client) PostBothWithBody(ctx context.Context, contentType string, body 
 }
 
 func (c *Client) PostBoth(ctx context.Context, body PostBothJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "PostBoth")
 	req, err := NewPostBothRequest(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -165,6 +178,7 @@ func (c *Client) PostBoth(ctx context.Context, body PostBothJSONRequestBody, req
 }
 
 func (c *Client) GetBoth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetBoth")
 	req, err := NewGetBothRequest(c.Server)
 	if err != nil {
 		return nil, err
@@ -177,6 +191,7 @@ func (c *Client) GetBoth(ctx context.Context, reqEditors ...RequestEditorFn) (*h
 }
 
 func (c *Client) PostJsonWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "PostJsonWithBody")
 	req, err := NewPostJsonRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -189,6 +204,7 @@ func (c *Client) PostJsonWithBody(ctx context.Context, contentType string, body 
 }
 
 func (c *Client) PostJson(ctx context.Context, body PostJsonJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "PostJson")
 	req, err := NewPostJsonRequest(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -201,6 +217,7 @@ func (c *Client) PostJson(ctx context.Context, body PostJsonJSONRequestBody, req
 }
 
 func (c *Client) GetJson(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetJson")
 	req, err := NewGetJsonRequest(c.Server)
 	if err != nil {
 		return nil, err
@@ -213,6 +230,7 @@ func (c *Client) GetJson(ctx context.Context, reqEditors ...RequestEditorFn) (*h
 }
 
 func (c *Client) PostOtherWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "PostOtherWithBody")
 	req, err := NewPostOtherRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -225,6 +243,7 @@ func (c *Client) PostOtherWithBody(ctx context.Context, contentType string, body
 }
 
 func (c *Client) GetOther(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetOther")
 	req, err := NewGetOtherRequest(c.Server)
 	if err != nil {
 		return nil, err
@@ -237,6 +256,7 @@ func (c *Client) GetOther(ctx context.Context, reqEditors ...RequestEditorFn) (*
 }
 
 func (c *Client) GetJsonWithTrailingSlash(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetJsonWithTrailingSlash")
 	req, err := NewGetJsonWithTrailingSlashRequest(c.Server)
 	if err != nil {
 		return nil, err
@@ -249,6 +269,7 @@ func (c *Client) GetJsonWithTrailingSlash(ctx context.Context, reqEditors ...Req
 }
 
 func (c *Client) PostVendorJsonWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "PostVendorJsonWithBody")
 	req, err := NewPostVendorJsonRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -261,6 +282,7 @@ func (c *Client) PostVendorJsonWithBody(ctx context.Context, contentType string,
 }
 
 func (c *Client) PostVendorJsonWithApplicationVndAPIPlusJSONBody(ctx context.Context, body PostVendorJsonApplicationVndAPIPlusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "PostVendorJsonWithApplicationVndAPIPlusJSONBody")
 	req, err := NewPostVendorJsonRequestWithApplicationVndAPIPlusJSONBody(c.Server, body)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-1039/client.gen.go
+++ b/internal/test/issues/issue-1039/client.gen.go
@@ -24,6 +24,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -94,6 +105,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) ExamplePatchWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ExamplePatchWithBody")
 	req, err := NewExamplePatchRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -106,6 +118,7 @@ func (c *Client) ExamplePatchWithBody(ctx context.Context, contentType string, b
 }
 
 func (c *Client) ExamplePatch(ctx context.Context, body ExamplePatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ExamplePatch")
 	req, err := NewExamplePatchRequest(c.Server, body)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-1087/api.gen.go
+++ b/internal/test/issues/issue-1087/api.gen.go
@@ -43,6 +43,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -111,6 +122,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetThings(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetThings")
 	req, err := NewGetThingsRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-1180/issue.gen.go
+++ b/internal/test/issues/issue-1180/issue.gen.go
@@ -30,6 +30,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -98,6 +109,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetSimplePrimitive(ctx context.Context, param string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetSimplePrimitive")
 	req, err := NewGetSimplePrimitiveRequest(c.Server, param)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-1182/pkg1/pkg1.gen.go
+++ b/internal/test/issues/issue-1182/pkg1/pkg1.gen.go
@@ -31,6 +31,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -99,6 +110,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) TestGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "TestGet")
 	req, err := NewTestGetRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-1182/pkg2/pkg2.gen.go
+++ b/internal/test/issues/issue-1182/pkg2/pkg2.gen.go
@@ -29,6 +29,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,

--- a/internal/test/issues/issue-1189/issue1189.gen.go
+++ b/internal/test/issues/issue-1189/issue1189.gen.go
@@ -205,6 +205,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -273,6 +284,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) Test(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Test")
 	req, err := NewTestRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-1208-1209/issue-multi-json.gen.go
+++ b/internal/test/issues/issue-1208-1209/issue-multi-json.gen.go
@@ -47,6 +47,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -115,6 +126,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) Test(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Test")
 	req, err := NewTestRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-1212/pkg1/pkg1.gen.go
+++ b/internal/test/issues/issue-1212/pkg1/pkg1.gen.go
@@ -33,6 +33,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -101,6 +112,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) Test(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Test")
 	req, err := NewTestRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-1212/pkg2/pkg2.gen.go
+++ b/internal/test/issues/issue-1212/pkg2/pkg2.gen.go
@@ -40,6 +40,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,

--- a/internal/test/issues/issue-1298/issue1298.gen.go
+++ b/internal/test/issues/issue-1298/issue1298.gen.go
@@ -36,6 +36,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -106,6 +117,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) TestWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "TestWithBody")
 	req, err := NewTestRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -118,6 +130,7 @@ func (c *Client) TestWithBody(ctx context.Context, contentType string, body io.R
 }
 
 func (c *Client) TestWithApplicationTestPlusJSONBody(ctx context.Context, body TestApplicationTestPlusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "TestWithApplicationTestPlusJSONBody")
 	req, err := NewTestRequestWithApplicationTestPlusJSONBody(c.Server, body)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-1397/issue1397.gen.go
+++ b/internal/test/issues/issue-1397/issue1397.gen.go
@@ -66,6 +66,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -136,6 +147,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) TestWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "TestWithBody")
 	req, err := NewTestRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -148,6 +160,7 @@ func (c *Client) TestWithBody(ctx context.Context, contentType string, body io.R
 }
 
 func (c *Client) TestWithApplicationTestPlusJSONBody(ctx context.Context, body TestApplicationTestPlusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "TestWithApplicationTestPlusJSONBody")
 	req, err := NewTestRequestWithApplicationTestPlusJSONBody(c.Server, body)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -55,6 +55,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -128,6 +139,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetPet(ctx context.Context, petId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetPet")
 	req, err := NewGetPetRequest(c.Server, petId)
 	if err != nil {
 		return nil, err
@@ -140,6 +152,7 @@ func (c *Client) GetPet(ctx context.Context, petId string, reqEditors ...Request
 }
 
 func (c *Client) ValidatePetsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ValidatePetsWithBody")
 	req, err := NewValidatePetsRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -152,6 +165,7 @@ func (c *Client) ValidatePetsWithBody(ctx context.Context, contentType string, b
 }
 
 func (c *Client) ValidatePets(ctx context.Context, body ValidatePetsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ValidatePets")
 	req, err := NewValidatePetsRequest(c.Server, body)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -44,6 +44,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -112,6 +123,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) ExampleGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ExampleGet")
 	req, err := NewExampleGetRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -40,6 +40,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -108,6 +119,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetFoo(ctx context.Context, params *GetFooParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetFoo")
 	req, err := NewGetFooRequest(c.Server, params)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -47,6 +47,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -115,6 +126,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetFoo(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetFoo")
 	req, err := NewGetFooRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/issues/issue240/client.gen.go
+++ b/internal/test/issues/issue240/client.gen.go
@@ -28,6 +28,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -99,6 +110,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetClient(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetClient")
 	req, err := NewGetClientRequest(c.Server)
 	if err != nil {
 		return nil, err
@@ -111,6 +123,7 @@ func (c *Client) GetClient(ctx context.Context, reqEditors ...RequestEditorFn) (
 }
 
 func (c *Client) UpdateClient(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "UpdateClient")
 	req, err := NewUpdateClientRequest(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/outputoptions/name-normalizer/to-camel-case-with-additional-initialisms/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/to-camel-case-with-additional-initialisms/name_normalizer.gen.go
@@ -127,6 +127,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -195,6 +206,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetHTTPPet(ctx context.Context, petID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetHTTPPet")
 	req, err := NewGetHTTPPetRequest(c.Server, petID)
 	if err != nil {
 		return nil, err

--- a/internal/test/outputoptions/name-normalizer/to-camel-case-with-digits/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/to-camel-case-with-digits/name_normalizer.gen.go
@@ -127,6 +127,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -195,6 +206,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetHttpPet(ctx context.Context, petId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetHttpPet")
 	req, err := NewGetHttpPetRequest(c.Server, petId)
 	if err != nil {
 		return nil, err

--- a/internal/test/outputoptions/name-normalizer/to-camel-case-with-initialisms/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/to-camel-case-with-initialisms/name_normalizer.gen.go
@@ -127,6 +127,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -195,6 +206,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetHTTPPet(ctx context.Context, petID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetHTTPPet")
 	req, err := NewGetHTTPPetRequest(c.Server, petID)
 	if err != nil {
 		return nil, err

--- a/internal/test/outputoptions/name-normalizer/to-camel-case/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/to-camel-case/name_normalizer.gen.go
@@ -127,6 +127,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -195,6 +206,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetHttpPet(ctx context.Context, petId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetHttpPet")
 	req, err := NewGetHttpPetRequest(c.Server, petId)
 	if err != nil {
 		return nil, err

--- a/internal/test/outputoptions/name-normalizer/unset/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/unset/name_normalizer.gen.go
@@ -127,6 +127,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -195,6 +206,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetHttpPet(ctx context.Context, petId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetHttpPet")
 	req, err := NewGetHttpPetRequest(c.Server, petId)
 	if err != nil {
 		return nil, err

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -149,6 +149,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -277,6 +288,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) GetContentObject(ctx context.Context, param ComplexObject, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetContentObject")
 	req, err := NewGetContentObjectRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -289,6 +301,7 @@ func (c *Client) GetContentObject(ctx context.Context, param ComplexObject, reqE
 }
 
 func (c *Client) GetCookie(ctx context.Context, params *GetCookieParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetCookie")
 	req, err := NewGetCookieRequest(c.Server, params)
 	if err != nil {
 		return nil, err
@@ -301,6 +314,7 @@ func (c *Client) GetCookie(ctx context.Context, params *GetCookieParams, reqEdit
 }
 
 func (c *Client) EnumParams(ctx context.Context, params *EnumParamsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "EnumParams")
 	req, err := NewEnumParamsRequest(c.Server, params)
 	if err != nil {
 		return nil, err
@@ -313,6 +327,7 @@ func (c *Client) EnumParams(ctx context.Context, params *EnumParamsParams, reqEd
 }
 
 func (c *Client) GetHeader(ctx context.Context, params *GetHeaderParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetHeader")
 	req, err := NewGetHeaderRequest(c.Server, params)
 	if err != nil {
 		return nil, err
@@ -325,6 +340,7 @@ func (c *Client) GetHeader(ctx context.Context, params *GetHeaderParams, reqEdit
 }
 
 func (c *Client) GetLabelExplodeArray(ctx context.Context, param []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetLabelExplodeArray")
 	req, err := NewGetLabelExplodeArrayRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -337,6 +353,7 @@ func (c *Client) GetLabelExplodeArray(ctx context.Context, param []int32, reqEdi
 }
 
 func (c *Client) GetLabelExplodeObject(ctx context.Context, param Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetLabelExplodeObject")
 	req, err := NewGetLabelExplodeObjectRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -349,6 +366,7 @@ func (c *Client) GetLabelExplodeObject(ctx context.Context, param Object, reqEdi
 }
 
 func (c *Client) GetLabelNoExplodeArray(ctx context.Context, param []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetLabelNoExplodeArray")
 	req, err := NewGetLabelNoExplodeArrayRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -361,6 +379,7 @@ func (c *Client) GetLabelNoExplodeArray(ctx context.Context, param []int32, reqE
 }
 
 func (c *Client) GetLabelNoExplodeObject(ctx context.Context, param Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetLabelNoExplodeObject")
 	req, err := NewGetLabelNoExplodeObjectRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -373,6 +392,7 @@ func (c *Client) GetLabelNoExplodeObject(ctx context.Context, param Object, reqE
 }
 
 func (c *Client) GetMatrixExplodeArray(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetMatrixExplodeArray")
 	req, err := NewGetMatrixExplodeArrayRequest(c.Server, id)
 	if err != nil {
 		return nil, err
@@ -385,6 +405,7 @@ func (c *Client) GetMatrixExplodeArray(ctx context.Context, id []int32, reqEdito
 }
 
 func (c *Client) GetMatrixExplodeObject(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetMatrixExplodeObject")
 	req, err := NewGetMatrixExplodeObjectRequest(c.Server, id)
 	if err != nil {
 		return nil, err
@@ -397,6 +418,7 @@ func (c *Client) GetMatrixExplodeObject(ctx context.Context, id Object, reqEdito
 }
 
 func (c *Client) GetMatrixNoExplodeArray(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetMatrixNoExplodeArray")
 	req, err := NewGetMatrixNoExplodeArrayRequest(c.Server, id)
 	if err != nil {
 		return nil, err
@@ -409,6 +431,7 @@ func (c *Client) GetMatrixNoExplodeArray(ctx context.Context, id []int32, reqEdi
 }
 
 func (c *Client) GetMatrixNoExplodeObject(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetMatrixNoExplodeObject")
 	req, err := NewGetMatrixNoExplodeObjectRequest(c.Server, id)
 	if err != nil {
 		return nil, err
@@ -421,6 +444,7 @@ func (c *Client) GetMatrixNoExplodeObject(ctx context.Context, id Object, reqEdi
 }
 
 func (c *Client) GetPassThrough(ctx context.Context, param string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetPassThrough")
 	req, err := NewGetPassThroughRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -433,6 +457,7 @@ func (c *Client) GetPassThrough(ctx context.Context, param string, reqEditors ..
 }
 
 func (c *Client) GetDeepObject(ctx context.Context, params *GetDeepObjectParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetDeepObject")
 	req, err := NewGetDeepObjectRequest(c.Server, params)
 	if err != nil {
 		return nil, err
@@ -445,6 +470,7 @@ func (c *Client) GetDeepObject(ctx context.Context, params *GetDeepObjectParams,
 }
 
 func (c *Client) GetQueryForm(ctx context.Context, params *GetQueryFormParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetQueryForm")
 	req, err := NewGetQueryFormRequest(c.Server, params)
 	if err != nil {
 		return nil, err
@@ -457,6 +483,7 @@ func (c *Client) GetQueryForm(ctx context.Context, params *GetQueryFormParams, r
 }
 
 func (c *Client) GetSimpleExplodeArray(ctx context.Context, param []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetSimpleExplodeArray")
 	req, err := NewGetSimpleExplodeArrayRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -469,6 +496,7 @@ func (c *Client) GetSimpleExplodeArray(ctx context.Context, param []int32, reqEd
 }
 
 func (c *Client) GetSimpleExplodeObject(ctx context.Context, param Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetSimpleExplodeObject")
 	req, err := NewGetSimpleExplodeObjectRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -481,6 +509,7 @@ func (c *Client) GetSimpleExplodeObject(ctx context.Context, param Object, reqEd
 }
 
 func (c *Client) GetSimpleNoExplodeArray(ctx context.Context, param []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetSimpleNoExplodeArray")
 	req, err := NewGetSimpleNoExplodeArrayRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -493,6 +522,7 @@ func (c *Client) GetSimpleNoExplodeArray(ctx context.Context, param []int32, req
 }
 
 func (c *Client) GetSimpleNoExplodeObject(ctx context.Context, param Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetSimpleNoExplodeObject")
 	req, err := NewGetSimpleNoExplodeObjectRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -505,6 +535,7 @@ func (c *Client) GetSimpleNoExplodeObject(ctx context.Context, param Object, req
 }
 
 func (c *Client) GetSimplePrimitive(ctx context.Context, param int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetSimplePrimitive")
 	req, err := NewGetSimplePrimitiveRequest(c.Server, param)
 	if err != nil {
 		return nil, err
@@ -517,6 +548,7 @@ func (c *Client) GetSimplePrimitive(ctx context.Context, param int32, reqEditors
 }
 
 func (c *Client) GetStartingWithNumber(ctx context.Context, n1param string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetStartingWithNumber")
 	req, err := NewGetStartingWithNumberRequest(c.Server, n1param)
 	if err != nil {
 		return nil, err

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -123,6 +123,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -222,6 +233,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) EnsureEverythingIsReferenced(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "EnsureEverythingIsReferenced")
 	req, err := NewEnsureEverythingIsReferencedRequest(c.Server)
 	if err != nil {
 		return nil, err
@@ -234,6 +246,7 @@ func (c *Client) EnsureEverythingIsReferenced(ctx context.Context, reqEditors ..
 }
 
 func (c *Client) Issue1051(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue1051")
 	req, err := NewIssue1051Request(c.Server)
 	if err != nil {
 		return nil, err
@@ -246,6 +259,7 @@ func (c *Client) Issue1051(ctx context.Context, reqEditors ...RequestEditorFn) (
 }
 
 func (c *Client) Issue127(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue127")
 	req, err := NewIssue127Request(c.Server)
 	if err != nil {
 		return nil, err
@@ -258,6 +272,7 @@ func (c *Client) Issue127(ctx context.Context, reqEditors ...RequestEditorFn) (*
 }
 
 func (c *Client) Issue185WithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue185WithBody")
 	req, err := NewIssue185RequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -270,6 +285,7 @@ func (c *Client) Issue185WithBody(ctx context.Context, contentType string, body 
 }
 
 func (c *Client) Issue185(ctx context.Context, body Issue185JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue185")
 	req, err := NewIssue185Request(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -282,6 +298,7 @@ func (c *Client) Issue185(ctx context.Context, body Issue185JSONRequestBody, req
 }
 
 func (c *Client) Issue209(ctx context.Context, str StringInPath, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue209")
 	req, err := NewIssue209Request(c.Server, str)
 	if err != nil {
 		return nil, err
@@ -294,6 +311,7 @@ func (c *Client) Issue209(ctx context.Context, str StringInPath, reqEditors ...R
 }
 
 func (c *Client) Issue30(ctx context.Context, pFallthrough string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue30")
 	req, err := NewIssue30Request(c.Server, pFallthrough)
 	if err != nil {
 		return nil, err
@@ -306,6 +324,7 @@ func (c *Client) Issue30(ctx context.Context, pFallthrough string, reqEditors ..
 }
 
 func (c *Client) GetIssues375(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "GetIssues375")
 	req, err := NewGetIssues375Request(c.Server)
 	if err != nil {
 		return nil, err
@@ -318,6 +337,7 @@ func (c *Client) GetIssues375(ctx context.Context, reqEditors ...RequestEditorFn
 }
 
 func (c *Client) Issue41(ctx context.Context, n1param N5StartsWithNumber, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue41")
 	req, err := NewIssue41Request(c.Server, n1param)
 	if err != nil {
 		return nil, err
@@ -330,6 +350,7 @@ func (c *Client) Issue41(ctx context.Context, n1param N5StartsWithNumber, reqEdi
 }
 
 func (c *Client) Issue9WithBody(ctx context.Context, params *Issue9Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue9WithBody")
 	req, err := NewIssue9RequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
@@ -342,6 +363,7 @@ func (c *Client) Issue9WithBody(ctx context.Context, params *Issue9Params, conte
 }
 
 func (c *Client) Issue9(ctx context.Context, params *Issue9Params, body Issue9JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue9")
 	req, err := NewIssue9Request(c.Server, params, body)
 	if err != nil {
 		return nil, err
@@ -354,6 +376,7 @@ func (c *Client) Issue9(ctx context.Context, params *Issue9Params, body Issue9JS
 }
 
 func (c *Client) Issue975(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "Issue975")
 	req, err := NewIssue975Request(c.Server)
 	if err != nil {
 		return nil, err

--- a/internal/test/strict-server/client/client.gen.go
+++ b/internal/test/strict-server/client/client.gen.go
@@ -82,6 +82,17 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+	if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+		return opid
+	}
+	return ""
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -201,6 +212,7 @@ type ClientInterface interface {
 }
 
 func (c *Client) JSONExampleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "JSONExampleWithBody")
 	req, err := NewJSONExampleRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -213,6 +225,7 @@ func (c *Client) JSONExampleWithBody(ctx context.Context, contentType string, bo
 }
 
 func (c *Client) JSONExample(ctx context.Context, body JSONExampleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "JSONExample")
 	req, err := NewJSONExampleRequest(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -225,6 +238,7 @@ func (c *Client) JSONExample(ctx context.Context, body JSONExampleJSONRequestBod
 }
 
 func (c *Client) MultipartExampleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "MultipartExampleWithBody")
 	req, err := NewMultipartExampleRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -237,6 +251,7 @@ func (c *Client) MultipartExampleWithBody(ctx context.Context, contentType strin
 }
 
 func (c *Client) MultipartRelatedExampleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "MultipartRelatedExampleWithBody")
 	req, err := NewMultipartRelatedExampleRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -249,6 +264,7 @@ func (c *Client) MultipartRelatedExampleWithBody(ctx context.Context, contentTyp
 }
 
 func (c *Client) MultipleRequestAndResponseTypesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "MultipleRequestAndResponseTypesWithBody")
 	req, err := NewMultipleRequestAndResponseTypesRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -261,6 +277,7 @@ func (c *Client) MultipleRequestAndResponseTypesWithBody(ctx context.Context, co
 }
 
 func (c *Client) MultipleRequestAndResponseTypes(ctx context.Context, body MultipleRequestAndResponseTypesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "MultipleRequestAndResponseTypes")
 	req, err := NewMultipleRequestAndResponseTypesRequest(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -273,6 +290,7 @@ func (c *Client) MultipleRequestAndResponseTypes(ctx context.Context, body Multi
 }
 
 func (c *Client) MultipleRequestAndResponseTypesWithFormdataBody(ctx context.Context, body MultipleRequestAndResponseTypesFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "MultipleRequestAndResponseTypesWithFormdataBody")
 	req, err := NewMultipleRequestAndResponseTypesRequestWithFormdataBody(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -285,6 +303,7 @@ func (c *Client) MultipleRequestAndResponseTypesWithFormdataBody(ctx context.Con
 }
 
 func (c *Client) MultipleRequestAndResponseTypesWithTextBody(ctx context.Context, body MultipleRequestAndResponseTypesTextRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "MultipleRequestAndResponseTypesWithTextBody")
 	req, err := NewMultipleRequestAndResponseTypesRequestWithTextBody(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -297,6 +316,7 @@ func (c *Client) MultipleRequestAndResponseTypesWithTextBody(ctx context.Context
 }
 
 func (c *Client) ReservedGoKeywordParameters(ctx context.Context, pType string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ReservedGoKeywordParameters")
 	req, err := NewReservedGoKeywordParametersRequest(c.Server, pType)
 	if err != nil {
 		return nil, err
@@ -309,6 +329,7 @@ func (c *Client) ReservedGoKeywordParameters(ctx context.Context, pType string, 
 }
 
 func (c *Client) ReusableResponsesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ReusableResponsesWithBody")
 	req, err := NewReusableResponsesRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -321,6 +342,7 @@ func (c *Client) ReusableResponsesWithBody(ctx context.Context, contentType stri
 }
 
 func (c *Client) ReusableResponses(ctx context.Context, body ReusableResponsesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "ReusableResponses")
 	req, err := NewReusableResponsesRequest(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -333,6 +355,7 @@ func (c *Client) ReusableResponses(ctx context.Context, body ReusableResponsesJS
 }
 
 func (c *Client) TextExampleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "TextExampleWithBody")
 	req, err := NewTextExampleRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -345,6 +368,7 @@ func (c *Client) TextExampleWithBody(ctx context.Context, contentType string, bo
 }
 
 func (c *Client) TextExampleWithTextBody(ctx context.Context, body TextExampleTextRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "TextExampleWithTextBody")
 	req, err := NewTextExampleRequestWithTextBody(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -357,6 +381,7 @@ func (c *Client) TextExampleWithTextBody(ctx context.Context, body TextExampleTe
 }
 
 func (c *Client) UnknownExampleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "UnknownExampleWithBody")
 	req, err := NewUnknownExampleRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -369,6 +394,7 @@ func (c *Client) UnknownExampleWithBody(ctx context.Context, contentType string,
 }
 
 func (c *Client) UnspecifiedContentTypeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "UnspecifiedContentTypeWithBody")
 	req, err := NewUnspecifiedContentTypeRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -381,6 +407,7 @@ func (c *Client) UnspecifiedContentTypeWithBody(ctx context.Context, contentType
 }
 
 func (c *Client) URLEncodedExampleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "URLEncodedExampleWithBody")
 	req, err := NewURLEncodedExampleRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -393,6 +420,7 @@ func (c *Client) URLEncodedExampleWithBody(ctx context.Context, contentType stri
 }
 
 func (c *Client) URLEncodedExampleWithFormdataBody(ctx context.Context, body URLEncodedExampleFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "URLEncodedExampleWithFormdataBody")
 	req, err := NewURLEncodedExampleRequestWithFormdataBody(c.Server, body)
 	if err != nil {
 		return nil, err
@@ -405,6 +433,7 @@ func (c *Client) URLEncodedExampleWithFormdataBody(ctx context.Context, body URL
 }
 
 func (c *Client) HeadersExampleWithBody(ctx context.Context, params *HeadersExampleParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "HeadersExampleWithBody")
 	req, err := NewHeadersExampleRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
@@ -417,6 +446,7 @@ func (c *Client) HeadersExampleWithBody(ctx context.Context, params *HeadersExam
 }
 
 func (c *Client) HeadersExample(ctx context.Context, params *HeadersExampleParams, body HeadersExampleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "HeadersExample")
 	req, err := NewHeadersExampleRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
@@ -429,6 +459,7 @@ func (c *Client) HeadersExample(ctx context.Context, params *HeadersExampleParam
 }
 
 func (c *Client) UnionExampleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "UnionExampleWithBody")
 	req, err := NewUnionExampleRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
@@ -441,6 +472,7 @@ func (c *Client) UnionExampleWithBody(ctx context.Context, contentType string, b
 }
 
 func (c *Client) UnionExample(ctx context.Context, body UnionExampleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	ctx = context.WithValue(ctx, operationIdKey(0), "UnionExample")
 	req, err := NewUnionExampleRequest(c.Server, body)
 	if err != nil {
 		return nil, err

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -8,6 +8,18 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+
+// operationIdKey is the context key for the operationId
+type operationIdKey int
+
+// GetOperationIdFromContext returns the operationId from the context
+func GetOperationIdFromContext(ctx context.Context) string {
+    if opid, ok := ctx.Value(operationIdKey(0)).(string); ok {
+        return opid
+    }
+    return ""
+}
+
 {{$clientTypeName := opts.OutputOptions.ClientTypeName -}}
 
 // {{ $clientTypeName }} which conforms to the OpenAPI3 specification for this service.
@@ -95,6 +107,7 @@ type ClientInterface interface {
 {{$opid := .OperationId -}}
 
 func (c *{{ $clientTypeName }}) {{$opid}}{{if .HasBody}}WithBody{{end}}(ctx context.Context{{genParamArgs $pathParams}}{{if $hasParams}}, params *{{$opid}}Params{{end}}{{if .HasBody}}, contentType string, body io.Reader{{end}}, reqEditors... RequestEditorFn) (*http.Response, error) {
+    ctx = context.WithValue(ctx, operationIdKey(0), "{{$opid}}{{if .HasBody}}WithBody{{end}}")
     req, err := New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(c.Server{{genParamNames .PathParams}}{{if $hasParams}}, params{{end}}{{if .HasBody}}, contentType, body{{end}})
     if err != nil {
         return nil, err
@@ -109,6 +122,7 @@ func (c *{{ $clientTypeName }}) {{$opid}}{{if .HasBody}}WithBody{{end}}(ctx cont
 {{range .Bodies}}
 {{if .IsSupportedByClient -}}
 func (c *{{ $clientTypeName }}) {{$opid}}{{.Suffix}}(ctx context.Context{{genParamArgs $pathParams}}{{if $hasParams}}, params *{{$opid}}Params{{end}}, body {{$opid}}{{.NameTag}}RequestBody, reqEditors... RequestEditorFn) (*http.Response, error) {
+    ctx = context.WithValue(ctx, operationIdKey(0), "{{$opid}}{{.Suffix}}")
     req, err := New{{$opid}}Request{{.Suffix}}(c.Server{{genParamNames $pathParams}}{{if $hasParams}}, params{{end}}, body)
     if err != nil {
         return nil, err


### PR DESCRIPTION
#1907 : set operationId in request context within client.tmpl for cross-cutting concerns 