### PR TITLE
docs(extensions): don't use `<details>` blocks in `<table>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2676,7 +2676,7 @@ type ClientWithExtension struct {
 
 Notice that the `ComplexField` is still generated in full, but the type will then be ignored with JSON marshalling.
 
-You can see this in more detail in [the example code](examples/extensions/xgojsonignore/).
+You can see this in more detail in [the example code](examples/extensions/xomitempty/).
 
 ### `x-go-json-ignore` - when (un)marshaling JSON, ignore field(s)
 


### PR DESCRIPTION
This is significantly hard to author, and makes it harder to read as
rendered Markdown, too, so let's expand these out.

We can retain the table view as a quick reference.
