### PR TITLE
feat(options): support for all Go types in aliases

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -269,9 +269,9 @@ type OutputOptions struct {
 	// Whether to generate nullable type for nullable fields
 	NullableType bool `yaml:"nullable-type,omitempty"`
 
-	// DisableTypeAliasesForType allows defining which OpenAPI `type`s will explicitly not use type aliases
-	// Currently supports:
-	//   "array"
+	// DisableTypeAliasesForType allows defining which OpenAPI `type`s will explicitly not use type aliases. Use Go type names
+	// and not the OpenAPI type names. Use "[]type" to disable arrays, a shortcut for all arrays can be used by specifying
+	// `array` value.
 	DisableTypeAliasesForType []string `yaml:"disable-type-aliases-for-type"`
 
 	// NameNormalizer is the method used to normalize Go names and types, for instance converting the text `MyApi` to `MyAPI`. Corresponds with the constants defined for `codegen.NameNormalizerFunction`

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -589,6 +589,7 @@ func oapiSchemaToGoType(schema *openapi3.Schema, path []string, outSchema *Schem
 		outSchema.AdditionalTypes = arrayType.AdditionalTypes
 		outSchema.Properties = arrayType.Properties
 		outSchema.DefineViaAlias = true
+		// kept for backward compatibility, array can be disabled via either "array" or "[]type"
 		if sliceContains(globalState.options.OutputOptions.DisableTypeAliasesForType, "array") {
 			outSchema.DefineViaAlias = false
 		}
@@ -655,6 +656,10 @@ func oapiSchemaToGoType(schema *openapi3.Schema, path []string, outSchema *Schem
 		outSchema.DefineViaAlias = true
 	} else {
 		return fmt.Errorf("unhandled Schema type: %v", t)
+	}
+
+	if outSchema.GoType != "" && sliceContains(globalState.options.OutputOptions.DisableTypeAliasesForType, outSchema.GoType) {
+		outSchema.DefineViaAlias = false
 	}
 	return nil
 }


### PR DESCRIPTION
I need to disable type aliases for some types but not all. I noticed there is actually a feature for that, but for some reason it is only available for arrays. This lifts that limitation while keeping the backward compatibility.