### PR TITLE
build: handle additional values in `GOVERSION`

### DIFF
--- a/examples/authenticated-api/stdhttp/Makefile
+++ b/examples/authenticated-api/stdhttp/Makefile
@@ -4,7 +4,7 @@ YELLOW := \e[0;33m
 RESET := \e[0;0m
 
 GOVER := $(shell go env GOVERSION)
-GOMINOR := $(shell bash -c "cut -f2 -d. <<< $(GOVER)")
+GOMINOR := $(shell bash -c "cut -f1 -d' ' <<< \"$(GOVER)\" | cut -f2 -d.")
 
 define execute-if-go-122
 @{ \

--- a/examples/extensions/xomitzero/Makefile
+++ b/examples/extensions/xomitzero/Makefile
@@ -4,7 +4,7 @@ YELLOW := \e[0;33m
 RESET := \e[0;0m
 
 GOVER := $(shell go env GOVERSION)
-GOMINOR := $(shell bash -c "cut -f2 -d. <<< $(GOVER)")
+GOMINOR := $(shell bash -c "cut -f1 -d' ' <<< \"$(GOVER)\" | cut -f2 -d.")
 
 define execute-if-go-124
 @{ \

--- a/examples/minimal-server/stdhttp-go-tool/Makefile
+++ b/examples/minimal-server/stdhttp-go-tool/Makefile
@@ -4,7 +4,7 @@ YELLOW := \e[0;33m
 RESET := \e[0;0m
 
 GOVER := $(shell go env GOVERSION)
-GOMINOR := $(shell bash -c "cut -f2 -d. <<< $(GOVER)")
+GOMINOR := $(shell bash -c "cut -f1 -d' ' <<< \"$(GOVER)\" | cut -f2 -d.")
 
 define execute-if-go-124
 @{ \

--- a/examples/minimal-server/stdhttp/Makefile
+++ b/examples/minimal-server/stdhttp/Makefile
@@ -4,7 +4,7 @@ YELLOW := \e[0;33m
 RESET := \e[0;0m
 
 GOVER := $(shell go env GOVERSION)
-GOMINOR := $(shell bash -c "cut -f2 -d. <<< $(GOVER)")
+GOMINOR := $(shell bash -c "cut -f1 -d' ' <<< \"$(GOVER)\" | cut -f2 -d.")
 
 define execute-if-go-122
 @{ \

--- a/examples/output-options/preferskipoptionalpointerwithomitzero/Makefile
+++ b/examples/output-options/preferskipoptionalpointerwithomitzero/Makefile
@@ -4,7 +4,7 @@ YELLOW := \e[0;33m
 RESET := \e[0;0m
 
 GOVER := $(shell go env GOVERSION)
-GOMINOR := $(shell bash -c "cut -f2 -d. <<< $(GOVER)")
+GOMINOR := $(shell bash -c "cut -f1 -d' ' <<< \"$(GOVER)\" | cut -f2 -d.")
 
 define execute-if-go-124
 @{ \

--- a/examples/petstore-expanded/stdhttp/Makefile
+++ b/examples/petstore-expanded/stdhttp/Makefile
@@ -4,7 +4,7 @@ YELLOW := \e[0;33m
 RESET := \e[0;0m
 
 GOVER := $(shell go env GOVERSION)
-GOMINOR := $(shell bash -c "cut -f2 -d. <<< $(GOVER)")
+GOMINOR := $(shell bash -c "cut -f1 -d' ' <<< \"$(GOVER)\" | cut -f2 -d.")
 
 define execute-if-go-122
 @{ \

--- a/internal/test/strict-server/stdhttp/Makefile
+++ b/internal/test/strict-server/stdhttp/Makefile
@@ -4,7 +4,7 @@ YELLOW := \e[0;33m
 RESET := \e[0;0m
 
 GOVER := $(shell go env GOVERSION)
-GOMINOR := $(shell bash -c "cut -f2 -d. <<< $(GOVER)")
+GOMINOR := $(shell bash -c "cut -f1 -d' ' <<< \"$(GOVER)\" | cut -f2 -d.")
 
 define execute-if-go-122
 @{ \


### PR DESCRIPTION
When building locally, the `make` scripts are failing on the result of:

```
$ go env GOVERSION
go1.25.3 X:nodwarf5
```

This splits the input correctly.
