### PR TITLE
chore(renovate): run `make tidy` after dependency updates to `go.mod`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,5 +39,15 @@
 			"matchCurrentVersion": "v0.0.0-00010101000000-000000000000",
 			"enabled": false
 		}
-	]
+	],
+	"postUpgradeTasks": {
+		"commands": [
+			"make tidy"
+		],
+		"fileFilters": [
+			"**/*/go.mod",
+			"**/*/go.sum"
+		],
+		"executionMode": "branch"
+	}
 }


### PR DESCRIPTION
As we've had it allowlisted by Mend, we can now run `make tidy` to get
PRs automagically updated.

This will update the whole branch (in the case of multiple dependency
bumps on the branch) and only target Go-specific dependency changes,
avoiding unnecessary updates when doing i.e. `golangci-lint` updates.
