### PR TITLE
fix(server-urls): restore generation of constants

### DIFF
--- a/pkg/codegen/templates/server-urls.tmpl
+++ b/pkg/codegen/templates/server-urls.tmpl
@@ -2,6 +2,7 @@
 {{ if eq 0 (len .OAPISchema.Variables) }}
 {{/* URLs without variables are straightforward, so we'll create them a constant */}}
 // {{ .GoName }} defines the Server URL for {{ if len .OAPISchema.Description }}{{ .OAPISchema.Description }}{{ else }}{{ .OAPISchema.URL }}{{ end }}
+const {{ .GoName}} = "{{ .OAPISchema.URL }}"
 {{ else }}
 {{/* URLs with variables are not straightforward, as we may need multiple types, and so will model them as a function */}}
 


### PR DESCRIPTION
This fixes a regression from 59fb0e86773ac572016038c9cd21569de8d6a1b2.
