### PR TITLE
Update enum generation to generate a map to validate enums.

### DIFF
--- a/examples/extensions/xenumnames/gen.go
+++ b/examples/extensions/xenumnames/gen.go
@@ -9,17 +9,47 @@ const (
 	EXP ClientType = "EXP"
 )
 
+var ClientTypeValues = map[ClientType]struct{}{
+	ACT: {},
+	EXP: {},
+}
+
+func (s ClientType) IsValid() bool {
+	_, ok := ClientTypeValues[s]
+	return ok
+}
+
 // Defines values for ClientTypeWithNamesExtension.
 const (
 	ClientTypeWithNamesExtensionActive  ClientTypeWithNamesExtension = "ACT"
 	ClientTypeWithNamesExtensionExpired ClientTypeWithNamesExtension = "EXP"
 )
 
+var ClientTypeWithNamesExtensionValues = map[ClientTypeWithNamesExtension]struct{}{
+	ClientTypeWithNamesExtensionActive:  {},
+	ClientTypeWithNamesExtensionExpired: {},
+}
+
+func (s ClientTypeWithNamesExtension) IsValid() bool {
+	_, ok := ClientTypeWithNamesExtensionValues[s]
+	return ok
+}
+
 // Defines values for ClientTypeWithVarNamesExtension.
 const (
 	ClientTypeWithVarNamesExtensionActive  ClientTypeWithVarNamesExtension = "ACT"
 	ClientTypeWithVarNamesExtensionExpired ClientTypeWithVarNamesExtension = "EXP"
 )
+
+var ClientTypeWithVarNamesExtensionValues = map[ClientTypeWithVarNamesExtension]struct{}{
+	ClientTypeWithVarNamesExtensionActive:  {},
+	ClientTypeWithVarNamesExtensionExpired: {},
+}
+
+func (s ClientTypeWithVarNamesExtension) IsValid() bool {
+	_, ok := ClientTypeWithVarNamesExtensionValues[s]
+	return ok
+}
 
 // ClientType defines model for ClientType.
 type ClientType string

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -83,6 +83,16 @@ type GetTestByNameResponse struct {
 	assert.Contains(t, code, "type EnumTestEnumNames int")
 	assert.Contains(t, code, "Two  EnumTestEnumNames = 2")
 	assert.Contains(t, code, "Double EnumTestEnumVarnames = 2")
+
+	// Check that enum validation maps are generated:
+	assert.Contains(t, code, "var EnumTestNumericsValues = map[EnumTestNumerics]struct{}")
+	assert.Contains(t, code, "var EnumTestEnumNamesValues = map[EnumTestEnumNames]struct{}")
+	assert.Contains(t, code, "var EnumTestEnumVarnamesValues = map[EnumTestEnumVarnames]struct{}")
+
+	// Check that IsValid() methods are generated for each enum:
+	assert.Contains(t, code, "func (s EnumTestNumerics) IsValid() bool {")
+	assert.Contains(t, code, "func (s EnumTestEnumNames) IsValid() bool {")
+	assert.Contains(t, code, "func (s EnumTestEnumVarnames) IsValid() bool {")
 }
 
 func TestExtPropGoTypeSkipOptionalPointer(t *testing.T) {

--- a/pkg/codegen/templates/constants.tmpl
+++ b/pkg/codegen/templates/constants.tmpl
@@ -12,4 +12,15 @@ const (
   {{$name}} {{$Enum.TypeName}} = {{$Enum.ValueWrapper}}{{$value}}{{$Enum.ValueWrapper -}}
 {{end}}
 )
+
+var {{$Enum.TypeName}}Values = map[{{$Enum.TypeName}}]struct{}{
+{{- range $name, $value := $Enum.GetValues}}
+	{{$name}}: {},
+{{- end}}
+}
+
+func (s {{$Enum.TypeName}}) IsValid() bool {
+  _, ok := {{$Enum.TypeName}}Values[s]
+  return ok
+}
 {{end}}


### PR DESCRIPTION
Customers often need to validate whether a value is a legit enum value. 
We implement that validation by creating helper functions.

With the helper function, customers no longer have to manually write their own version of the helper.

i.e. 
```
const (
	ClientTypeWithNamesExtensionActive  ClientTypeWithNamesExtension = "ACT"
	ClientTypeWithNamesExtensionExpired ClientTypeWithNamesExtension = "EXP"
)

var ClientTypeWithNamesExtensionValues = map[ClientTypeWithNamesExtension]struct{}{
	ClientTypeWithNamesExtensionActive:  {},
	ClientTypeWithNamesExtensionExpired: {},
}

func (s ClientTypeWithNamesExtension) IsValid() bool {
	_, ok := ClientTypeWithNamesExtensionValues[s]
	return ok
}
```
and then the customer uses it like: 
```
func legit() {
	k := ClientTypeWithNamesExtension("")
	isValid := k.IsValid()
	fmt.Print(isValid)
}
```