### PR TITLE
fix: allow response error handler to set status code

### DIFF
--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -74,20 +74,12 @@
                 {{if eq .NameTag "Multipart" -}}
                     writer := multipart.NewWriter(w)
                 {{end -}}
-                w.Header().Set("Content-Type", {{if eq .NameTag "Multipart"}}{{if eq .ContentType "multipart/form-data"}}writer.FormDataContentType(){{else}}mime.FormatMediaType("{{.ContentType}}", map[string]string{"boundary": writer.Boundary()}){{end}}{{else if .HasFixedContentType }}"{{.ContentType}}"{{else}}response.ContentType{{end}})
-                {{if not .IsSupported -}}
-                    if response.ContentLength != 0 {
-                        w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
-                    }
-                {{end -}}
-                {{range $headers -}}
-                    w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
-                {{end -}}
-                w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
-                {{$hasBodyVar := or ($hasHeaders) (not $fixedStatusCode) (not .IsSupported)}}
+                {{$hasBodyVar := or ($hasHeaders) (not $fixedStatusCode) (not .IsSupported) -}}
                 {{if .IsJSON -}}
-                    {{$hasUnionElements := ne 0 (len .Schema.UnionElements)}}
-                    return json.NewEncoder(w).Encode(response{{if $hasBodyVar}}.Body{{end}}{{if $hasUnionElements}}.union{{end}})
+                    {{$hasUnionElements := ne 0 (len .Schema.UnionElements) -}}
+                    if err :=json.NewEncoder(w).Encode(response{{if $hasBodyVar}}.Body{{end}}{{if $hasUnionElements}}.union{{end}}); err != nil {
+                    return err
+                    } 
                 {{else if eq .NameTag "Text" -}}
                     _, err := w.Write([]byte({{if $hasBodyVar}}response.Body{{else}}response{{end}}))
                     return err
@@ -108,6 +100,17 @@
                     _, err := io.Copy(w, response.Body)
                     return err
                 {{end}}{{/* if eq .NameTag "JSON" */ -}}
+                w.Header().Set("Content-Type", {{if eq .NameTag "Multipart"}}{{if eq .ContentType "multipart/form-data"}}writer.FormDataContentType(){{else}}mime.FormatMediaType("{{.ContentType}}", map[string]string{"boundary": writer.Boundary()}){{end}}{{else if .HasFixedContentType }}"{{.ContentType}}"{{else}}response.ContentType{{end}})
+                {{if not .IsSupported -}}
+                    if response.ContentLength != 0 {
+                        w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+                    }
+                {{end -}}
+                {{range $headers -}}
+                    w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                {{end -}}
+                w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                return nil
             }
         {{end}}
 


### PR DESCRIPTION
Version: 2.4.1

Issue: Status code is set to 200 before marshalling data into body inside visit<ResponseName> functions, so when an error occurs marshalling the ResponseErrorHandlerFunc cannot set the status code.

Reproduce: 
``` openapi.yaml
openapi: 3.0.1
info:
  title: error-handler-example
  version: 1.0.0
paths:
  /api/example:
    post:
      operationId: exampleHandler
      responses:
        200:
          description: example
          content:
            application/json:
              schema:
                type: object
                properties:
                  example:
                    type: string
                    format: email
```
```
package: api
generate:
  gorilla-server: true
  strict-server: true
  models: true
output: generated/gen.go
```

```
package main

import (
	"context"
	"net/http"

	api "example.go/generated"
	openapi_types "github.com/oapi-codegen/runtime/types"
)

type ExampleHandler struct {
}

func main() {
	e := &ExampleHandler{}
	h := api.NewStrictHandlerWithOptions(e, nil, api.StrictHTTPServerOptions{
		ResponseErrorHandlerFunc: func(w http.ResponseWriter, r *http.Request, err error) {
			w.WriteHeader(500)
		},
	})
	handler := api.Handler(h)
	err := http.ListenAndServe(":8080", handler)
	panic(err)
}

func (*ExampleHandler) ExampleHandler(ctx context.Context,
	request api.ExampleHandlerRequestObject) (api.ExampleHandlerResponseObject, error) {
	email := openapi_types.Email("invalid email")
	return api.ExampleHandler200JSONResponse{
		Example: &email,
	}, nil
}
```
Generated visit function

```
func (response ExampleHandler200JSONResponse) VisitExampleHandlerResponse(w http.ResponseWriter) error {
	w.Header().Set("Content-Type", "application/json")
	w.WriteHeader(200)

	return json.NewEncoder(w).Encode(response)
}
```

Proposed changes would have the output

```
func (response ExampleHandler200JSONResponse) VisitExampleHandlerResponse(w http.ResponseWriter) error {
	if err := json.NewEncoder(w).Encode(response); err != nil {
		return err
	}
	w.Header().Set("Content-Type", "application/json")
	w.WriteHeader(200)
	return nil
}
```
