### PR TITLE
Fix bullet point line `prefer-skip-optional-pointer-with-omitzero` typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3839,7 +3839,7 @@ This can be tuned on a per-field basis, using the [`x-go-type-skip-optional-poin
 
 As of `oapi-codegen` v2.5.0, this can be tuned in two specific ways, via the following `output-options:`:
 
-- `prefer-skip-optional-pointer`: a global default that you do _not_ want the "optional pointer" generated. Optional fields will not have an "optional pointer", and will have an `omitempty` JSON tag.
+- `prefer-skip-optional-pointer`: a global default that you do _not_ want the "optional pointer" generated. Optional fields will not have an "optional pointer", and will have an `omitempty` JSON tag
 - `prefer-skip-optional-pointer-with-omitzero`: when used in conjunction with `prefer-skip-optional-pointer`, any optional fields are generated with an `omitzero` JSON tag. **Requires Go 1.24+**
 
 In both cases, there is control on a per-field level to set `x-go-type-skip-optional-pointer: false` or `x-omitzero: false` to undo these to field(s).


### PR DESCRIPTION
Just noted a small typo in the root `README.md`, the line outlining the use of the `prefer-skip-optional-pointer-with-omitzero` refers to itself, not the option of `prefer-skip-optional-pointer` above it.

Actually noted this in the https://github.com/oapi-codegen/oapi-codegen/releases/tag/v2.5.0 release notes (which also needs fixing) - so assume this was cut and pasted from the `README.md` -> into the release notes.
