### PR TITLE
fix: respect requestBody.required in strict server

### DIFF
--- a/pkg/codegen/templates/strict/strict-gin.tmpl
+++ b/pkg/codegen/templates/strict/strict-gin.tmpl
@@ -34,9 +34,17 @@ type strictHandler struct {
                 {{if .IsJSON }}
                     var body {{$opid}}{{.NameTag}}RequestBody
                     if err := ctx.ShouldBindJSON(&body); err != nil {
+                        {{ if .Required -}}
                         ctx.Status(http.StatusBadRequest)
                         ctx.Error(err)
                         return
+                        {{ else -}}
+                        if !errors.Is(err, io.EOF) {
+                            ctx.Status(http.StatusBadRequest)
+                            ctx.Error(err)
+                            return
+                        }
+                        {{ end -}}
                     }
                     request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = &body
                 {{else if eq .NameTag "Formdata" -}}


### PR DESCRIPTION
I noticed that `requestBody.required` wasn't being respected and requests without a body were failing with an `[EOF]` error even though required was set to false.

This PR is a tentative fix to this issue. It certainly works as my API now behaves according to the spec and it fails without a body only if `required: true`

I was wondering if we should also do:

```
var body *{{$opid}}{{.NameTag}}RequestBody
```

That would mean that if the body isn't present we would correctly send a nil object down to the server implementation but I am concerned that would lead to lots of panics in existing services for users that hadn't been paying attention to the fact that `required: false` is the default behavior when not set.

Thoughts?