### PR TITLE
chore(renovate): correctly create branches for top-level files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,8 @@
 			"matchFileNames": [
 				"**/*"
 			],
-			"additionalBranchPrefix": "{{#if isGroup }}{{ else }}{{packageFileDir}}/{{/if}}",
-			"commitMessageSuffix": "{{#if isGroup }}{{ else }} ({{packageFileDir}}){{/if}}"
+			"additionalBranchPrefix": "{{#if isGroup }}{{ else }}{{#if packageFileDir}}{{packageFileDir}}/{{else}}{{packageFile}}/{{/if}}{{/if}}",
+			"commitMessageSuffix": "{{#if isGroup }}{{ else }} ({{#if packageFileDir}}{{packageFileDir}}{{else}}{{packageFile}}{{/if}}){{/if}}"
 		},
 		{
 			"description": "Don't attempt to bump dependencies if they're only used in example code, but allow manually forcing them via Dependency Dashboard",


### PR DESCRIPTION
Previously, the `packageFileDir` would be set to "", so the branch name
would be generated as:

    "branchName": "renovate//github.com-golangci-golangci-lint-2.x"

With this fix, we see:

    "branchName": "renovate/github.com-golangci-golangci-lint-2.x",
