### PR TITLE
docs: fix GitHub flavoured markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3188,7 +3188,7 @@ output-options:
     typedef.tmpl: no-prefix.tmpl
 ```
 
-> [!WARN]
+> [!WARNING]
 > We do not interpolate `~` or `$HOME` (or other environment variables) in paths given
 
 ### HTTPS paths


### PR DESCRIPTION
Hi, `[!WARN]` is not valid. It has to be `[!WARNING]`.

> [!WARN]
> Invalid

> [!WARNING]
> Valid