### PR TITLE
Run golangci-lint on a supported Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ permissions:
   contents: read
 jobs:
   build:
-    uses: oapi-codegen/actions/.github/workflows/ci.yml@b9f2c274c1c631e648931dbbcc1942c2b2027837 # v0.4.0
+    uses: oapi-codegen/actions/.github/workflows/ci.yml@75566d848d25021f137594c947f26171094fb511 # v0.5.0
+    with:
+      lint_versions: '["1.25"]'
 
   build-binaries:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We only need to run lint on a single version of Go, as the output isn't Go runtime dependent, however, we need to be careful to run it in an environment where the Go runtime isn't newer than what the golangci-lint executable was built with, because it panics on some kind of version check in that case.

Resolves: #2214