### PR TITLE
fix: properly access user data in iris context

### DIFF
--- a/pkg/codegen/templates/iris/iris-middleware.tmpl
+++ b/pkg/codegen/templates/iris/iris-middleware.tmpl
@@ -35,7 +35,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx iris.Context) {
 {{end}}
 
 {{range .SecurityDefinitions}}
-    ctx.Set({{.ProviderName | sanitizeGoIdentity | ucFirst}}Scopes, {{toStringArray .Scopes}})
+    ctx.Values().Set({{.ProviderName | sanitizeGoIdentity | ucFirst}}Scopes, {{toStringArray .Scopes}})
 {{end}}
 
 {{if .RequiresParamObject}}


### PR DESCRIPTION
The way the code tried to access user set values on the iris context was wrong.

This PR leverage the "user" storage provided by the iris Context object.

fixes #1988