### PR TITLE
chore(renovate): don't exclude `examples` and `internal/test`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
 		"local>oapi-codegen/renovate-config"
-	]
+	],
+	"gomod": {
+		"ignorePaths": []
+	}
 }


### PR DESCRIPTION
We're using `:default`[0] from our configuration, which then
excludes our `examples` and `internal/test` directories[1][2][3].

It is handy for us to keep these dependencies up-to-date, so we should
override the `ignorePaths` for Go dependencies.

[0]: https://github.com/oapi-codegen/renovate-config/blob/d63ca7f61facd164040be09ee8a32090435cef57/default.json#L4
[1]: https://docs.renovatebot.com/presets-config/#configbest-practices
[2]: https://docs.renovatebot.com/presets-config/#configrecommended
[3]: https://docs.renovatebot.com/presets-default/#ignoremodulesandtests
