### PR TITLE
chore(renovate): improve actionability of pending updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,22 @@
 				"examples/**/*"
 			],
 			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "Don't attempt to bump `replace` statements for internal modules",
+			"matchDepNames": [
+				"github.com/oapi-codegen/oapi-codegen/v2"
+			],
+			"matchCurrentVersion": "v2.0.0-00010101000000-000000000000",
+			"enabled": false
+		},
+		{
+			"description": "Don't attempt to bump `replace` statements for internal modules",
+			"matchDepNames": [
+				"github.com/oapi-codegen/oapi-codegen/v2/internal/test"
+			],
+			"matchCurrentVersion": "v0.0.0-00010101000000-000000000000",
+			"enabled": false
 		}
 	]
 }


### PR DESCRIPTION
- **chore(renovate): group dependency updates by directory**
- **chore(renovate): don't raise PRs for `internal/test` and `examples`**
- **chore(renovate): don't raise PRs for internal `replace`d modules**
