### PR TITLE
fix: create directories if they do not exist before writing output file

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -320,7 +320,7 @@ func main() {
 
 	if opts.OutputFile != "" {
 		if err := os.MkdirAll(filepath.Dir(opts.OutputFile), 0o755); err != nil {
-			errExit("error unable to create directory: %s", err)
+			errExit("error unable to create directory: %s\n", err)
 		}
 		err = os.WriteFile(opts.OutputFile, []byte(code), 0o644)
 		if err != nil {

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -319,6 +319,9 @@ func main() {
 	}
 
 	if opts.OutputFile != "" {
+		if err := os.MkdirAll(filepath.Dir(opts.OutputFile), 0o755); err != nil {
+			errExit("error unable to create directory: %s", err)
+		}
 		err = os.WriteFile(opts.OutputFile, []byte(code), 0o644)
 		if err != nil {
 			errExit("error writing generated code to file: %s\n", err)


### PR DESCRIPTION
#1052 

If the parent directory of the output file doesn't exist, it will be automatically created before writing the generated code. This prevents errors if the specified output path contains a non-existent directory.


