### PR TITLE
feat(codegen): emit nullable.Value[T] when `nullable-type` is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -2327,7 +2327,7 @@ However, you lose the ability to understand the three cases, as there's no way t
 - is this field `null`? (Can be checked with `S.Field == nil`)
 - does this field have a value? (`S.Field != nil && *S.Field == "123"`)
 
-As of `oapi-codegen` [v2.1.0](https://github.com/oapi-codegen/oapi-codegen/releases/tag/v2.1.0) it is now possible to represent this with the `nullable.Nullable` type from [our new library, oapi-codegen/nullable](https://github.com/oapi-codegen/nullable).
+As of `oapi-codegen` [v2.1.0](https://github.com/oapi-codegen/oapi-codegen/releases/tag/v2.1.0) it is now possible to represent this with the `nullable.Value` type from [our library, oapi-codegen/nullable](https://github.com/oapi-codegen/nullable). (previously `nullable.Nullable`, now deprecated);
 
 If you configure your generator's Output Options to opt-in to this behaviour, as so:
 
@@ -2341,7 +2341,7 @@ You will now receive the following output:
 ```go
 type S struct {
     // note that there's no pointer here, just `omitempty`
-    Field nullable.Nullable[string] `json:"field,omitempty"`
+    Field nullable.Value[string] `json:"field,omitempty"`
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/oapi-codegen/nullable v1.1.0 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwd
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
+github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=

--- a/internal/test/issues/issue-1039/issue_test.go
+++ b/internal/test/issues/issue-1039/issue_test.go
@@ -17,16 +17,16 @@ func ptr[T any](v T) *T {
 func TestNullableTypesMarshal(t *testing.T) {
 	// include all fields in patch request
 	patchReq := PatchRequest{
-		ComplexRequiredNullable: nullable.NewNullableWithValue(ComplexRequiredNullable{
+		ComplexRequiredNullable: nullable.NewValue(ComplexRequiredNullable{
 			Name: ptr("test-name"),
 		}),
 		SimpleOptionalNonNullable: ptr(SimpleOptionalNonNullable("bar")),
-		ComplexOptionalNullable: nullable.NewNullableWithValue(ComplexOptionalNullable{
-			AliasName: nullable.NewNullableWithValue("foo-alias"),
+		ComplexOptionalNullable: nullable.NewValue(ComplexOptionalNullable{
+			AliasName: nullable.NewValue("foo-alias"),
 			Name:      ptr("foo"),
 		}),
-		SimpleOptionalNullable: nullable.NewNullableWithValue(10),
-		SimpleRequiredNullable: nullable.NewNullableWithValue(5),
+		SimpleOptionalNullable: nullable.NewValue(10),
+		SimpleRequiredNullable: nullable.NewValue(5),
 	}
 
 	expected := []byte(`{"complex_optional_nullable":{"alias_name":"foo-alias","name":"foo"},"complex_required_nullable":{"name":"test-name"},"simple_optional_non_nullable":"bar","simple_optional_nullable":10,"simple_required_nullable":5}`)
@@ -37,15 +37,15 @@ func TestNullableTypesMarshal(t *testing.T) {
 
 	// omit some fields
 	patchReq = PatchRequest{
-		ComplexRequiredNullable: nullable.NewNullableWithValue(ComplexRequiredNullable{
+		ComplexRequiredNullable: nullable.NewValue(ComplexRequiredNullable{
 			Name: ptr("test-name"),
 		}),
 		// SimpleOptionalNonNullable is omitted
-		ComplexOptionalNullable: nullable.NewNullableWithValue(ComplexOptionalNullable{
-			AliasName: nullable.NewNullableWithValue("test-alias-name"),
+		ComplexOptionalNullable: nullable.NewValue(ComplexOptionalNullable{
+			AliasName: nullable.NewValue("test-alias-name"),
 			Name:      ptr("test-name"),
 		}),
-		SimpleOptionalNullable: nullable.NewNullableWithValue(10),
+		SimpleOptionalNullable: nullable.NewValue(10),
 		// SimpleRequiredNullable is omitted
 	}
 

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -116,7 +116,7 @@ func (p Property) GoFieldName() string {
 func (p Property) GoTypeDef() string {
 	typeDef := p.Schema.TypeDecl()
 	if globalState.options.OutputOptions.NullableType && p.Nullable {
-		return "nullable.Nullable[" + typeDef + "]"
+		return "nullable.Value[" + typeDef + "]"
 	}
 	if !p.Schema.SkipOptionalPointer &&
 		(!p.Required || p.Nullable ||

--- a/pkg/codegen/schema_test.go
+++ b/pkg/codegen/schema_test.go
@@ -308,7 +308,7 @@ func TestProperty_GoTypeDef_nullable(t *testing.T) {
 				Required: true,
 				Nullable: true,
 			},
-			want: "nullable.Nullable[int]",
+			want: "nullable.Value[int]",
 		},
 
 		{
@@ -336,7 +336,7 @@ func TestProperty_GoTypeDef_nullable(t *testing.T) {
 				Required: false,
 				Nullable: true,
 			},
-			want: "nullable.Nullable[int]",
+			want: "nullable.Value[int]",
 		},
 
 		{
@@ -422,7 +422,7 @@ func TestProperty_GoTypeDef_nullable(t *testing.T) {
 				WriteOnly: true,
 				Nullable:  true,
 			},
-			want: "nullable.Nullable[int]",
+			want: "nullable.Value[int]",
 		},
 
 		{
@@ -436,7 +436,7 @@ func TestProperty_GoTypeDef_nullable(t *testing.T) {
 				WriteOnly: true,
 				Nullable:  true,
 			},
-			want: "nullable.Nullable[int]",
+			want: "nullable.Value[int]",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Follow-on PR from https://github.com/oapi-codegen/nullable/pull/21.

Please do not merge this before nullable/pull/21 lands (tests won't pass anyway).

- Switch generator from deprecated `nullable.Nullable[T]` to output `nullable.Value[T]` for nullable fields
- Update schema tests to expect Value[T]
- Update README to prefer nullable.Value with migration notes
- Do not edit generated fixtures; regeneration will follow after library update

Before merging this PR, and after nullable/pull/21 lands:

- Bump github.com/oapi-codegen/nullable version to the release that includes Value[T]. `go get github.com/oapi-codegen/nullable`
- Run: `go generate ./internal/test/issues/issue-1039` (and other fixtures) to re-emit `nullable.Value[...]`.
