### PR TITLE
docs(std-http-server): warn when not using Go 1.22

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -271,6 +271,15 @@ func main() {
 		errExit("configuration error: %v\n", err)
 	}
 
+	if warnings := opts.Generate.Warnings(); len(warnings) > 0 {
+		out := "WARNING: A number of warning(s) were returned when validating the GenerateOptions:"
+		for k, v := range warnings {
+			out += "\n- " + k + ": " + v
+		}
+
+		_, _ = fmt.Fprint(os.Stderr, out)
+	}
+
 	// If the user asked to output configuration, output it to stdout and exit
 	if flagOutputConfig {
 		buf, err := yaml.Marshal(opts)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/getkin/kin-openapi v0.128.0
 	github.com/speakeasy-api/openapi-overlay v0.10.1
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/mod v0.17.0
 	golang.org/x/text v0.20.0
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
 	gopkg.in/yaml.v2 v2.4.0
@@ -26,5 +27,4 @@ require (
 	github.com/speakeasy-api/jsonpath v0.6.0 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
-	golang.org/x/mod v0.17.0 // indirect
 )

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -132,6 +132,35 @@ func (oo GenerateOptions) Validate() map[string]string {
 	return nil
 }
 
+func (oo GenerateOptions) Warnings() map[string]string {
+	warnings := make(map[string]string)
+
+	if oo.StdHTTPServer {
+		if warning := oo.warningForStdHTTP(); warning != "" {
+			warnings["std-http-server"] = warning
+		}
+	}
+
+	return warnings
+}
+
+func (oo GenerateOptions) warningForStdHTTP() string {
+	pathToGoMod, mod, err := findAndParseGoModuleForDepth(".", maximumDepthToSearchForGoMod)
+	if err != nil {
+		return fmt.Sprintf("Encountered an error while trying to find a `go.mod` or a `tools.mod` in this directory, or %d levels above it: %v", maximumDepthToSearchForGoMod, err)
+	}
+
+	if mod == nil {
+		return fmt.Sprintf("Failed to find a `go.mod` or a `tools.mod` in this directory, or %d levels above it, so unable to validate that you're using Go 1.22+. If you start seeing API interactions resulting in a `404 page not found`, the Go directive (implying source compatibility for this module) needs to be bumped. See also: https://www.jvt.me/posts/2024/03/04/go-net-http-why-404/", maximumDepthToSearchForGoMod)
+	}
+
+	if !hasMinimalMinorGoDirective(minimumGoVersionForGenerateStdHTTPServer, mod) {
+		return fmt.Sprintf("Found a `go.mod` or a `tools.mod` at path %v, but it only had a version of %v, whereas the minimum required is 1.%d. It's very likely API interactions will result in a `404 page not found`. The Go directive (implying source compatibility for this module) needs to be bumped. See also: https://www.jvt.me/posts/2024/03/04/go-net-http-why-404/", pathToGoMod, mod.Go.Version, minimumGoVersionForGenerateStdHTTPServer)
+	}
+
+	return ""
+}
+
 // CompatibilityOptions specifies backward compatibility settings for the
 // code generator.
 type CompatibilityOptions struct {

--- a/pkg/codegen/minimum_go_version.go
+++ b/pkg/codegen/minimum_go_version.go
@@ -1,0 +1,91 @@
+package codegen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+const maximumDepthToSearchForGoMod = 5
+
+// minimumGoVersionForGenerateStdHTTPServer indicates the Go 1.x minor version that the module the std-http-server is being generated into needs.
+// If the version is lower, a warning should be logged.
+const minimumGoVersionForGenerateStdHTTPServer = 22
+
+func findAndParseGoModuleForDepth(dir string, maxDepth int) (string, *modfile.File, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to determine absolute path for %v: %w", dir, err)
+	}
+	currentDir := absDir
+
+	for i := 0; i <= maxDepth; i++ {
+		goModPath := filepath.Join(currentDir, "go.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			goModContent, err := os.ReadFile(goModPath)
+			if err != nil {
+				return "", nil, fmt.Errorf("failed to read `go.mod`: %w", err)
+			}
+
+			mod, err := modfile.ParseLax("go.mod", goModContent, nil)
+			if err != nil {
+				return "", nil, fmt.Errorf("failed to parse `go.mod`: %w", err)
+			}
+
+			return goModPath, mod, nil
+		}
+
+		goModPath = filepath.Join(currentDir, "tools.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			goModContent, err := os.ReadFile(goModPath)
+			if err != nil {
+				return "", nil, fmt.Errorf("failed to read `tools.mod`: %w", err)
+			}
+
+			parsedModFile, err := modfile.ParseLax("tools.mod", goModContent, nil)
+			if err != nil {
+				return "", nil, fmt.Errorf("failed to parse `tools.mod`: %w", err)
+			}
+
+			return goModPath, parsedModFile, nil
+		}
+
+		parentDir := filepath.Dir(currentDir)
+		// NOTE that this may not work particularly well on Windows
+		if parentDir == "/" {
+			break
+		}
+
+		currentDir = parentDir
+	}
+
+	return "", nil, fmt.Errorf("no `go.mod` or `tools.mod` file found within %d levels upwards from %s", maxDepth, absDir)
+}
+
+// hasMinimalMinorGoDirective indicates that the Go module (`mod`) has a minor version greater than or equal to the `expected`'s
+// This only applies to the `go` directive:
+//
+//	go 1.23
+//	go 1.22.1
+func hasMinimalMinorGoDirective(expected int, mod *modfile.File) bool {
+	parts := strings.Split(mod.Go.Version, ".")
+
+	if len(parts) < 2 {
+		return false
+	}
+
+	actual, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+
+	if actual < expected {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION

Although this is less necessary after bumping our minimum Go version to
1.22 (in 0e8156a14e1a92e59194230873b2053d5b29e38b), it's still
worthwhile ensuring that the module we're generating the code for is
correctly set to Go 1.22, otherwise users will receive:

    HTTP/1.1 404 Not Found
    ...
    404 page not found

To do this, we can introduce a new means to flag "warnings" that need to
be output.

We need to make sure we're using `ParseLax` to reduce the risk of new
directives or content being introduced into a `go.mod` breaking
`oapi-codegen`.

This is a step towards being able to implement future warnings to ensure
that consumers are using correct Go versions.

Closes #1628.

[0]: https://www.jvt.me/posts/2024/03/04/go-net-http-why-404/



---

> [!WARNING]
> I'm not quite sure about this - especially for `oapi-codegen`-as-a-library
