### PR TITLE
feat(nullable): nullable.go for OpenAPI 3.1 compatibility

### DIFF
--- a/pkg/codegen/nullable.go
+++ b/pkg/codegen/nullable.go
@@ -1,0 +1,128 @@
+package codegen
+
+import (
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// IsSchemaNullable determines whether a schema permits JSON null.
+//
+//   - For OpenAPI 3.1 (JSON Schema 2020-12), a schema is nullable if, considering
+//     base constraints (type/enum/not) and composition (oneOf/anyOf/allOf), the
+//     overall schema would accept the JSON null value. Empty schemas `{}` are not
+//     considered nullable here by design to avoid over-detection in generators.
+//   - For OpenAPI 3.0, falls back to `schema.Value.Nullable`.
+func IsSchemaNullable(specVersion string, sref *openapi3.SchemaRef) bool {
+	if sref == nil || sref.Value == nil {
+		return false
+	}
+
+	if strings.HasPrefix(specVersion, "3.1") {
+		return permitsNull31(sref)
+	}
+	return sref.Value.Nullable
+}
+
+// permitsNull31 returns true if the schema (draft 2020-12 semantics) permits JSON null,
+// accounting for base constraints (type/enum/not) and composed constraints (oneOf/anyOf/allOf).
+// NOTE: Empty schemas are intentionally treated as non-nullable for generator purposes.
+func permitsNull31(schemaRef *openapi3.SchemaRef) bool {
+	if schemaRef == nil || schemaRef.Value == nil {
+		return false
+	}
+	schema := schemaRef.Value
+
+	// Base constraints that immediately rule out null
+	if baseDisallowsNull(schema) {
+		return false
+	}
+	// "not" forbids null if its subschema would accept null
+	if notForbidsNull(schema.Not) {
+		return false
+	}
+
+	// Composition constraints - AllOf
+	if len(schema.AllOf) > 0 {
+		for _, sub := range schema.AllOf {
+			if !permitsNull31(sub) {
+				return false
+			}
+		}
+		return true
+	}
+	// Composition constraints - OneOf
+	if len(schema.OneOf) > 0 {
+		matches := 0
+		for _, sub := range schema.OneOf {
+			if permitsNull31(sub) {
+				matches++
+			}
+		}
+		return matches == 1
+	}
+	// Composition constraints - AnyOf
+	if len(schema.AnyOf) > 0 {
+		for _, sub := range schema.AnyOf {
+			if permitsNull31(sub) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// No composition: decide from type/enum
+	if typeIncludesNull(schema.Type) {
+		return true
+	}
+	if enumIncludesNull(schema.Enum) {
+		return true
+	}
+
+	// Treat empty/unconstrained schemas as non-nullable for codegen
+	return false
+}
+
+func baseDisallowsNull(s *openapi3.Schema) bool {
+	// If a base type is present and does NOT include null, null cannot be valid overall
+	if s.Type != nil && !typeIncludesNull(s.Type) {
+		return true
+	}
+	// If enum exists and does NOT contain null, then null is disallowed
+	if len(s.Enum) > 0 && !enumIncludesNull(s.Enum) {
+		return true
+	}
+	return false
+}
+
+func typeIncludesNull(t *openapi3.Types) bool {
+	if t == nil {
+		return false
+	}
+	if t.Is(openapi3.TypeNull) {
+		return true
+	}
+	for _, typ := range t.Slice() {
+		if typ == openapi3.TypeNull {
+			return true
+		}
+	}
+	return false
+}
+
+func enumIncludesNull(values []any) bool {
+	for _, v := range values {
+		if v == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func notForbidsNull(notRef *openapi3.SchemaRef) bool {
+	if notRef == nil || notRef.Value == nil {
+		return false
+	}
+	// If the negated schema would accept null, then the parent forbids null
+	return permitsNull31(notRef)
+}

--- a/pkg/codegen/nullable_test.go
+++ b/pkg/codegen/nullable_test.go
@@ -1,0 +1,294 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func schemaRefFromDoc(t *testing.T, docYAML string, schemaName string) (*openapi3.SchemaRef, string) {
+	t.Helper()
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(docYAML))
+	require.NoError(t, err, "failed to load OpenAPI document")
+	ref, ok := doc.Components.Schemas[schemaName]
+	require.Truef(t, ok, "schema %q not found in components", schemaName)
+	return ref, doc.OpenAPI
+}
+
+func TestIsSchemaNullable_31_TypeOnlyNull(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      type: 'null'
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.True(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_TypeOnlyString(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      type: 'string'
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.False(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_TypeUnionIncludesNull(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      type: [string, 'null']
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.True(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_NonNullable(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      type: [string, integer]
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.False(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_OneOfWithNullOnly(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      oneOf:
+        - { type: string }
+        - { type: 'null' }
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.True(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_OneOf_AllNullArms(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      oneOf:
+        - { type: 'null' }
+        - { type: 'null' }
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	// JSON Schema oneOf requires exactly one match; null matches both arms → not nullable via oneOf
+	assert.False(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_OneOf_MixedMultipleNullAllowingArms(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      oneOf:
+        - { type: ['string','null'] }
+        - { type: 'null' }
+        - { type: integer }
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	// Two subschemas explicitly allow null -> oneOf(null) must fail (violates exactly-one)
+	assert.False(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_AnyOfWithNullOnly(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      anyOf:
+        - { type: integer }
+        - { type: 'null' }
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.True(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_AnyOf_AllNullArms(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      anyOf:
+        - { type: 'null' }
+        - { type: 'null' }
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.True(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_AllOf_OneNullArm(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      allOf:
+        - { type: 'null' }
+        - { type: string }
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.False(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_AllOf_AllNullArms(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      allOf:
+        - { type: 'null' }
+        - { type: 'null' }
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.True(t, IsSchemaNullable(ver, ref))
+}
+func TestIsSchemaNullable_31_BaseTypeBlocksNull_InAnyOf(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      type: string
+      anyOf:
+        - { type: 'null' }
+        - { minLength: 1 }
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.False(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_EnumAllowsNull_NoType(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      enum: [null, "x"]
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.True(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_EnumAllowsNull_WithTypeString_Disallowed(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      type: string
+      enum: [null, "x"]
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.False(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_NotBlocksNull(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      type: ['string','null']
+      not:
+        type: 'null'
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.False(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_31_EmptySchema_NotNullableByPolicy(t *testing.T) {
+	doc := `
+openapi: 3.1.0
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S: {}
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.False(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_30_FallbackTrue(t *testing.T) {
+	doc := `
+openapi: 3.0.3
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      type: string
+      nullable: true
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.True(t, IsSchemaNullable(ver, ref))
+}
+
+func TestIsSchemaNullable_30_FallbackFalse(t *testing.T) {
+	doc := `
+openapi: 3.0.3
+info: { title: t, version: v }
+paths: {}
+components:
+  schemas:
+    S:
+      type: string
+`
+	ref, ver := schemaRefFromDoc(t, doc, "S")
+	assert.False(t, IsSchemaNullable(ver, ref))
+}


### PR DESCRIPTION

## Summary

Hello maintainers 👋 

New contributor to this project, so feedback very much welcome & appreciated! 

We just upgraded our internal OAS Spec to version 3.1, before running in to #373 3.1 compatibility issues. Instead of downgrading, I have some cycles to spend on hopefully progressing some of the tasks under https://github.com/orgs/oapi-codegen/projects/4.

This is the first in a small series of PRs to hopefully make progress towards the changed [nullable behaviour in OAS 3.1](https://github.com/orgs/oapi-codegen/projects/4/views/1?pane=issue&itemId=124577261), while ensuring backwards compatibility.

## Open Questions up-front:

- Is this the right approach?
- If not, should this live elsewhere?
  - https://github.com/oapi-codegen/nullable ?
  - or upstream in https://github.com/getkin/kin-openapi?
- Is the assumption of "Empty schemas being treated as non-nullable to avoid over-detection in codegen" a valid one?

## This PR

nullable.go handles null in line with [JSON schema core 2020-12 spec](https://json-schema.org/draft/2020-12/json-schema-core) for OAS 3.1, with one explicit generator policy:
Empty schemas `{}` are treated as non-nullable to avoid over-detection in codegen.

What's included:
- [x] Centralised 3.1 null detector in `pkg/codegen/nullable.go` (this PR) _but not wired up yet._
  - Exports `IsSchemaNullable(specVersion string, schema *openapi3.SchemaRef) bool`
  - Keeps default behaviour unchanged (i.e. `output-options.nullable-type` exists in `configuration-schema.json`, default `false`)
  - 3.1: Considers `type` (including union with `'null'`), `oneOf`/`anyOf`/`allOf`, `enum` (null present), and `not` (blocks null if it accepts null)
  - 3.0: Falls back to `schema.Value.Nullable` for `nullable: true` compatibility
  - a single file keeps logic consistent and avoids scattered special cases throughout the codebase.
- Tests in `pkg/codegen/nullability_test.go` 
  - Validates consistency against patterns from the [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12).
  
 Note: The detector intentionally diverges from raw JSON Schema for `{}` as explained above.

The logic & test coverage of `oneOf/anyOf/allOf` got a little hairy, so I found I understood it better once I sketched it out.

- General rule (where k is “how many subschemas explicitly allow null”):
  - anyOf: k ≥ 1 
  - oneOf: k = 1 
  - allOf: k = total number of subschemas 

e.g.
- `[ {'type':'string'} ]` is zero subschemas, k=0
- `[ {'type':'null'} ]` is one subschema, k=1
- `[ {'type':'null'}, {'type':'null'} ]` k=2, etc...

k | anyOf(null) | oneOf(null) | allOf(null)
-- | -- | -- | --
0 | ❌ | ❌ | ❌
1 | ✅ | ✅ | ❌
2+ | ✅ | ❌ | ✅ (only if all explicitly allow null)

appendix below with full test coverage matrix.

## Future Work

- [ ] If above PR is accepted, integrate `IsSchemaNullable()` into the broader codebase,
- [ ] Feature-flag: Wire up existing `output-options.nullable-type` config
  - When `output-options.nullable-type` is enabled, use `nullable.Value[T]` from `github.com/oapi-codegen/nullable` (previously `nullable.Nullable[T]`), non-blocking PR: #2067 
  - Otherwise retain existing behaviour for 3.0 users
- [ ] Version gating and safety
  - Detect spec version; enable 3.1 paths only when `openapi: 3.1.*`
  - Provide unit-test coverage for detector behavior on both 3.0 and 3.1 inputs
 
 ## Delivery plan
 
rough PR split
- [ ] PR1: detector (unused) + tests **<- this PR**
- [ ] PR2: Explicit feature-flag & initial schema integration,
- [ ] PR3: Version gating & safety,
- [ ] PR4?: Cleanup, docs touch-ups, internal refactors if needed

## Checklist

- [x] Tests added/updated (for new features or bug fixes)
- [ ] ~Documentation updated (README/CONTRIBUTING/examples as needed)~ N/A
- [x] `make tidy` is run locally
- [x] `make test` is run locally
- [ ] ~`make generate` run is run locally and outputs committed (if generated code is affected)~ N/A
- [x] `make lint` is run locally

## Additional context
- oapi-codegen [Project Board for 3.1 support](https://github.com/orgs/oapi-codegen/projects/4/views/1?pane=issue&itemId=124577261)
- json-schema-org [anyOf JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/anyOf.json)
- https://github.com/OAI/OpenAPI-Specification/issues/3148

Test Coverage of all cases:

Case Description | Combinator | Example  | k | assert | Covered by test
----- | -- | -- | ---:| --:| --
Type-only null | `type` | `type: 'null'` | 1 | ✅ | TestIsSchemaNullable_31_TypeOnlyNull
Type-only string | `type` | `type: 'string'` | 0 | ❌ | TestIsSchemaNullable_31_TypeOnlyString
Type union includes null | `type` | `type: ['string','null']` | 1 | ✅ | TestIsSchemaNullable_31_TypeUnionIncludesNull
Type union, no null | `type` | `type: ['string','integer']` | 0 | ❌ | TestIsSchemaNullable_31_NonNullable
oneOf with single null-only arm | `oneOf` | `[ {type:'string'}, {type:'null'} ]` | 1 | ✅ | TestIsSchemaNullable_31_OneOfWithNullOnly
oneOf with two null-only arms | `oneOf` | `[ {type:'null'}, {type:'null'} ]` | 2 | ❌ | TestIsSchemaNullable_31_OneOf_AllNullArms
oneOf mixed, multiple null-allowing arms | `oneOf` | `[ {type:['string','null']}, {type:'null'}, {type:'integer'} ]` | 2 | ❌ | TestIsSchemaNullable_31_OneOf_MixedMultipleNullAllowingArms
anyOf with single null-only arm | `anyOf` | `[ {type:'integer'}, {type:'null'} ]` | 1 | ✅ | TestIsSchemaNullable_31_AnyOfWithNullOnly
anyOf with two null-only arms | `anyOf` | `[ {type:'null'}, {type:'null'} ]` | 2 | ✅ | TestIsSchemaNullable_31_AnyOf_AllNullArms
allOf with one null-only arm | `allOf` | `[ {type:'null'}, {type:'string'} ]` | 1 | ❌ | TestIsSchemaNullable_31_AllOf_OneNullArm
allOf with all null-only arms | `allOf` | `[ {type:'null'}, {type:'null'} ]` | 2 | ✅ | TestIsSchemaNullable_31_AllOf_AllNullArms
Base type blocks null in anyOf | `anyOf` + `type` | `type:'string', anyOf: [ {type:'null'}, {minLength:1} ]` | 1 | ❌ | TestIsSchemaNullable_31_BaseTypeBlocksNull_InAnyOf
enum includes null (no type) | `enum` | `enum: [null, 'x']` | 1 | ✅ | TestIsSchemaNullable_31_EnumAllowsNull_NoType
enum includes null but base type excludes | `enum` + base | `type:'string', enum: [null, 'x']` | 1 | ❌ | TestIsSchemaNullable_31_EnumAllowsNull_WithTypeString_Disallowed
not blocks null | `not` | `type: ['string','null'], not: {type:'null'}` | 1 | ❌ | TestIsSchemaNullable_31_NotBlocksNull
empty schema (policy) |  | `{}` |  | ❌ | TestIsSchemaNullable_31_EmptySchema_NotNullableByPolicy
OAS 3.0 nullable true | 3.0 | `{type:'string', nullable:true}` |  | ✅ | TestIsSchemaNullable_30_FallbackTrue
OAS 3.0 default false | 3.0 | `{type:'string'}` |  | ❌ | TestIsSchemaNullable_30_FallbackFalse