### PR TITLE
feat: allow preserving specific schemas during prune (preserve-schemas + x-oapi-codegen-keep-unused)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2017,7 +2017,10 @@ output: only-models.gen.go
 generate:
   models: true
 output-options:
-  # NOTE that this is only required for the `Unreferenced` type
+  # To keep only specific unreferenced schemas, use preserve-schemas instead of skip-prune:
+  # preserve-schemas: [Unreferenced]
+  # Or add x-oapi-codegen-keep-unused: true on a schema in your spec.
+  # To keep all unreferenced components, use:
   skip-prune: true
 ```
 
@@ -4454,6 +4457,7 @@ output-options:
   include-operation-ids: []
   exclude-operation-ids: []
   exclude-schemas: []
+  preserve-schemas: []  # schema names to keep when pruning unreferenced components
 ```
 
 Check [the docs](https://pkg.go.dev/github.com/oapi-codegen/oapi-codegen/v2/pkg/codegen#OutputOptions) for more details of usage.

--- a/configuration-schema.json
+++ b/configuration-schema.json
@@ -127,6 +127,13 @@
           "type": "boolean",
           "description": "Whether to skip pruning unused components on the generated code"
         },
+        "preserve-schemas": {
+          "type": "array",
+          "description": "Schema names to keep during prune even when unreferenced. Ignored when empty. See also x-oapi-codegen-keep-unused on a schema.",
+          "items": {
+            "type": "string"
+          }
+        },
         "include-tags": {
           "type": "array",
           "description": "Only include operations that have one of these tags. Ignored when empty.",

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -151,7 +151,7 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 	filterOperationsByTag(spec, opts)
 	filterOperationsByOperationID(spec, opts)
 	if !opts.OutputOptions.SkipPrune {
-		pruneUnusedComponents(spec)
+		pruneUnusedComponents(spec, opts.OutputOptions.PreserveSchemas)
 	}
 
 	// if we are provided an override for the response type suffix update it

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -246,6 +246,8 @@ type OutputOptions struct {
 	SkipFmt bool `yaml:"skip-fmt,omitempty"`
 	// Whether to skip pruning unused components on the generated code
 	SkipPrune bool `yaml:"skip-prune,omitempty"`
+	// PreserveSchemas lists schema names to keep during prune even when unreferenced. Ignored when empty. See also x-oapi-codegen-keep-unused on a schema.
+	PreserveSchemas []string `yaml:"preserve-schemas,omitempty"`
 	// Only include operations that have one of these tags. Ignored when empty.
 	IncludeTags []string `yaml:"include-tags,omitempty"`
 	// Exclude operations that have one of these tags. Ignored when empty.

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -27,6 +27,8 @@ const (
 	// extOapiCodegenOnlyHonourGoName is to be used to explicitly enforce the generation of a field as the `x-go-name` extension has describe it.
 	// This is intended to be used alongside the `allow-unexported-struct-field-names` Compatibility option
 	extOapiCodegenOnlyHonourGoName = "x-oapi-codegen-only-honour-go-name"
+	// extKeepUnused marks a schema to be kept during prune even when not referenced (x-oapi-codegen-keep-unused: true).
+	extKeepUnused = "x-oapi-codegen-keep-unused"
 )
 
 func extString(extPropValue any) (string, error) {


### PR DESCRIPTION
Add two ways to keep unreferenced component schemas from being pruned:

- output-options.preserve-schemas: list of schema names to always keep, even when not referenced anywhere in the spec.
- x-oapi-codegen-keep-unused: set to true on a schema in the OpenAPI spec so that schema is never pruned when unreferenced.

pruneUnusedComponents() now takes an optional preserveSchemas []string (from config); schemas in that list or with the extension are not removed. Existing call sites use nil. Tests and configuration-schema/README updated.