### PR TITLE
fix(renovate): only run `make tidy` after Go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,16 +38,23 @@
 			],
 			"matchCurrentVersion": "v0.0.0-00010101000000-000000000000",
 			"enabled": false
+		},
+		{
+			"description": "",
+			"matchFileNames": [
+				"**/*/go.mod",
+				"**/*.go.sum"
+			],
+			"postUpgradeTasks": {
+				"commands": [
+					"make tidy"
+				],
+				"fileFilters": [
+					"**/*/go.mod",
+					"**/*/go.sum"
+				],
+				"executionMode": "branch"
+			}
 		}
-	],
-	"postUpgradeTasks": {
-		"commands": [
-			"make tidy"
-		],
-		"fileFilters": [
-			"**/*/go.mod",
-			"**/*/go.sum"
-		],
-		"executionMode": "branch"
-	}
+	]
 }


### PR DESCRIPTION
Otherwise we see i.e.

```
Command failed: make tidy
make: go: No such file or directory
make: *** [Makefile:44: tidy] Error 127
```
