### PR TITLE
build: add Scorecards workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,46 @@
+name: Scorecard supply-chain security
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below)
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          show-progress: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
This is another step towards better understanding this project's health,
and making it clear to consumers.

Although we're already onboarded via the upstream project[0] (via the
"old" repo name), it's better to have this a first-class product of our
project, as this also allows validating i.e. branch protection due to
`permissions: read-all`.

Takes configuration via Renovate's usage[1], alongside the suggested
version from the Scorecard project.

This uploads the SARIF results to show that we have issues in the
Security tab (for maintainers).

[0]: https://securityscorecards.dev/viewer/?uri=github.com%2Fdeepmap%2Foapi-codegen
[1]: https://github.com/renovatebot/renovate/blob/8b86b8cdb4a3e36d6211e47a2e6a201f25f674da/.github/workflows/scorecard.yml
