### PR TITLE
chore: don't use non-GitHub URL for tests

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen_test.go
+++ b/cmd/oapi-codegen/oapi-codegen_test.go
@@ -10,7 +10,7 @@ func TestLoader(t *testing.T) {
 
 	paths := []string{
 		"../../examples/petstore-expanded/petstore-expanded.yaml",
-		"https://petstore3.swagger.io/api/v3/openapi.json",
+		"https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/v2.4.1/examples/petstore-expanded/petstore-expanded.yaml",
 	}
 
 	for _, v := range paths {


### PR DESCRIPTION
As we shouldn't be relying on a service we don't support, especially as
right now it's returning HTTP 403s.
