### PR TITLE
fix(server-urls): use URL in GoDoc if `description` is empty

### DIFF
--- a/examples/generate/serverurls/gen.go
+++ b/examples/generate/serverurls/gen.go
@@ -9,25 +9,18 @@ import (
 )
 
 // ServerUrlDevelopmentServer defines the Server URL for Development server
-const ServerUrlDevelopmentServer = "https://development.gigantic-server.com/v1"
 
 // ServerUrlDevelopmentServer1 defines the Server URL for Development server
-const ServerUrlDevelopmentServer1 = "http://localhost:80"
 
 // ServerUrlDevelopmentServer2 defines the Server URL for Development server
-const ServerUrlDevelopmentServer2 = "http://localhost:80"
 
-// ServerUrlHttplocalhost443 defines the Server URL for
-const ServerUrlHttplocalhost443 = "http://localhost:443"
+// ServerUrlHttplocalhost443 defines the Server URL for http://localhost:443
 
 // ServerUrlProductionServer defines the Server URL for Production server
-const ServerUrlProductionServer = "https://api.gigantic-server.com/v1"
 
 // ServerUrlSomeLowercaseName defines the Server URL for some lowercase name
-const ServerUrlSomeLowercaseName = "http://localhost:80"
 
 // ServerUrlStagingServer defines the Server URL for Staging server
-const ServerUrlStagingServer = "https://staging.gigantic-server.com/v1"
 
 // ServerUrlTheProductionAPIServerBasePathVariable is the `basePath` variable for ServerUrlTheProductionAPIServer
 type ServerUrlTheProductionAPIServerBasePathVariable string

--- a/pkg/codegen/templates/server-urls.tmpl
+++ b/pkg/codegen/templates/server-urls.tmpl
@@ -1,8 +1,7 @@
 {{ range . }}
 {{ if eq 0 (len .OAPISchema.Variables) }}
 {{/* URLs without variables are straightforward, so we'll create them a constant */}}
-// {{ .GoName }} defines the Server URL for {{ .OAPISchema.Description }}
-const {{ .GoName}} = "{{ .OAPISchema.URL }}"
+// {{ .GoName }} defines the Server URL for {{ if len .OAPISchema.Description }}{{ .OAPISchema.Description }}{{ else }}{{ .OAPISchema.URL }}{{ end }}
 {{ else }}
 {{/* URLs with variables are not straightforward, as we may need multiple types, and so will model them as a function */}}
 


### PR DESCRIPTION
Otherwise the sentence ends abruptly.
