### PR TITLE
fix: handle text refs in strict echo handler

### DIFF
--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -531,6 +531,8 @@ type ReusableresponseJSONResponse struct {
 	Headers ReusableresponseResponseHeaders
 }
 
+type UnauthorizedTextResponse string
+
 type JSONExampleRequestObject struct {
 	Body *JSONExampleJSONRequestBody
 }
@@ -792,6 +794,16 @@ type TextExample400Response = BadrequestResponse
 func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
 	w.WriteHeader(400)
 	return nil
+}
+
+type TextExample401TextResponse struct{ UnauthorizedTextResponse }
+
+func (response TextExample401TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(401)
+
+	_, err := w.Write([]byte(response.UnauthorizedTextResponse))
+	return err
 }
 
 type TextExampledefaultResponse struct {
@@ -1524,24 +1536,24 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYS3PbNhD+Kxi0p5QUZccn3hpPJm3T1h3ZPnV8gIilhIQE0MVStEaj/94BQb0sWpUS",
-	"PTqZ3PhY7C6+b3ex2BnPTGmNBk2OpzOO4KzRDpqXoZAI/1TgyL9JcBkqS8ponvJ3Qg7af/OII1RODAtY",
-	"LPfymdEEulkqrC1UJvzS5JPz62fcZWMohX/6ESHnKf8hWbmShL8ugWdR2gL4fD6PXnhw95FHfAxCAjbe",
-	"hserTd00tcBT7giVHnGvJIhdd4opTTAC9Na8aOuEF1j4kc64RWMBSQWMJqKooNtS+8UMP0FGYQdK52Yb",
-	"y1ujSSjtmFR5DgiaWAse8zocc5W1BgkkG06Zt5ARc4ATQB5xUuQd4/fr31nrsOMRnwC6YOiq1+/1PV/G",
-	"ghZW8ZS/bT5F3AoaNxtaEmRNF++/3d/9yZRjoiJTClKZKIopKwW6sShAMqXJeBerjFyPN5awIf5X2a5+",
-	"30Lpo6YJoHdGTk8RME1croXzdb9/pricR/wmGOvSsXQqWUuwRk0uqqID80f9WZtaM0A02O4sKauClBVI",
-	"61xtov3HQmQfyJf6ktxgGUtB4kSoH8vSpYGPEQpBIPcgYBAkD+NhTf1JWfgaOxfloK3HnXXqfmxqx8am",
-	"ZmSYBFGwWtGYLRa+KLBKM8Gc0qMC2MKpqJPMAtpj72ctB+1eHryOk9ezaEPLc1zXddwkUIUF6MzIL6Mw",
-	"4qoUI0isHm0u97oF8ZQPp+RDdvuAO1IiR5zgmRJbCKV3n95nKunfkT5aYod0RWi6EhmPTPwZprVBGVuB",
-	"ogQCdMnMW597xSPoSOW/lpIsE5oNgWlRgmQiJ0D2wbBWpdtK2UFr94P5GERWqpqWZ/mS/j3jHpKmDeIR",
-	"9wZ4GlAJea3Qk05YQbQDtqf/jM+vImCBZmi24w1T3WVwUaKW0CHkzpfELuY68AuWBmsSl2nadkfc1vXj",
-	"HGeQZ/L1o/8Bnvdqu45Y+s6d24cCVoWPr2PWrtoHti+spHugOFESTFLamwM1XwxUZyFTuQIZt7uIg2+v",
-	"lYRbozME2myB/JVOG2JLZf6mSWNgAYGIOcNqYGXliFnhHFPUVJFChduqhK3i8bjy7DZYeliV012svjkR",
-	"p28uxehN/+rwJW9PHDcbrcwr+Tj4/X2QOfTOfrSe6cCO73h2L5TO/pISrw21ulP4lyCwOtMzUBPfEWnJ",
-	"EKhCDZJNlFgMYrZys1WworWrFwpurLqhxYDtkIYo2qnrmke7hnBP3/CI6JSjy3PFaaXVrlHho//N2h76",
-	"5dmgjP6fDgJFQYBakJrAT8e5QW5rMRru8ibTXrAc7Wnh6duLqnnEw+w6lKAKC18niGyaJGHm3XO1GI0A",
-	"e8okwiqPwr8BAAD//4h9qqfAGAAA",
+	"H4sIAAAAAAAC/+xYTXPbNhP+Kxi87yklTdvJibfGk0nbtHVHtk8dH1bEUkJCAiiwFK1q9N87IEh90rKU",
+	"SFYn0xs/sM8unv3AYmc806XRChU5ns64RWe0cti8DEFY/KtCR/5NoMusNCS14il/D2LQ/ptH3GLlYFhg",
+	"J+7XZ1oRqkYUjClkBl40+ey8/Iy7bIwl+Kf/W8x5yv+XLE1Jwl+X4BOUpkA+n8+jDQtuP/GIjxEE2sba",
+	"8Hi1jk1TgzzljqxUI+5BwrLr3mVSEY7Qem3ziFcKKhprK/9GsbEhwidKTAFS7Va3ZfTDKqb/3W7UC3d7",
+	"TWfcWG3Qkgx+mEBRYf9u2i96+BkzCgqlyvW2v260IpDKMSHzHC0qYu1+mMdwzFXGaEso2HDKvIaMmEM7",
+	"QcsjTpK8Yfxu9TtrDXY84hO0Lii6uri8uPQxoQ0qMJKn/G3zKeIGaNxsaBEERvfF1i93t78z6RhUpEsg",
+	"mUFRTFkJ1o2hQMGkIu1NrDJyF7zRZJvg+lm00h9aKn1kNkH6XovpKYKyif2VlLm+vHyl2J9H/F1Q1oex",
+	"MCpZSeIGJoeq6OH8QX1RulYMrdVdAiRlVZA0YGnVV+ts/9Yt2YfyBV6Sa1vGAghOxPqxNJ2b+NhiARTq",
+	"zwsOGISVh/lhBf6kXvgWPWf1QVuPe+vU3VjXjo11zUgzgVCwWtKYdYIbBVYqBsxJNSqQdUZFvc4ssD1a",
+	"f1Ri0O7l3mOcvJ5FayhPcV3XcZNAlS1QZVp8nQsjLksYYWLUaF3cYwPxlA+n5EN2+4A7UiJH+x/Zr1PS",
+	"/2P6aIkd0tVi05WIeKTjLzittRWxAQslElqXzLz2uQceYU8q/7FYyTJQbIhMQYmCQU5o2UfNWki3lbKD",
+	"Vu9H/SksWUI1Lc/iJf1zxj0lTRvEI+4V8DSwEvJaWu90shVGO2h7fDE+v8kBHZuhoY/XVPWXwa5ELaiz",
+	"mDtfEvs818Nf0DRYWXGepm13xG1dcV7jDPKefP7ov8envdquI5a+185tL3L1ssjaVe1glqvw8XmiW6l9",
+	"uP7K8rsH9RMpUCeleXcg8pnap0o5g5nMJYq43UUcbHuujtxolVmk9b7J3wOVJrYA89dTGiMLDETMaVYj",
+	"KytHzIBzTFJTegoZrrgCtyrOw9Kym6DpflmDd3n1zYl8+uZcHt0rtzZF3p44btb6n2fycfDrh7Dm0Iv+",
+	"0RqtA9vE4+k9Uzr7m028Mm3rT+GfwoJlI5ChnPg2SglmkSqrULCJhG56s5WbLcDSrX0NVDBj2UJ1k79D",
+	"uqhoJ9Y1j3ZNBx+/47nSaWeqrxOnlZK75osP/jdrG+/Ns0Fq9S+dHkJBaBWQnOAPx7l2bqNohbd5k2kb",
+	"Xo721PD4/UXVPOJh4B1KUGULXyeITJokYVB+4WoYjdBeSJ2AkZ6FfwIAAP//A81wLVkZAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -277,6 +277,8 @@ type ReusableresponseJSONResponse struct {
 	Headers ReusableresponseResponseHeaders
 }
 
