### PR TITLE
build: add explicit `permissions` blocks for Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Build project
 on: [ push, pull_request ]
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,5 +1,9 @@
 name: Ensure generated files are up-to-date
 on: [ push, pull_request ]
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     # Mondays at 0000
     - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+
 jobs:
   check-for-vulnerabilities:
     name: Check for vulnerabilities using `govulncheck`

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,9 @@ name: "Pull Request Labeler"
 on:
 - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint project
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
This mirrors what we have set at a repo- and org-level as defaults
(`Read repository contents and packages permissions`), but this makes it
explicit for Static Analysis tools.
