### PR TITLE
fix(stdhttp): correctly generate root paths

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -628,6 +628,12 @@ func SwaggerUriToGorillaUri(uri string) string {
 //	{?param}
 //	{?param*}
 func SwaggerUriToStdHttpUri(uri string) string {
+	// https://pkg.go.dev/net/http#hdr-Patterns-ServeMux
+	// The special wildcard {$} matches only the end of the URL. For example, the pattern "/{$}" matches only the path "/", whereas the pattern "/" matches every path.
+	if uri == "/" {
+		return "/{$}"
+	}
+
 	return pathParamRE.ReplaceAllString(uri, "{$1}")
 }
 

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -439,6 +439,7 @@ func TestSwaggerUriToChiUri(t *testing.T) {
 }
 
 func TestSwaggerUriToStdHttpUriUri(t *testing.T) {
+	assert.Equal(t, "/{$}", SwaggerUriToStdHttpUri("/"))
 	assert.Equal(t, "/path", SwaggerUriToStdHttpUri("/path"))
 	assert.Equal(t, "/path/{arg}", SwaggerUriToStdHttpUri("/path/{arg}"))
 	assert.Equal(t, "/path/{arg1}/{arg2}", SwaggerUriToStdHttpUri("/path/{arg1}/{arg2}"))


### PR DESCRIPTION
As noted in #1952, using the root path for a given path doesn't get
correctly converted to the end-of-URL matcher, so we're accidentally
creating a matcher for /all/ URLs, which is invalid.

We can add a special case handler for the root path, and return the
expected wildcard alternatively.

Closes #1952.
