### PR TITLE
build: capture `govulncheck` results as Code Scanning alerts

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,35 @@
+name: Determine known CVEs through `govulncheck`
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Mondays at 0000
+    - cron: "0 0 * * 1"
+jobs:
+  check-for-vulnerabilities:
+    name: Check for vulnerabilities using `govulncheck`
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          # to be explicit, we're only checking the top-level `oapi-codegen` package
+          # we are intentionally NOT intending to keep on top of security updates in `internal/test` or `examples`, or any submodules thereof
+          go-package: ./...
+          # NOTE that we want to produce the SARIF-formatted report, which can then be consumed by other tools ...
+          output-format: sarif
+          output-file: govulncheck.sarif
+
+      # ... such as the Code Scanning tab (https://github.com/oapi-codegen/oapi-codegen/security/code-scanning?query=is%3Aopen+branch%3Amain+tool%3Agovulncheck)
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.2
+        with:
+          sarif_file: govulncheck.sarif
+          category: govulncheck
+
+      - name: Print code scanning results URL
+        run: |
+          echo "Results: https://github.com/${{ github.repository }}/security/code-scanning?query=is%3Aopen+branch%3Amain+tool%3Agovulncheck"


### PR DESCRIPTION
Related to [0] and regular questions we've had in the past, we don't
have a clear answer for "are we vulnerable to a CVE" in a way that our
users are clearly able to determine, as well as "will oapi-codegen fix
it".

As a step towards answering the former, and leading towards the latter,
we can start running `govulncheck` in CI as a way to ensure that we
always have that information to hand.

This will re-run on commits to HEAD, as well as on a schedule, to make
sure we're aware of new CVEs.

By producing this in SARIF format, we can then have this uploaded to
GitHub's Code Scanning alerts, which are more straightforward to
validate.

The Code Scanning alerts page is gated to maintainers, but doesn't
(currently) hide anything that can't be seen by someone running
`govulncheck` themselves on the project.

We also make sure to explicitly note what permissions are required to
handle the workflow.

[0]: https://github.com/oapi-codegen/governance/issues/11