### PR TITLE
fix: runtime import breaks

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -149,7 +149,7 @@ func (g GenerateOptions) RouterImports() []AdditionalImport {
 	case g.Echo5Server:
 		imports = append(imports, AdditionalImport{Package: "github.com/labstack/echo/v5"})
 		if g.Strict {
-			imports = append(imports, AdditionalImport{Alias: "strictecho5", Package: "github.com/oapi-codegen/runtime/strictmiddleware/echo/v5"})
+			imports = append(imports, AdditionalImport{Alias: "strictecho5", Package: "github.com/oapi-codegen/runtime/strictmiddleware/echo-v5"})
 		}
 	case g.ChiServer:
 		imports = append(imports, AdditionalImport{Package: "github.com/go-chi/chi/v5"})


### PR DESCRIPTION
* fix the break in import od runtime  in the generated code after https://github.com/oapi-codegen/runtime/pull/89/changes/702ab913d08cc6a9cfe3fb00dd8722e1cca311ae
* closes https://github.com/oapi-codegen/oapi-codegen/issues/2275