### PR TITLE
Add missing case to type generation traversal

### DIFF
--- a/examples/extensions/xgotypename/api.yaml
+++ b/examples/extensions/xgotypename/api.yaml
@@ -25,3 +25,18 @@ components:
           type: number
           # NOTE attempting a `x-go-type-name` here is a no-op, as we're not producing a _type_ only a _field_
           x-go-type-name: ThisWillNotBeUsed
+paths:
+  /example:
+    get:
+      operationId: exampleGet
+      responses:
+        '200':
+          description: "OK"
+          content:
+            'application/json':
+              schema:
+                type: object
+                x-go-type-name: ResponseRenamed
+                properties:
+                  name:
+                    type: string

--- a/examples/extensions/xgotypename/gen.go
+++ b/examples/extensions/xgotypename/gen.go
@@ -17,3 +17,8 @@ type ClientRenamedByExtension struct {
 	Id   *float32 `json:"id,omitempty"`
 	Name string   `json:"name"`
 }
+
+// ResponseRenamed defines parameters for ExampleGet.
+type ResponseRenamed struct {
+	Name *string `json:"name,omitempty"`
+}

--- a/internal/test/any_of/codegen/inline/openapi.gen.go
+++ b/internal/test/any_of/codegen/inline/openapi.gen.go
@@ -48,6 +48,11 @@ type Rat struct {
 // apiKeyAuthContextKey is the context key for ApiKeyAuth security scheme
 type apiKeyAuthContextKey string
 
+// GetPets200JSONResponse_Data_Item defines parameters for GetPets.
+type GetPets200JSONResponse_Data_Item struct {
+	union json.RawMessage
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
 

--- a/internal/test/issues/issue-1277/content-array.gen.go
+++ b/internal/test/issues/issue-1277/content-array.gen.go
@@ -16,6 +16,96 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// Test200JSONResponse_Item defines parameters for Test.
+type Test200JSONResponse_Item struct {
+	Field1               *string                `json:"field1,omitempty"`
+	Field2               *string                `json:"field2,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// Getter for additional properties for Test200JSONResponse_Item. Returns the specified
+// element and whether it was found
+func (a Test200JSONResponse_Item) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for Test200JSONResponse_Item
+func (a *Test200JSONResponse_Item) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for Test200JSONResponse_Item to handle AdditionalProperties
+func (a *Test200JSONResponse_Item) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["field1"]; found {
+		err = json.Unmarshal(raw, &a.Field1)
+		if err != nil {
+			return fmt.Errorf("error reading 'field1': %w", err)
+		}
+		delete(object, "field1")
+	}
+
+	if raw, found := object["field2"]; found {
+		err = json.Unmarshal(raw, &a.Field2)
+		if err != nil {
+			return fmt.Errorf("error reading 'field2': %w", err)
+		}
+		delete(object, "field2")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for Test200JSONResponse_Item to handle AdditionalProperties
+func (a Test200JSONResponse_Item) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.Field1 != nil {
+		object["field1"], err = json.Marshal(a.Field1)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'field1': %w", err)
+		}
+	}
+
+	if a.Field2 != nil {
+		object["field2"], err = json.Marshal(a.Field2)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'field2': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
 
@@ -416,12 +506,6 @@ type TestResponseObject interface {
 }
 
 type Test200JSONResponse []Test200JSONResponse_Item
-
-type Test200JSONResponse_Item struct {
-	Field1               *string                `json:"field1,omitempty"`
-	Field2               *string                `json:"field2,omitempty"`
-	AdditionalProperties map[string]interface{} `json:"-"`
-}
 
 func (response Test200JSONResponse) VisitTestResponse(w http.ResponseWriter) error {
 

--- a/internal/test/name_conflict_resolution/name_conflict_resolution.gen.go
+++ b/internal/test/name_conflict_resolution/name_conflict_resolution.gen.go
@@ -258,6 +258,18 @@ type QueryJSONBody struct {
 	Q *string `json:"q,omitempty"`
 }
 
+// PatchResource200ApplicationJSONPatchPlusJSONResponse1 defines parameters for PatchResource.
+type PatchResource200ApplicationJSONPatchPlusJSONResponse1 = []Resource
+
+// PatchResource200ApplicationJSONPatchPlusJSONResponse2 defines parameters for PatchResource.
+type PatchResource200ApplicationJSONPatchPlusJSONResponse2 = string
+
+// PatchResource200ApplicationJSONPatchQueryPlusJSONResponse1 defines parameters for PatchResource.
+type PatchResource200ApplicationJSONPatchQueryPlusJSONResponse1 = []Resource
+
+// PatchResource200ApplicationJSONPatchQueryPlusJSONResponse2 defines parameters for PatchResource.
+type PatchResource200ApplicationJSONPatchQueryPlusJSONResponse2 = string
+
 // PostFooJSONRequestBody defines body for PostFoo for application/json ContentType.
 type PostFooJSONRequestBody PostFooJSONBody
 

--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -1190,8 +1190,6 @@ type UnionExample200JSONResponse struct {
 	Headers UnionExample200ResponseHeaders
 }
 
-type UnionExample200JSONResponse0 = string
-
 func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer

--- a/internal/test/strict-server/chi/types.gen.go
+++ b/internal/test/strict-server/chi/types.gen.go
@@ -26,6 +26,9 @@ type HeadersExampleParams struct {
 	Header2 *int   `json:"header2,omitempty"`
 }
 
+// UnionExample200JSONResponse0 defines parameters for UnionExample.
+type UnionExample200JSONResponse0 = string
+
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.
 type JSONExampleJSONRequestBody = Example
 

--- a/internal/test/strict-server/client/client.gen.go
+++ b/internal/test/strict-server/client/client.gen.go
@@ -39,6 +39,9 @@ type HeadersExampleParams struct {
 	Header2 *int   `json:"header2,omitempty"`
 }
 
+// UnionExample200JSONResponse0 defines parameters for UnionExample.
+type UnionExample200JSONResponse0 = string
+
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.
 type JSONExampleJSONRequestBody = Example
 

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -910,8 +910,6 @@ type UnionExample200JSONResponse struct {
 	Headers UnionExample200ResponseHeaders
 }
 
-type UnionExample200JSONResponse0 = string
-
 func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer

--- a/internal/test/strict-server/echo/types.gen.go
+++ b/internal/test/strict-server/echo/types.gen.go
@@ -26,6 +26,9 @@ type HeadersExampleParams struct {
 	Header2 *int   `json:"header2,omitempty"`
 }
 
+// UnionExample200JSONResponse0 defines parameters for UnionExample.
+type UnionExample200JSONResponse0 = string
+
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.
 type JSONExampleJSONRequestBody = Example
 

--- a/internal/test/strict-server/fiber/types.gen.go
+++ b/internal/test/strict-server/fiber/types.gen.go
@@ -26,6 +26,9 @@ type HeadersExampleParams struct {
 	Header2 *int   `json:"header2,omitempty"`
 }
 
+// UnionExample200JSONResponse0 defines parameters for UnionExample.
+type UnionExample200JSONResponse0 = string
+
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.
 type JSONExampleJSONRequestBody = Example
 

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -985,8 +985,6 @@ type UnionExample200JSONResponse struct {
 	Headers UnionExample200ResponseHeaders
 }
 
-type UnionExample200JSONResponse0 = string
-
 func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer

--- a/internal/test/strict-server/gin/types.gen.go
+++ b/internal/test/strict-server/gin/types.gen.go
@@ -26,6 +26,9 @@ type HeadersExampleParams struct {
 	Header2 *int   `json:"header2,omitempty"`
 }
 
+// UnionExample200JSONResponse0 defines parameters for UnionExample.
+type UnionExample200JSONResponse0 = string
+
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.
 type JSONExampleJSONRequestBody = Example
 

--- a/internal/test/strict-server/gorilla/server.gen.go
+++ b/internal/test/strict-server/gorilla/server.gen.go
@@ -1101,8 +1101,6 @@ type UnionExample200JSONResponse struct {
 	Headers UnionExample200ResponseHeaders
 }
 
-type UnionExample200JSONResponse0 = string
-
 func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer

--- a/internal/test/strict-server/gorilla/types.gen.go
+++ b/internal/test/strict-server/gorilla/types.gen.go
@@ -26,6 +26,9 @@ type HeadersExampleParams struct {
 	Header2 *int   `json:"header2,omitempty"`
 }
 
+// UnionExample200JSONResponse0 defines parameters for UnionExample.
+type UnionExample200JSONResponse0 = string
+
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.
 type JSONExampleJSONRequestBody = Example
 

--- a/internal/test/strict-server/iris/types.gen.go
+++ b/internal/test/strict-server/iris/types.gen.go
@@ -26,6 +26,9 @@ type HeadersExampleParams struct {
 	Header2 *int   `json:"header2,omitempty"`
 }
 
+// UnionExample200JSONResponse0 defines parameters for UnionExample.
+type UnionExample200JSONResponse0 = string
+
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.
 type JSONExampleJSONRequestBody = Example
 

--- a/internal/test/strict-server/stdhttp/server.gen.go
+++ b/internal/test/strict-server/stdhttp/server.gen.go
@@ -1096,8 +1096,6 @@ type UnionExample200JSONResponse struct {
 	Headers UnionExample200ResponseHeaders
 }
 
-type UnionExample200JSONResponse0 = string
-
 func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer

--- a/internal/test/strict-server/stdhttp/types.gen.go
+++ b/internal/test/strict-server/stdhttp/types.gen.go
@@ -26,6 +26,9 @@ type HeadersExampleParams struct {
 	Header2 *int   `json:"header2,omitempty"`
 }
 
+// UnionExample200JSONResponse0 defines parameters for UnionExample.
+type UnionExample200JSONResponse0 = string
+
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.
 type JSONExampleJSONRequestBody = Example
 

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -1104,6 +1104,12 @@ func GenerateTypeDefsForOperation(op OperationDefinition) []TypeDefinition {
 	for _, body := range op.Bodies {
 		typeDefs = append(typeDefs, body.Schema.AdditionalTypes...)
 	}
+
+	for _, resp := range op.Responses {
+		for _, content := range resp.Contents {
+			typeDefs = append(typeDefs, content.Schema.AdditionalTypes...)
+		}
+	}
 	return typeDefs
 }
 

--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -80,10 +80,6 @@
                 }
             {{end}}
 
-            {{- range .Schema.AdditionalTypes}}
-            type {{.TypeName}} {{if .IsAlias }}={{end}} {{.Schema.TypeDecl}}
-            {{- end}}
-
             func (response {{$receiverTypeName}}) Visit{{$opid}}Response(w http.ResponseWriter) error {
                 {{if eq .NameTag "Multipart" -}}
                     writer := multipart.NewWriter(w)


### PR DESCRIPTION
Fixes: #1306

GenerateTypeDefsForOperation() was extracting AdditionalTypes from params and request bodies, but not from response content schemas. This meant that x-go-type-name on an inline response schema was silently ignored — the type definition was created internally but never collected for output.

Add the missing loop over op.Responses[].Contents[].Schema to extract AdditionalTypes, matching the existing pattern for params and bodies. Extend the xgotypename example with a response-level x-go-type-name test case.

Due to this bug, we've neglected to generate types for any types defined inline in responses, so a lot of generated files were affected due to those types being missing.