### PR TITLE
fix: make it possible to have the same path parameter twice in URL

### DIFF
--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -53,10 +53,15 @@ func genParamArgs(params []ParameterDefinition) string {
 	if len(params) == 0 {
 		return ""
 	}
-	parts := make([]string, len(params))
-	for i, p := range params {
+	seenBefore := make(map[string]bool, len(params))
+	parts := make([]string, len(params))[:0]
+	for _, p := range params {
 		paramName := p.GoVariableName()
-		parts[i] = fmt.Sprintf("%s %s", paramName, p.TypeDef())
+		if seenBefore[paramName] {
+			continue
+		}
+		seenBefore[paramName] = true
+		parts = append(parts, fmt.Sprintf("%s %s", paramName, p.TypeDef()))
 	}
 	return ", " + strings.Join(parts, ", ")
 }
@@ -69,9 +74,15 @@ func genParamTypes(params []ParameterDefinition) string {
 	if len(params) == 0 {
 		return ""
 	}
-	parts := make([]string, len(params))
-	for i, p := range params {
-		parts[i] = p.TypeDef()
+	seenBefore := make(map[string]bool, len(params))
+	parts := make([]string, len(params))[:0]
+	for _, p := range params {
+		paramName := p.GoVariableName()
+		if seenBefore[paramName] {
+			continue
+		}
+		seenBefore[paramName] = true
+		parts = append(parts, p.TypeDef())
 	}
 	return ", " + strings.Join(parts, ", ")
 }
@@ -83,9 +94,15 @@ func genParamNames(params []ParameterDefinition) string {
 	if len(params) == 0 {
 		return ""
 	}
-	parts := make([]string, len(params))
-	for i, p := range params {
-		parts[i] = p.GoVariableName()
+	seenBefore := make(map[string]bool, len(params))
+	parts := make([]string, len(params))[:0]
+	for _, p := range params {
+		paramName := p.GoVariableName()
+		if seenBefore[paramName] {
+			continue
+		}
+		seenBefore[paramName] = true
+		parts = append(parts, p.GoVariableName())
 	}
 	return ", " + strings.Join(parts, ", ")
 }

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -656,12 +656,18 @@ func ReplacePathParamsWithStr(uri string) string {
 // SortParamsByPath reorders the given parameter definitions to match those in the path URI.
 func SortParamsByPath(path string, in []ParameterDefinition) ([]ParameterDefinition, error) {
 	pathParams := OrderedParamsFromUri(path)
-	n := len(in)
-	if len(pathParams) != n {
-		return nil, fmt.Errorf("path '%s' has %d positional parameters, but spec has %d declared",
-			path, len(pathParams), n)
+
+	uniquePathParams := make(map[string]bool, len(pathParams))
+	for _, param := range pathParams {
+		uniquePathParams[param] = true
 	}
-	out := make([]ParameterDefinition, len(in))
+
+	n := len(in)
+	if len(uniquePathParams) != n {
+		return nil, fmt.Errorf("path '%s' has %d positional parameters, but spec has %d declared",
+			path, len(uniquePathParams), n)
+	}
+	out := make([]ParameterDefinition, len(pathParams))
 	for i, name := range pathParams {
 		p := ParameterDefinitions(in).FindByName(name)
 		if p == nil {


### PR DESCRIPTION
This makes it possible to parse the keycloak openapi spec, which for one API has a URL of '/admin/realms/{realm}/clients/{client-uuid}/roles/{role-name}/composites/clients/{client-uuid}'.