### PR TITLE
fix codegen for same type used with multiple discriminators

### DIFF
--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -227,6 +227,12 @@ type OneOfObject13 struct {
 	union                json.RawMessage
 }
 
+// OneOfObject14 oneOf with discriminator where multiple values map to the same schema (tests deterministic generation)
+type OneOfObject14 struct {
+	Category string `json:"category"`
+	union    json.RawMessage
+}
+
 // OneOfObject2 oneOf with inline elements
 type OneOfObject2 struct {
 	union json.RawMessage
@@ -1383,6 +1389,136 @@ func (t OneOfObject13) ValueByDiscriminator() (interface{}, error) {
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)
 	}
+}
+
+// AsOneOfVariant4 returns the union data inside the OneOfObject14 as a OneOfVariant4
+func (t OneOfObject14) AsOneOfVariant4() (OneOfVariant4, error) {
+	var body OneOfVariant4
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOneOfVariant4 overwrites any union data inside the OneOfObject14 as the provided OneOfVariant4
+func (t *OneOfObject14) FromOneOfVariant4(v OneOfVariant4) error {
+	t.Category = "type_a"
+
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOneOfVariant4 performs a merge with any union data inside the OneOfObject14, using the provided OneOfVariant4
+func (t *OneOfObject14) MergeOneOfVariant4(v OneOfVariant4) error {
+	t.Category = "type_a"
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsOneOfVariant5 returns the union data inside the OneOfObject14 as a OneOfVariant5
+func (t OneOfObject14) AsOneOfVariant5() (OneOfVariant5, error) {
+	var body OneOfVariant5
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOneOfVariant5 overwrites any union data inside the OneOfObject14 as the provided OneOfVariant5
+func (t *OneOfObject14) FromOneOfVariant5(v OneOfVariant5) error {
+	t.Category = "type_x"
+
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOneOfVariant5 performs a merge with any union data inside the OneOfObject14, using the provided OneOfVariant5
+func (t *OneOfObject14) MergeOneOfVariant5(v OneOfVariant5) error {
+	t.Category = "type_x"
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t OneOfObject14) Discriminator() (string, error) {
+	var discriminator struct {
+		Discriminator string `json:"category"`
+	}
+	err := json.Unmarshal(t.union, &discriminator)
+	return discriminator.Discriminator, err
+}
+
+func (t OneOfObject14) ValueByDiscriminator() (interface{}, error) {
+	discriminator, err := t.Discriminator()
+	if err != nil {
+		return nil, err
+	}
+	switch discriminator {
+	case "type_a":
+		return t.AsOneOfVariant4()
+	case "type_b":
+		return t.AsOneOfVariant4()
+	case "type_x":
+		return t.AsOneOfVariant5()
+	case "type_y":
+		return t.AsOneOfVariant5()
+	default:
+		return nil, errors.New("unknown discriminator value: " + discriminator)
+	}
+}
+
+func (t OneOfObject14) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	object := make(map[string]json.RawMessage)
+	if t.union != nil {
+		err = json.Unmarshal(b, &object)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	object["category"], err = json.Marshal(t.Category)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'category': %w", err)
+	}
+
+	b, err = json.Marshal(object)
+	return b, err
+}
+
+func (t *OneOfObject14) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	if err != nil {
+		return err
+	}
+	object := make(map[string]json.RawMessage)
+	err = json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["category"]; found {
+		err = json.Unmarshal(raw, &t.Category)
+		if err != nil {
+			return fmt.Errorf("error reading 'category': %w", err)
+		}
+	}
+
+	return err
 }
 
 // AsOneOfObject20 returns the union data inside the OneOfObject2 as a OneOfObject20

--- a/internal/test/components/components.yaml
+++ b/internal/test/components/components.yaml
@@ -386,6 +386,24 @@ components:
       required:
         - type
       additionalProperties: true
+    OneOfObject14:
+      description: oneOf with discriminator where multiple values map to the same schema (tests deterministic generation)
+      type: object
+      properties:
+        category:
+          type: string
+      oneOf:
+        - $ref: '#/components/schemas/OneOfVariant4'
+        - $ref: '#/components/schemas/OneOfVariant5'
+      discriminator:
+        propertyName: category
+        mapping:
+          type_a: '#/components/schemas/OneOfVariant4'
+          type_b: '#/components/schemas/OneOfVariant4'
+          type_x: '#/components/schemas/OneOfVariant5'
+          type_y: '#/components/schemas/OneOfVariant5'
+      required:
+        - category
     AnyOfObject1:
       description: simple anyOf case
       anyOf:

--- a/pkg/codegen/templates/union.tmpl
+++ b/pkg/codegen/templates/union.tmpl
@@ -14,8 +14,10 @@
         // From{{ .Method }} overwrites any union data inside the {{$typeName}} as the provided {{.}}
         func (t *{{$typeName}}) From{{ .Method }} (v {{.}}) error {
             {{if $discriminator -}}
-                {{range $value, $type := $discriminator.Mapping -}}
-                    {{if eq $type $element -}}
+                {{$matched := false -}}
+                {{range $value := $discriminator.SortedMappingKeys -}}
+                    {{$type := index $discriminator.Mapping $value -}}
+                    {{if and (eq $type $element) (not $matched) -}}
                         {{$hasProperty := false -}}
                         {{range $properties -}}
                             {{if eq .GoFieldName $discriminator.PropertyName -}}
@@ -24,6 +26,7 @@
                             {{end -}}
                         {{end -}}
                         {{if not $hasProperty}}v.{{$discriminator.PropertyName}} = "{{$value}}"{{end}}
+                        {{$matched = true -}}
                     {{end -}}
                 {{end -}}
             {{end -}}
@@ -35,8 +38,10 @@
         // Merge{{ .Method }} performs a merge with any union data inside the {{$typeName}}, using the provided {{.}}
         func (t *{{$typeName}}) Merge{{ .Method }} (v {{.}}) error {
             {{if $discriminator -}}
-                {{range $value, $type := $discriminator.Mapping -}}
-                    {{if eq $type $element -}}
+                {{$matched := false -}}
+                {{range $value := $discriminator.SortedMappingKeys -}}
+                    {{$type := index $discriminator.Mapping $value -}}
+                    {{if and (eq $type $element) (not $matched) -}}
                         {{$hasProperty := false -}}
                         {{range $properties -}}
                             {{if eq .GoFieldName $discriminator.PropertyName -}}
@@ -45,6 +50,7 @@
                             {{end -}}
                         {{end -}}
                         {{if not $hasProperty}}v.{{$discriminator.PropertyName}} = "{{$value}}"{{end}}
+                        {{$matched = true -}}
                     {{end -}}
                 {{end -}}
             {{end -}}
@@ -75,7 +81,8 @@
                     return nil, err
                 }
                 switch discriminator{
-                    {{range $value, $type := $discriminator.Mapping -}}
+                    {{range $value := $discriminator.SortedMappingKeys -}}
+                        {{$type := index $discriminator.Mapping $value -}}
                         case "{{$value}}":
                             return t.As{{$type}}()
                     {{end -}}


### PR DESCRIPTION
# Fix Missing Discriminator Mappings When Multiple Values Map to Same Schema

## Problem

When an OpenAPI spec has multiple discriminator values that map to the same schema type, the code generator would only include **one** of the values in the generated code, and which value was included would vary randomly between runs.

### Example

Given an OpenAPI spec with discriminator mappings like:
```yaml
discriminator:
  propertyName: category
  mapping:
    type_a: '#/components/schemas/VariantA'
    type_b: '#/components/schemas/VariantA'
    type_x: '#/components/schemas/VariantB'
```

The generated `ValueByDiscriminator()` switch would be **incomplete**, randomly including either `type_a` OR `type_b`, but not both:

```go
switch discriminator {
case "type_a":  // Sometimes "type_b" instead - randomly varies!
    return t.AsVariantA()
case "type_x":
    return t.AsVariantB()
default:
    return nil, errors.New("unknown discriminator value: " + discriminator)
}
```

This means valid discriminator values specified in the OpenAPI spec would fail at runtime with "unknown discriminator value" errors.

## Root Cause

The discriminator mapping builder in `generateUnion()` iterated over the spec's discriminator map and **broke after finding the first match**:

```go
for k, v := range discriminator.Mapping {
    if v == element.Ref {
        outSchema.Discriminator.Mapping[k] = elementSchema.GoType
        mapped = true
        break  // ❌ Only includes ONE random value per schema
    }
}
```

Since Go map iteration order is randomized, this meant:
- Sometimes `type_a` was processed first and included (making `type_b` fail at runtime)
- Sometimes `type_b` was processed first and included (making `type_a` fail at runtime)
- The code generation varied randomly between runs

## Solution

### 1. Include All Discriminator Mappings

Updated `generateUnion()` in schema.go to:
- Process all discriminator keys in sorted order (for deterministic output)
- Include **all** keys that map to each schema type
- Remove the early `break` that caused mappings to be silently dropped

Before:
```go
for k, v := range discriminator.Mapping {
    if v == element.Ref {
        outSchema.Discriminator.Mapping[k] = elementSchema.GoType
        mapped = true
        break  // ❌ Only adds ONE mapping per schema
    }
}
```

After:
```go
sortedKeys := make([]string, 0, len(discriminator.Mapping))
for k := range discriminator.Mapping {
    sortedKeys = append(sortedKeys, k)
}
sort.Strings(sortedKeys)

for _, k := range sortedKeys {
    v := discriminator.Mapping[k]
    if v == element.Ref {
        outSchema.Discriminator.Mapping[k] = elementSchema.GoType
        mapped = true
        // ✅ Continue to include ALL mappings
    }
}
```

### 2. Added `SortedMappingKeys()` Helper Method

Added a helper method to the `Discriminator` struct that returns mapping keys in sorted order, ensuring deterministic code generation across runs:

```go
func (d *Discriminator) SortedMappingKeys() []string {
    keys := make([]string, 0, len(d.Mapping))
    for k := range d.Mapping {
        keys = append(keys, k)
    }
    sort.Strings(keys)
    return keys
}
```

### 3. Updated Templates

Modified union.tmpl to use sorted keys:
- Use `SortedMappingKeys()` instead of direct map iteration for deterministic output
- Add `$matched` flag in `From*` and `Merge*` methods to use the first (alphabetically) discriminator value
- Ensures `ValueByDiscriminator()` includes ALL discriminator values as switch cases

```go
{{$matched := false -}}
{{range $value := $discriminator.SortedMappingKeys -}}
    {{$type := index $discriminator.Mapping $value -}}
    {{if and (eq $type $element) (not $matched) -}}
        v.{{$discriminator.PropertyName}} = "{{$value}}"
        {{$matched = true -}}
    {{end -}}
{{end -}}
```

### 4. Improved Validation

Updated validation logic to check that all union elements have at least one discriminator mapping, rather than requiring count equality between mappings and elements (which incorrectly fails when multiple discriminator values map to the same schema).

## Changes Summary

### Modified Files
- `pkg/codegen/schema.go`:
  - Added `SortedMappingKeys()` method to `Discriminator` struct
  - Fixed `generateUnion()` to sort keys and include all mappings
  - Improved discriminator validation logic
- `pkg/codegen/templates/union.tmpl`:
  - Updated `From{{ .Method }}` to use sorted keys with early-exit
  - Updated `Merge{{ .Method }}` to use sorted keys with early-exit
  - Updated `ValueByDiscriminator()` to use sorted keys

### Test Coverage
- Added test case with multiple discriminator values mapping to the same schema
- Test verifies code generation is deterministic across multiple runs
- Test validates all discriminator values appear in switch statements

## Impact

### Generated Code Changes

For schemas with multiple discriminator values mapping to the same type:

1. **`ValueByDiscriminator()` switch**: Now includes **ALL** discriminator values as cases (previously missing random values)
2. **`From*` methods**: Consistently use the first alphabetically sorted discriminator value
3. **`Merge*` methods**: Same deterministic behavior

Example:
```go
// Before: INCOMPLETE - missing valid discriminator values!
switch discriminator {
case "type_a":  // ❌ type_b is missing! Will fail at runtime
    return t.AsVariantA()
case "type_x":
    return t.AsVariantB()
default:
    return nil, errors.New("unknown discriminator value: " + discriminator)
}

// After: COMPLETE - all discriminator values included
switch discriminator {
case "type_a":  // ✅ Both values included
    return t.AsVariantA()
case "type_b":  // ✅ No longer missing
    return t.AsVariantA()
case "type_x":
    return t.AsVariantB()
case "type_y":
    return t.AsVariantB()
default:
    return nil, errors.New("unknown discriminator value: " + discriminator)
}
```

### Backward Compatibility

This is a **bug fix** that corrects missing discriminator mappings. For projects with multiple discriminator values mapping to the same schema:

**Before this fix:**
- Runtime errors: `"unknown discriminator value: type_b"` for valid discriminator values
- Incomplete switch statements missing valid cases
- Random code generation (sometimes worked, sometimes didn't)

**After this fix:**
- All discriminator values work correctly
- Complete switch statements with all cases
- Deterministic code generation
- The discriminator value used in `From*`/`Merge*` methods is the alphabetically first value

This change fixes a correctness bug where valid OpenAPI discriminator mappings were silently dropped, causing runtime failures.

## Verification

- ✅ New test `TestOneOfWithDiscriminator_MultipleMappingsToSameSchema` validates all discriminator values work
- ✅ All existing tests pass
- ✅ Generated code includes all discriminator cases in switch statements
- ✅ Code generation is deterministic across multiple runs