+type UnauthorizedTextResponse string
+
 type JSONExampleRequestObject struct {
 	Body *JSONExampleJSONRequestBody
 }
@@ -538,6 +540,16 @@ type TextExample400Response = BadrequestResponse
 func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
 	w.WriteHeader(400)
 	return nil
+}
+
+type TextExample401TextResponse struct{ UnauthorizedTextResponse }
+
+func (response TextExample401TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(401)
+
+	_, err := w.Write([]byte(response.UnauthorizedTextResponse))
+	return err
 }
 
 type TextExampledefaultResponse struct {
@@ -1227,24 +1239,24 @@ func (sh *strictHandler) UnionExample(ctx echo.Context) error {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYS3PbNhD+Kxi0p5QUZccn3hpPJm3T1h3ZPnV8gIilhIQE0MVStEaj/94BQb0sWpUS",
-	"PTqZ3PhY7C6+b3ex2BnPTGmNBk2OpzOO4KzRDpqXoZAI/1TgyL9JcBkqS8ponvJ3Qg7af/OII1RODAtY",
-	"LPfymdEEulkqrC1UJvzS5JPz62fcZWMohX/6ESHnKf8hWbmShL8ugWdR2gL4fD6PXnhw95FHfAxCAjbe",
-	"hserTd00tcBT7giVHnGvJIhdd4opTTAC9Na8aOuEF1j4kc64RWMBSQWMJqKooNtS+8UMP0FGYQdK52Yb",
-	"y1ujSSjtmFR5DgiaWAse8zocc5W1BgkkG06Zt5ARc4ATQB5xUuQd4/fr31nrsOMRnwC6YOiq1+/1PV/G",
-	"ghZW8ZS/bT5F3AoaNxtaEmRNF++/3d/9yZRjoiJTClKZKIopKwW6sShAMqXJeBerjFyPN5awIf5X2a5+",
-	"30Lpo6YJoHdGTk8RME1croXzdb9/pricR/wmGOvSsXQqWUuwRk0uqqID80f9WZtaM0A02O4sKauClBVI",
-	"61xtov3HQmQfyJf6ktxgGUtB4kSoH8vSpYGPEQpBIPcgYBAkD+NhTf1JWfgaOxfloK3HnXXqfmxqx8am",
-	"ZmSYBFGwWtGYLRa+KLBKM8Gc0qMC2MKpqJPMAtpj72ctB+1eHryOk9ezaEPLc1zXddwkUIUF6MzIL6Mw",
-	"4qoUI0isHm0u97oF8ZQPp+RDdvuAO1IiR5zgmRJbCKV3n95nKunfkT5aYod0RWi6EhmPTPwZprVBGVuB",
-	"ogQCdMnMW597xSPoSOW/lpIsE5oNgWlRgmQiJ0D2wbBWpdtK2UFr94P5GERWqpqWZ/mS/j3jHpKmDeIR",
-	"9wZ4GlAJea3Qk05YQbQDtqf/jM+vImCBZmi24w1T3WVwUaKW0CHkzpfELuY68AuWBmsSl2nadkfc1vXj",
-	"HGeQZ/L1o/8Bnvdqu45Y+s6d24cCVoWPr2PWrtoHti+spHugOFESTFLamwM1XwxUZyFTuQIZt7uIg2+v",
-	"lYRbozME2myB/JVOG2JLZf6mSWNgAYGIOcNqYGXliFnhHFPUVJFChduqhK3i8bjy7DZYeliV012svjkR",
-	"p28uxehN/+rwJW9PHDcbrcwr+Tj4/X2QOfTOfrSe6cCO73h2L5TO/pISrw21ulP4lyCwOtMzUBPfEWnJ",
-	"EKhCDZJNlFgMYrZys1WworWrFwpurLqhxYDtkIYo2qnrmke7hnBP3/CI6JSjy3PFaaXVrlHho//N2h76",
-	"5dmgjP6fDgJFQYBakJrAT8e5QW5rMRru8ibTXrAc7Wnh6duLqnnEw+w6lKAKC18niGyaJGHm3XO1GI0A",
-	"e8okwiqPwr8BAAD//4h9qqfAGAAA",
+	"H4sIAAAAAAAC/+xYTXPbNhP+Kxi87yklTdvJibfGk0nbtHVHtk8dH1bEUkJCAiiwFK1q9N87IEh90rKU",
+	"SFYn0xs/sM8unv3AYmc806XRChU5ns64RWe0cti8DEFY/KtCR/5NoMusNCS14il/D2LQ/ptH3GLlYFhg",
+	"J+7XZ1oRqkYUjClkBl40+ey8/Iy7bIwl+Kf/W8x5yv+XLE1Jwl+X4BOUpkA+n8+jDQtuP/GIjxEE2sba",
+	"8Hi1jk1TgzzljqxUI+5BwrLr3mVSEY7Qem3ziFcKKhprK/9GsbEhwidKTAFS7Va3ZfTDKqb/3W7UC3d7",
+	"TWfcWG3Qkgx+mEBRYf9u2i96+BkzCgqlyvW2v260IpDKMSHzHC0qYu1+mMdwzFXGaEso2HDKvIaMmEM7",
+	"QcsjTpK8Yfxu9TtrDXY84hO0Lii6uri8uPQxoQ0qMJKn/G3zKeIGaNxsaBEERvfF1i93t78z6RhUpEsg",
+	"mUFRTFkJ1o2hQMGkIu1NrDJyF7zRZJvg+lm00h9aKn1kNkH6XovpKYKyif2VlLm+vHyl2J9H/F1Q1oex",
+	"MCpZSeIGJoeq6OH8QX1RulYMrdVdAiRlVZA0YGnVV+ts/9Yt2YfyBV6Sa1vGAghOxPqxNJ2b+NhiARTq",
+	"zwsOGISVh/lhBf6kXvgWPWf1QVuPe+vU3VjXjo11zUgzgVCwWtKYdYIbBVYqBsxJNSqQdUZFvc4ssD1a",
+	"f1Ri0O7l3mOcvJ5FayhPcV3XcZNAlS1QZVp8nQsjLksYYWLUaF3cYwPxlA+n5EN2+4A7UiJH+x/Zr1PS",
+	"/2P6aIkd0tVi05WIeKTjLzittRWxAQslElqXzLz2uQceYU8q/7FYyTJQbIhMQYmCQU5o2UfNWki3lbKD",
+	"Vu9H/SksWUI1Lc/iJf1zxj0lTRvEI+4V8DSwEvJaWu90shVGO2h7fDE+v8kBHZuhoY/XVPWXwa5ELaiz",
+	"mDtfEvs818Nf0DRYWXGepm13xG1dcV7jDPKefP7ov8envdquI5a+185tL3L1ssjaVe1glqvw8XmiW6l9",
+	"uP7K8rsH9RMpUCeleXcg8pnap0o5g5nMJYq43UUcbHuujtxolVmk9b7J3wOVJrYA89dTGiMLDETMaVYj",
+	"KytHzIBzTFJTegoZrrgCtyrOw9Kym6DpflmDd3n1zYl8+uZcHt0rtzZF3p44btb6n2fycfDrh7Dm0Iv+",
+	"0RqtA9vE4+k9Uzr7m028Mm3rT+GfwoJlI5ChnPg2SglmkSqrULCJhG56s5WbLcDSrX0NVDBj2UJ1k79D",
+	"uqhoJ9Y1j3ZNBx+/47nSaWeqrxOnlZK75osP/jdrG+/Ns0Fq9S+dHkJBaBWQnOAPx7l2bqNohbd5k2kb",
+	"Xo721PD4/UXVPOJh4B1KUGULXyeITJokYVB+4WoYjdBeSJ2AkZ6FfwIAAP//A81wLVkZAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/fiber/server.gen.go
+++ b/internal/test/strict-server/fiber/server.gen.go
@@ -248,6 +248,8 @@ type ReusableresponseJSONResponse struct {
 	Headers ReusableresponseResponseHeaders
 }
 
+type UnauthorizedTextResponse string
+
 type JSONExampleRequestObject struct {
 	Body *JSONExampleJSONRequestBody
 }
@@ -509,6 +511,16 @@ type TextExample400Response = BadrequestResponse
 func (response TextExample400Response) VisitTextExampleResponse(ctx *fiber.Ctx) error {
 	ctx.Status(400)
 	return nil
+}
+
+type TextExample401TextResponse struct{ UnauthorizedTextResponse }
+
+func (response TextExample401TextResponse) VisitTextExampleResponse(ctx *fiber.Ctx) error {
+	ctx.Response().Header.Set("Content-Type", "text/plain")
+	ctx.Status(401)
+
+	_, err := ctx.WriteString(string(response.UnauthorizedTextResponse))
+	return err
 }
 
 type TextExampledefaultResponse struct {
@@ -1202,24 +1214,24 @@ func (sh *strictHandler) UnionExample(ctx *fiber.Ctx) error {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYS3PbNhD+Kxi0p5QUZccn3hpPJm3T1h3ZPnV8gIilhIQE0MVStEaj/94BQb0sWpUS",
-	"PTqZ3PhY7C6+b3ex2BnPTGmNBk2OpzOO4KzRDpqXoZAI/1TgyL9JcBkqS8ponvJ3Qg7af/OII1RODAtY",
-	"LPfymdEEulkqrC1UJvzS5JPz62fcZWMohX/6ESHnKf8hWbmShL8ugWdR2gL4fD6PXnhw95FHfAxCAjbe",
-	"hserTd00tcBT7giVHnGvJIhdd4opTTAC9Na8aOuEF1j4kc64RWMBSQWMJqKooNtS+8UMP0FGYQdK52Yb",
-	"y1ujSSjtmFR5DgiaWAse8zocc5W1BgkkG06Zt5ARc4ATQB5xUuQd4/fr31nrsOMRnwC6YOiq1+/1PV/G",
-	"ghZW8ZS/bT5F3AoaNxtaEmRNF++/3d/9yZRjoiJTClKZKIopKwW6sShAMqXJeBerjFyPN5awIf5X2a5+",
-	"30Lpo6YJoHdGTk8RME1croXzdb9/pricR/wmGOvSsXQqWUuwRk0uqqID80f9WZtaM0A02O4sKauClBVI",
-	"61xtov3HQmQfyJf6ktxgGUtB4kSoH8vSpYGPEQpBIPcgYBAkD+NhTf1JWfgaOxfloK3HnXXqfmxqx8am",
-	"ZmSYBFGwWtGYLRa+KLBKM8Gc0qMC2MKpqJPMAtpj72ctB+1eHryOk9ezaEPLc1zXddwkUIUF6MzIL6Mw",
-	"4qoUI0isHm0u97oF8ZQPp+RDdvuAO1IiR5zgmRJbCKV3n95nKunfkT5aYod0RWi6EhmPTPwZprVBGVuB",
-	"ogQCdMnMW597xSPoSOW/lpIsE5oNgWlRgmQiJ0D2wbBWpdtK2UFr94P5GERWqpqWZ/mS/j3jHpKmDeIR",
-	"9wZ4GlAJea3Qk05YQbQDtqf/jM+vImCBZmi24w1T3WVwUaKW0CHkzpfELuY68AuWBmsSl2nadkfc1vXj",
-	"HGeQZ/L1o/8Bnvdqu45Y+s6d24cCVoWPr2PWrtoHti+spHugOFESTFLamwM1XwxUZyFTuQIZt7uIg2+v",
-	"lYRbozME2myB/JVOG2JLZf6mSWNgAYGIOcNqYGXliFnhHFPUVJFChduqhK3i8bjy7DZYeliV012svjkR",
-	"p28uxehN/+rwJW9PHDcbrcwr+Tj4/X2QOfTOfrSe6cCO73h2L5TO/pISrw21ulP4lyCwOtMzUBPfEWnJ",
-	"EKhCDZJNlFgMYrZys1WworWrFwpurLqhxYDtkIYo2qnrmke7hnBP3/CI6JSjy3PFaaXVrlHho//N2h76",
-	"5dmgjP6fDgJFQYBakJrAT8e5QW5rMRru8ibTXrAc7Wnh6duLqnnEw+w6lKAKC18niGyaJGHm3XO1GI0A",
-	"e8okwiqPwr8BAAD//4h9qqfAGAAA",
+	"H4sIAAAAAAAC/+xYTXPbNhP+Kxi87yklTdvJibfGk0nbtHVHtk8dH1bEUkJCAiiwFK1q9N87IEh90rKU",
+	"SFYn0xs/sM8unv3AYmc806XRChU5ns64RWe0cti8DEFY/KtCR/5NoMusNCS14il/D2LQ/ptH3GLlYFhg",
+	"J+7XZ1oRqkYUjClkBl40+ey8/Iy7bIwl+Kf/W8x5yv+XLE1Jwl+X4BOUpkA+n8+jDQtuP/GIjxEE2sba",
+	"8Hi1jk1TgzzljqxUI+5BwrLr3mVSEY7Qem3ziFcKKhprK/9GsbEhwidKTAFS7Va3ZfTDKqb/3W7UC3d7",
+	"TWfcWG3Qkgx+mEBRYf9u2i96+BkzCgqlyvW2v260IpDKMSHzHC0qYu1+mMdwzFXGaEso2HDKvIaMmEM7",
+	"QcsjTpK8Yfxu9TtrDXY84hO0Lii6uri8uPQxoQ0qMJKn/G3zKeIGaNxsaBEERvfF1i93t78z6RhUpEsg",
+	"mUFRTFkJ1o2hQMGkIu1NrDJyF7zRZJvg+lm00h9aKn1kNkH6XovpKYKyif2VlLm+vHyl2J9H/F1Q1oex",
+	"MCpZSeIGJoeq6OH8QX1RulYMrdVdAiRlVZA0YGnVV+ts/9Yt2YfyBV6Sa1vGAghOxPqxNJ2b+NhiARTq",
+	"zwsOGISVh/lhBf6kXvgWPWf1QVuPe+vU3VjXjo11zUgzgVCwWtKYdYIbBVYqBsxJNSqQdUZFvc4ssD1a",
+	"f1Ri0O7l3mOcvJ5FayhPcV3XcZNAlS1QZVp8nQsjLksYYWLUaF3cYwPxlA+n5EN2+4A7UiJH+x/Zr1PS",
+	"/2P6aIkd0tVi05WIeKTjLzittRWxAQslElqXzLz2uQceYU8q/7FYyTJQbIhMQYmCQU5o2UfNWki3lbKD",
+	"Vu9H/SksWUI1Lc/iJf1zxj0lTRvEI+4V8DSwEvJaWu90shVGO2h7fDE+v8kBHZuhoY/XVPWXwa5ELaiz",
+	"mDtfEvs818Nf0DRYWXGepm13xG1dcV7jDPKefP7ov8envdquI5a+185tL3L1ssjaVe1glqvw8XmiW6l9",
+	"uP7K8rsH9RMpUCeleXcg8pnap0o5g5nMJYq43UUcbHuujtxolVmk9b7J3wOVJrYA89dTGiMLDETMaVYj",
+	"KytHzIBzTFJTegoZrrgCtyrOw9Kym6DpflmDd3n1zYl8+uZcHt0rtzZF3p44btb6n2fycfDrh7Dm0Iv+",
+	"0RqtA9vE4+k9Uzr7m028Mm3rT+GfwoJlI5ChnPg2SglmkSqrULCJhG56s5WbLcDSrX0NVDBj2UJ1k79D",
+	"uqhoJ9Y1j3ZNBx+/47nSaWeqrxOnlZK75osP/jdrG+/Ns0Fq9S+dHkJBaBWQnOAPx7l2bqNohbd5k2kb",
+	"Xo721PD4/UXVPOJh4B1KUGULXyeITJokYVB+4WoYjdBeSJ2AkZ6FfwIAAP//A81wLVkZAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -342,6 +342,8 @@ type ReusableresponseJSONResponse struct {
 	Headers ReusableresponseResponseHeaders
 }
 
+type UnauthorizedTextResponse string
+
 type JSONExampleRequestObject struct {
 	Body *JSONExampleJSONRequestBody
 }
@@ -603,6 +605,16 @@ type TextExample400Response = BadrequestResponse
 func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
 	w.WriteHeader(400)
 	return nil
+}
+
+type TextExample401TextResponse struct{ UnauthorizedTextResponse }
+
+func (response TextExample401TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(401)
+
+	_, err := w.Write([]byte(response.UnauthorizedTextResponse))
+	return err
 }
 
 type TextExampledefaultResponse struct {
@@ -1335,24 +1347,24 @@ func (sh *strictHandler) UnionExample(ctx *gin.Context) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYS3PbNhD+Kxi0p5QUZccn3hpPJm3T1h3ZPnV8gIilhIQE0MVStEaj/94BQb0sWpUS",
-	"PTqZ3PhY7C6+b3ex2BnPTGmNBk2OpzOO4KzRDpqXoZAI/1TgyL9JcBkqS8ponvJ3Qg7af/OII1RODAtY",
-	"LPfymdEEulkqrC1UJvzS5JPz62fcZWMohX/6ESHnKf8hWbmShL8ugWdR2gL4fD6PXnhw95FHfAxCAjbe",
-	"hserTd00tcBT7giVHnGvJIhdd4opTTAC9Na8aOuEF1j4kc64RWMBSQWMJqKooNtS+8UMP0FGYQdK52Yb",
-	"y1ujSSjtmFR5DgiaWAse8zocc5W1BgkkG06Zt5ARc4ATQB5xUuQd4/fr31nrsOMRnwC6YOiq1+/1PV/G",
-	"ghZW8ZS/bT5F3AoaNxtaEmRNF++/3d/9yZRjoiJTClKZKIopKwW6sShAMqXJeBerjFyPN5awIf5X2a5+",
-	"30Lpo6YJoHdGTk8RME1croXzdb9/pricR/wmGOvSsXQqWUuwRk0uqqID80f9WZtaM0A02O4sKauClBVI",
-	"61xtov3HQmQfyJf6ktxgGUtB4kSoH8vSpYGPEQpBIPcgYBAkD+NhTf1JWfgaOxfloK3HnXXqfmxqx8am",
-	"ZmSYBFGwWtGYLRa+KLBKM8Gc0qMC2MKpqJPMAtpj72ctB+1eHryOk9ezaEPLc1zXddwkUIUF6MzIL6Mw",
-	"4qoUI0isHm0u97oF8ZQPp+RDdvuAO1IiR5zgmRJbCKV3n95nKunfkT5aYod0RWi6EhmPTPwZprVBGVuB",
-	"ogQCdMnMW597xSPoSOW/lpIsE5oNgWlRgmQiJ0D2wbBWpdtK2UFr94P5GERWqpqWZ/mS/j3jHpKmDeIR",
-	"9wZ4GlAJea3Qk05YQbQDtqf/jM+vImCBZmi24w1T3WVwUaKW0CHkzpfELuY68AuWBmsSl2nadkfc1vXj",
-	"HGeQZ/L1o/8Bnvdqu45Y+s6d24cCVoWPr2PWrtoHti+spHugOFESTFLamwM1XwxUZyFTuQIZt7uIg2+v",
-	"lYRbozME2myB/JVOG2JLZf6mSWNgAYGIOcNqYGXliFnhHFPUVJFChduqhK3i8bjy7DZYeliV012svjkR",
-	"p28uxehN/+rwJW9PHDcbrcwr+Tj4/X2QOfTOfrSe6cCO73h2L5TO/pISrw21ulP4lyCwOtMzUBPfEWnJ",
-	"EKhCDZJNlFgMYrZys1WworWrFwpurLqhxYDtkIYo2qnrmke7hnBP3/CI6JSjy3PFaaXVrlHho//N2h76",
-	"5dmgjP6fDgJFQYBakJrAT8e5QW5rMRru8ibTXrAc7Wnh6duLqnnEw+w6lKAKC18niGyaJGHm3XO1GI0A",
-	"e8okwiqPwr8BAAD//4h9qqfAGAAA",
+	"H4sIAAAAAAAC/+xYTXPbNhP+Kxi87yklTdvJibfGk0nbtHVHtk8dH1bEUkJCAiiwFK1q9N87IEh90rKU",
+	"SFYn0xs/sM8unv3AYmc806XRChU5ns64RWe0cti8DEFY/KtCR/5NoMusNCS14il/D2LQ/ptH3GLlYFhg",
+	"J+7XZ1oRqkYUjClkBl40+ey8/Iy7bIwl+Kf/W8x5yv+XLE1Jwl+X4BOUpkA+n8+jDQtuP/GIjxEE2sba",
+	"8Hi1jk1TgzzljqxUI+5BwrLr3mVSEY7Qem3ziFcKKhprK/9GsbEhwidKTAFS7Va3ZfTDKqb/3W7UC3d7",
+	"TWfcWG3Qkgx+mEBRYf9u2i96+BkzCgqlyvW2v260IpDKMSHzHC0qYu1+mMdwzFXGaEso2HDKvIaMmEM7",
+	"QcsjTpK8Yfxu9TtrDXY84hO0Lii6uri8uPQxoQ0qMJKn/G3zKeIGaNxsaBEERvfF1i93t78z6RhUpEsg",
+	"mUFRTFkJ1o2hQMGkIu1NrDJyF7zRZJvg+lm00h9aKn1kNkH6XovpKYKyif2VlLm+vHyl2J9H/F1Q1oex",
+	"MCpZSeIGJoeq6OH8QX1RulYMrdVdAiRlVZA0YGnVV+ts/9Yt2YfyBV6Sa1vGAghOxPqxNJ2b+NhiARTq",
+	"zwsOGISVh/lhBf6kXvgWPWf1QVuPe+vU3VjXjo11zUgzgVCwWtKYdYIbBVYqBsxJNSqQdUZFvc4ssD1a",
+	"f1Ri0O7l3mOcvJ5FayhPcV3XcZNAlS1QZVp8nQsjLksYYWLUaF3cYwPxlA+n5EN2+4A7UiJH+x/Zr1PS",
+	"/2P6aIkd0tVi05WIeKTjLzittRWxAQslElqXzLz2uQceYU8q/7FYyTJQbIhMQYmCQU5o2UfNWki3lbKD",
+	"Vu9H/SksWUI1Lc/iJf1zxj0lTRvEI+4V8DSwEvJaWu90shVGO2h7fDE+v8kBHZuhoY/XVPWXwa5ELaiz",
+	"mDtfEvs818Nf0DRYWXGepm13xG1dcV7jDPKefP7ov8envdquI5a+185tL3L1ssjaVe1glqvw8XmiW6l9",
+	"uP7K8rsH9RMpUCeleXcg8pnap0o5g5nMJYq43UUcbHuujtxolVmk9b7J3wOVJrYA89dTGiMLDETMaVYj",
+	"KytHzIBzTFJTegoZrrgCtyrOw9Kym6DpflmDd3n1zYl8+uZcHt0rtzZF3p44btb6n2fycfDrh7Dm0Iv+",
+	"0RqtA9vE4+k9Uzr7m028Mm3rT+GfwoJlI5ChnPg2SglmkSqrULCJhG56s5WbLcDSrX0NVDBj2UJ1k79D",
+	"uqhoJ9Y1j3ZNBx+/47nSaWeqrxOnlZK75osP/jdrG+/Ns0Fq9S+dHkJBaBWQnOAPx7l2bqNohbd5k2kb",
+	"Xo721PD4/UXVPOJh4B1KUGULXyeITJokYVB+4WoYjdBeSJ2AkZ6FfwIAAP//A81wLVkZAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/gorilla/server.gen.go
+++ b/internal/test/strict-server/gorilla/server.gen.go
@@ -454,6 +454,8 @@ type ReusableresponseJSONResponse struct {
 	Headers ReusableresponseResponseHeaders
 }
 
+type UnauthorizedTextResponse string
+
 type JSONExampleRequestObject struct {
 	Body *JSONExampleJSONRequestBody
 }
@@ -715,6 +717,16 @@ type TextExample400Response = BadrequestResponse
 func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
 	w.WriteHeader(400)
 	return nil
+}
+
+type TextExample401TextResponse struct{ UnauthorizedTextResponse }
+
+func (response TextExample401TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(401)
+
+	_, err := w.Write([]byte(response.UnauthorizedTextResponse))
+	return err
 }
 
 type TextExampledefaultResponse struct {
@@ -1447,24 +1459,24 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYS3PbNhD+Kxi0p5QUZccn3hpPJm3T1h3ZPnV8gIilhIQE0MVStEaj/94BQb0sWpUS",
-	"PTqZ3PhY7C6+b3ex2BnPTGmNBk2OpzOO4KzRDpqXoZAI/1TgyL9JcBkqS8ponvJ3Qg7af/OII1RODAtY",
-	"LPfymdEEulkqrC1UJvzS5JPz62fcZWMohX/6ESHnKf8hWbmShL8ugWdR2gL4fD6PXnhw95FHfAxCAjbe",
-	"hserTd00tcBT7giVHnGvJIhdd4opTTAC9Na8aOuEF1j4kc64RWMBSQWMJqKooNtS+8UMP0FGYQdK52Yb",
-	"y1ujSSjtmFR5DgiaWAse8zocc5W1BgkkG06Zt5ARc4ATQB5xUuQd4/fr31nrsOMRnwC6YOiq1+/1PV/G",
-	"ghZW8ZS/bT5F3AoaNxtaEmRNF++/3d/9yZRjoiJTClKZKIopKwW6sShAMqXJeBerjFyPN5awIf5X2a5+",
-	"30Lpo6YJoHdGTk8RME1croXzdb9/pricR/wmGOvSsXQqWUuwRk0uqqID80f9WZtaM0A02O4sKauClBVI",
-	"61xtov3HQmQfyJf6ktxgGUtB4kSoH8vSpYGPEQpBIPcgYBAkD+NhTf1JWfgaOxfloK3HnXXqfmxqx8am",
-	"ZmSYBFGwWtGYLRa+KLBKM8Gc0qMC2MKpqJPMAtpj72ctB+1eHryOk9ezaEPLc1zXddwkUIUF6MzIL6Mw",
-	"4qoUI0isHm0u97oF8ZQPp+RDdvuAO1IiR5zgmRJbCKV3n95nKunfkT5aYod0RWi6EhmPTPwZprVBGVuB",
-	"ogQCdMnMW597xSPoSOW/lpIsE5oNgWlRgmQiJ0D2wbBWpdtK2UFr94P5GERWqpqWZ/mS/j3jHpKmDeIR",
-	"9wZ4GlAJea3Qk05YQbQDtqf/jM+vImCBZmi24w1T3WVwUaKW0CHkzpfELuY68AuWBmsSl2nadkfc1vXj",
-	"HGeQZ/L1o/8Bnvdqu45Y+s6d24cCVoWPr2PWrtoHti+spHugOFESTFLamwM1XwxUZyFTuQIZt7uIg2+v",
-	"lYRbozME2myB/JVOG2JLZf6mSWNgAYGIOcNqYGXliFnhHFPUVJFChduqhK3i8bjy7DZYeliV012svjkR",
-	"p28uxehN/+rwJW9PHDcbrcwr+Tj4/X2QOfTOfrSe6cCO73h2L5TO/pISrw21ulP4lyCwOtMzUBPfEWnJ",
-	"EKhCDZJNlFgMYrZys1WworWrFwpurLqhxYDtkIYo2qnrmke7hnBP3/CI6JSjy3PFaaXVrlHho//N2h76",
-	"5dmgjP6fDgJFQYBakJrAT8e5QW5rMRru8ibTXrAc7Wnh6duLqnnEw+w6lKAKC18niGyaJGHm3XO1GI0A",
-	"e8okwiqPwr8BAAD//4h9qqfAGAAA",
+	"H4sIAAAAAAAC/+xYTXPbNhP+Kxi87yklTdvJibfGk0nbtHVHtk8dH1bEUkJCAiiwFK1q9N87IEh90rKU",
+	"SFYn0xs/sM8unv3AYmc806XRChU5ns64RWe0cti8DEFY/KtCR/5NoMusNCS14il/D2LQ/ptH3GLlYFhg",
+	"J+7XZ1oRqkYUjClkBl40+ey8/Iy7bIwl+Kf/W8x5yv+XLE1Jwl+X4BOUpkA+n8+jDQtuP/GIjxEE2sba",
+	"8Hi1jk1TgzzljqxUI+5BwrLr3mVSEY7Qem3ziFcKKhprK/9GsbEhwidKTAFS7Va3ZfTDKqb/3W7UC3d7",
+	"TWfcWG3Qkgx+mEBRYf9u2i96+BkzCgqlyvW2v260IpDKMSHzHC0qYu1+mMdwzFXGaEso2HDKvIaMmEM7",
+	"QcsjTpK8Yfxu9TtrDXY84hO0Lii6uri8uPQxoQ0qMJKn/G3zKeIGaNxsaBEERvfF1i93t78z6RhUpEsg",
+	"mUFRTFkJ1o2hQMGkIu1NrDJyF7zRZJvg+lm00h9aKn1kNkH6XovpKYKyif2VlLm+vHyl2J9H/F1Q1oex",
+	"MCpZSeIGJoeq6OH8QX1RulYMrdVdAiRlVZA0YGnVV+ts/9Yt2YfyBV6Sa1vGAghOxPqxNJ2b+NhiARTq",
+	"zwsOGISVh/lhBf6kXvgWPWf1QVuPe+vU3VjXjo11zUgzgVCwWtKYdYIbBVYqBsxJNSqQdUZFvc4ssD1a",
+	"f1Ri0O7l3mOcvJ5FayhPcV3XcZNAlS1QZVp8nQsjLksYYWLUaF3cYwPxlA+n5EN2+4A7UiJH+x/Zr1PS",
+	"/2P6aIkd0tVi05WIeKTjLzittRWxAQslElqXzLz2uQceYU8q/7FYyTJQbIhMQYmCQU5o2UfNWki3lbKD",
+	"Vu9H/SksWUI1Lc/iJf1zxj0lTRvEI+4V8DSwEvJaWu90shVGO2h7fDE+v8kBHZuhoY/XVPWXwa5ELaiz",
+	"mDtfEvs818Nf0DRYWXGepm13xG1dcV7jDPKefP7ov8envdquI5a+185tL3L1ssjaVe1glqvw8XmiW6l9",
+	"uP7K8rsH9RMpUCeleXcg8pnap0o5g5nMJYq43UUcbHuujtxolVmk9b7J3wOVJrYA89dTGiMLDETMaVYj",
+	"KytHzIBzTFJTegoZrrgCtyrOw9Kym6DpflmDd3n1zYl8+uZcHt0rtzZF3p44btb6n2fycfDrh7Dm0Iv+",
+	"0RqtA9vE4+k9Uzr7m028Mm3rT+GfwoJlI5ChnPg2SglmkSqrULCJhG56s5WbLcDSrX0NVDBj2UJ1k79D",
+	"uqhoJ9Y1j3ZNBx+/47nSaWeqrxOnlZK75osP/jdrG+/Ns0Fq9S+dHkJBaBWQnOAPx7l2bqNohbd5k2kb",
+	"Xo721PD4/UXVPOJh4B1KUGULXyeITJokYVB+4WoYjdBeSJ2AkZ6FfwIAAP//A81wLVkZAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/iris/server.gen.go
+++ b/internal/test/strict-server/iris/server.gen.go
@@ -263,6 +263,8 @@ type ReusableresponseJSONResponse struct {
 	Headers ReusableresponseResponseHeaders
 }
 
+type UnauthorizedTextResponse string
+
 type JSONExampleRequestObject struct {
 	Body *JSONExampleJSONRequestBody
 }
@@ -524,6 +526,16 @@ type TextExample400Response = BadrequestResponse
 func (response TextExample400Response) VisitTextExampleResponse(ctx iris.Context) error {
 	ctx.StatusCode(400)
 	return nil
+}
+
+type TextExample401TextResponse string
+
+func (response TextExample401TextResponse) VisitTextExampleResponse(ctx iris.Context) error {
+	ctx.ResponseWriter().Header().Set("Content-Type", "text/plain")
+	ctx.StatusCode(401)
+
+	_, err := ctx.WriteString(string(response))
+	return err
 }
 
 type TextExampledefaultResponse struct {
@@ -1275,24 +1287,24 @@ func (sh *strictHandler) UnionExample(ctx iris.Context) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYS3PbNhD+Kxi0p5QUZccn3hpPJm3T1h3ZPnV8gIilhIQE0MVStEaj/94BQb0sWpUS",
-	"PTqZ3PhY7C6+b3ex2BnPTGmNBk2OpzOO4KzRDpqXoZAI/1TgyL9JcBkqS8ponvJ3Qg7af/OII1RODAtY",
-	"LPfymdEEulkqrC1UJvzS5JPz62fcZWMohX/6ESHnKf8hWbmShL8ugWdR2gL4fD6PXnhw95FHfAxCAjbe",
-	"hserTd00tcBT7giVHnGvJIhdd4opTTAC9Na8aOuEF1j4kc64RWMBSQWMJqKooNtS+8UMP0FGYQdK52Yb",
-	"y1ujSSjtmFR5DgiaWAse8zocc5W1BgkkG06Zt5ARc4ATQB5xUuQd4/fr31nrsOMRnwC6YOiq1+/1PV/G",
-	"ghZW8ZS/bT5F3AoaNxtaEmRNF++/3d/9yZRjoiJTClKZKIopKwW6sShAMqXJeBerjFyPN5awIf5X2a5+",
-	"30Lpo6YJoHdGTk8RME1croXzdb9/pricR/wmGOvSsXQqWUuwRk0uqqID80f9WZtaM0A02O4sKauClBVI",
-	"61xtov3HQmQfyJf6ktxgGUtB4kSoH8vSpYGPEQpBIPcgYBAkD+NhTf1JWfgaOxfloK3HnXXqfmxqx8am",
-	"ZmSYBFGwWtGYLRa+KLBKM8Gc0qMC2MKpqJPMAtpj72ctB+1eHryOk9ezaEPLc1zXddwkUIUF6MzIL6Mw",
-	"4qoUI0isHm0u97oF8ZQPp+RDdvuAO1IiR5zgmRJbCKV3n95nKunfkT5aYod0RWi6EhmPTPwZprVBGVuB",
-	"ogQCdMnMW597xSPoSOW/lpIsE5oNgWlRgmQiJ0D2wbBWpdtK2UFr94P5GERWqpqWZ/mS/j3jHpKmDeIR",
-	"9wZ4GlAJea3Qk05YQbQDtqf/jM+vImCBZmi24w1T3WVwUaKW0CHkzpfELuY68AuWBmsSl2nadkfc1vXj",
-	"HGeQZ/L1o/8Bnvdqu45Y+s6d24cCVoWPr2PWrtoHti+spHugOFESTFLamwM1XwxUZyFTuQIZt7uIg2+v",
-	"lYRbozME2myB/JVOG2JLZf6mSWNgAYGIOcNqYGXliFnhHFPUVJFChduqhK3i8bjy7DZYeliV012svjkR",
-	"p28uxehN/+rwJW9PHDcbrcwr+Tj4/X2QOfTOfrSe6cCO73h2L5TO/pISrw21ulP4lyCwOtMzUBPfEWnJ",
-	"EKhCDZJNlFgMYrZys1WworWrFwpurLqhxYDtkIYo2qnrmke7hnBP3/CI6JSjy3PFaaXVrlHho//N2h76",
-	"5dmgjP6fDgJFQYBakJrAT8e5QW5rMRru8ibTXrAc7Wnh6duLqnnEw+w6lKAKC18niGyaJGHm3XO1GI0A",
-	"e8okwiqPwr8BAAD//4h9qqfAGAAA",
+	"H4sIAAAAAAAC/+xYTXPbNhP+Kxi87yklTdvJibfGk0nbtHVHtk8dH1bEUkJCAiiwFK1q9N87IEh90rKU",
+	"SFYn0xs/sM8unv3AYmc806XRChU5ns64RWe0cti8DEFY/KtCR/5NoMusNCS14il/D2LQ/ptH3GLlYFhg",
+	"J+7XZ1oRqkYUjClkBl40+ey8/Iy7bIwl+Kf/W8x5yv+XLE1Jwl+X4BOUpkA+n8+jDQtuP/GIjxEE2sba",
+	"8Hi1jk1TgzzljqxUI+5BwrLr3mVSEY7Qem3ziFcKKhprK/9GsbEhwidKTAFS7Va3ZfTDKqb/3W7UC3d7",
+	"TWfcWG3Qkgx+mEBRYf9u2i96+BkzCgqlyvW2v260IpDKMSHzHC0qYu1+mMdwzFXGaEso2HDKvIaMmEM7",
+	"QcsjTpK8Yfxu9TtrDXY84hO0Lii6uri8uPQxoQ0qMJKn/G3zKeIGaNxsaBEERvfF1i93t78z6RhUpEsg",
+	"mUFRTFkJ1o2hQMGkIu1NrDJyF7zRZJvg+lm00h9aKn1kNkH6XovpKYKyif2VlLm+vHyl2J9H/F1Q1oex",
+	"MCpZSeIGJoeq6OH8QX1RulYMrdVdAiRlVZA0YGnVV+ts/9Yt2YfyBV6Sa1vGAghOxPqxNJ2b+NhiARTq",
+	"zwsOGISVh/lhBf6kXvgWPWf1QVuPe+vU3VjXjo11zUgzgVCwWtKYdYIbBVYqBsxJNSqQdUZFvc4ssD1a",
+	"f1Ri0O7l3mOcvJ5FayhPcV3XcZNAlS1QZVp8nQsjLksYYWLUaF3cYwPxlA+n5EN2+4A7UiJH+x/Zr1PS",
+	"/2P6aIkd0tVi05WIeKTjLzittRWxAQslElqXzLz2uQceYU8q/7FYyTJQbIhMQYmCQU5o2UfNWki3lbKD",
+	"Vu9H/SksWUI1Lc/iJf1zxj0lTRvEI+4V8DSwEvJaWu90shVGO2h7fDE+v8kBHZuhoY/XVPWXwa5ELaiz",
+	"mDtfEvs818Nf0DRYWXGepm13xG1dcV7jDPKefP7ov8envdquI5a+185tL3L1ssjaVe1glqvw8XmiW6l9",
+	"uP7K8rsH9RMpUCeleXcg8pnap0o5g5nMJYq43UUcbHuujtxolVmk9b7J3wOVJrYA89dTGiMLDETMaVYj",
+	"KytHzIBzTFJTegoZrrgCtyrOw9Kym6DpflmDd3n1zYl8+uZcHt0rtzZF3p44btb6n2fycfDrh7Dm0Iv+",
+	"0RqtA9vE4+k9Uzr7m028Mm3rT+GfwoJlI5ChnPg2SglmkSqrULCJhG56s5WbLcDSrX0NVDBj2UJ1k79D",
+	"uqhoJ9Y1j3ZNBx+/47nSaWeqrxOnlZK75osP/jdrG+/Ns0Fq9S+dHkJBaBWQnOAPx7l2bqNohbd5k2kb",
+	"Xo721PD4/UXVPOJh4B1KUGULXyeITJokYVB+4WoYjdBeSJ2AkZ6FfwIAAP//A81wLVkZAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/strict-schema.yaml
+++ b/internal/test/strict-server/strict-schema.yaml
@@ -100,6 +100,8 @@ paths:
                 type: string
         400:
           $ref: "#/components/responses/badrequest"
+        401:
+          $ref: "#/components/responses/unauthorized"
         default:
           description: Unknown error
   /unknown:
@@ -300,6 +302,13 @@ components:
   responses:
     badrequest:
       description: BadRequest
+    unauthorized:
+      description: Unauthorized
+      content:
+        text/plain:
+          schema:
+            type: string
+
     reusableresponse:
       description: OK
       headers:

--- a/pkg/codegen/templates/strict/strict-fiber-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-fiber-interface.tmpl
@@ -89,7 +89,7 @@
                     {{$hasUnionElements := ne 0 (len .Schema.UnionElements)}}
                     return ctx.JSON(&{{if $hasBodyVar}}response.Body{{else}}response{{end}}{{if $hasUnionElements}}.union{{end}})
                 {{else if eq .NameTag "Text" -}}
-                    _, err := ctx.WriteString(string({{if $hasBodyVar}}response.Body{{else}}response{{end}}))
+                    _, err := ctx.WriteString(string({{if $hasBodyVar}}response.Body{{else}}response{{if and $ref .NameTagOrContentType}}.{{$ref}}{{.NameTagOrContentType}}Response{{end}}{{end}}))
                     return err
                 {{else if eq .NameTag "Formdata" -}}
                     if form, err := runtime.MarshalForm({{if $hasBodyVar}}response.Body{{else}}response{{end}}, nil); err != nil {

--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -89,7 +89,7 @@
                     {{$hasUnionElements := ne 0 (len .Schema.UnionElements)}}
                     return json.NewEncoder(w).Encode(response{{if $hasBodyVar}}.Body{{end}}{{if $hasUnionElements}}.union{{end}})
                 {{else if eq .NameTag "Text" -}}
-                    _, err := w.Write([]byte({{if $hasBodyVar}}response.Body{{else}}response{{end}}))
+                    _, err := w.Write([]byte({{if $hasBodyVar}}response.Body{{else}}response{{if and $ref .NameTagOrContentType}}.{{$ref}}{{.NameTagOrContentType}}Response{{end}}{{end}}))
                     return err
                 {{else if eq .NameTag "Formdata" -}}
                     if form, err := runtime.MarshalForm({{if $hasBodyVar}}response.Body{{else}}response{{end}}, nil); err != nil {


### PR DESCRIPTION
Fixes a problem where the server generated code did not compile for strict echo.

Also adds a test case to trigger the problem and then verify the update

fixes #2076 