### PR TITLE
Propagate external refs into allOf

### DIFF
--- a/internal/test/externalref/packageA/externalref.gen.go
+++ b/internal/test/externalref/packageA/externalref.gen.go
@@ -16,18 +16,35 @@ import (
 	externalRef0 "github.com/oapi-codegen/oapi-codegen/v2/internal/test/externalref/packageB"
 )
 
+// EnrichedUser defines model for EnrichedUser.
+type EnrichedUser struct {
+	ExtraField *string              `json:"extra_field,omitempty"`
+	Id         string               `json:"id"`
+	Roles      *[]externalRef0.Role `json:"roles,omitempty"`
+	Username   string               `json:"username"`
+}
+
 // ObjectA defines model for ObjectA.
 type ObjectA struct {
 	Name    *string               `json:"name,omitempty"`
 	ObjectB *externalRef0.ObjectB `json:"object_b,omitempty"`
 }
 
+// StatusPostPayload defines model for StatusPostPayload.
+type StatusPostPayload struct {
+	Reason *string                 `json:"reason,omitempty"`
+	Status externalRef0.StatusEnum `json:"status"`
+}
+
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/4yOMcrDMAxG7/L9/xjI7q25QI8QHKMkbhNZ2OpQgu5e7BS6dOikBw896UBIuyQm1gJ3",
-	"oISVdt/wOt0o6KWi5CSUNVIT7HeqU59CcCiaIy+wDqltjFOV/5lmOPz1n37/jvfiw90vNIxFKIznnQFm",
-	"1uG7+vUFa43Ic4Ljx7Z1SELsJcIBNa5rOY29AgAA//84dUj5+QAAAA==",
+	"H4sIAAAAAAAC/5xTzW7CMAx+F2/HSIhrbkPiDNo0LghVJnEhW5pkSToNVXn3KaEIKjqp7GbX9tfvp+1A",
+	"2MZZQyYG4B0EcaQGS7k0XokjyfdAPveo9aoGvu3g2VMNHJ5m19tZfzhzKD7xQIsqOBJVuU2sA+etIx8V",
+	"FWj6iR6rWpGWuY0nR8AhRK/MAVJilyd2/0EiQtolBqtSv+T9IZjBhkZQWH9d7fNwOuXzexaQMo+3iLEN",
+	"axviGk/aovyvEWegzXzEDE8YrJnswzjbqa6kO4RXq8simbYBvgWUjTLAoM3R7di9rWPCluX4BkRE9U3A",
+	"QJm+nIq0mQ8tHqoKZeexQG8YZvWevlrlSWaaPdxugtGXv2DIR8nRL89b3c8jNQ/SLXlco0fv8ZT7nMdf",
+	"oQ5VKQk36/fi8r4ytQVuWq0ZWEcGnQIOkFXHYzhP0m8AAAD//1KVtScdBAAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/externalref/packageA/spec.yaml
+++ b/internal/test/externalref/packageA/spec.yaml
@@ -6,3 +6,22 @@ components:
           type: string
         object_b:
           $ref: ../packageB/spec.yaml#/components/schemas/ObjectB
+    # Reproduces https://github.com/oapi-codegen/oapi-codegen/issues/2288
+    # allOf extending a cross-file schema should qualify nested type refs
+    EnrichedUser:
+      allOf:
+        - $ref: '../packageB/spec.yaml#/components/schemas/User'
+        - type: object
+          properties:
+            extra_field:
+              type: string
+    # Reproduces https://github.com/oapi-codegen/oapi-codegen/issues/2288 (comment)
+    # allOf extending a cross-file schema whose own definition uses allOf
+    # with local refs — those inner refs must also be qualified.
+    StatusPostPayload:
+      allOf:
+        - $ref: '../packageB/spec.yaml#/components/schemas/StatusV1'
+        - type: object
+          properties:
+            reason:
+              type: string

--- a/internal/test/externalref/packageB/externalref.gen.go
+++ b/internal/test/externalref/packageB/externalref.gen.go
@@ -15,16 +15,73 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
+// Defines values for Role.
+const (
+	RoleAdmin Role = "admin"
+	RoleUser  Role = "user"
+)
+
+// Valid indicates whether the value is a known member of the Role enum.
+func (e Role) Valid() bool {
+	switch e {
+	case RoleAdmin:
+		return true
+	case RoleUser:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for StatusEnum.
+const (
+	Active   StatusEnum = "active"
+	Inactive StatusEnum = "inactive"
+)
+
+// Valid indicates whether the value is a known member of the StatusEnum enum.
+func (e StatusEnum) Valid() bool {
+	switch e {
+	case Active:
+		return true
+	case Inactive:
+		return true
+	default:
+		return false
+	}
+}
+
 // ObjectB defines model for ObjectB.
 type ObjectB struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// Role defines model for Role.
+type Role string
+
+// StatusEnum defines model for StatusEnum.
+type StatusEnum string
+
+// StatusV1 defines model for StatusV1.
+type StatusV1 struct {
+	Status StatusEnum `json:"status"`
+}
+
+// User defines model for User.
+type User struct {
+	Id       string  `json:"id"`
+	Roles    *[]Role `json:"roles,omitempty"`
+	Username string  `json:"username"`
+}
+
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/yTJwQ0CMQxE0V7mnApypAFqCNHAGm1sKzYHtNreUZa5zJfegW7DTakZqAeibxztyvvj",
-	"zZ63lT7NOVN4gbbB9fl1oiJyir5wrhWIPg1VP/teYE5tLqhAgbfc4i/nLwAA//8neaWPdgAAAA==",
+	"H4sIAAAAAAAC/4RRTUvDQBT8L6PHheB1j4LngqKX0sOavNiV/XL3rVDK/nd5a7CxtXjKhJnJm5kcMUaf",
+	"YqDABfqIMu7Jmw43r+808r3AlGOizJY6EYwnefIhETQKZxve0FpTeIyuUxSqh97CTN4GKNRCGTt1blF4",
+	"YsO1PHT5yjay/SQo2LDA696XO3Ea5zYz9PY8a+kaQbeZZmjcDKfCw9J2WKWQFpk+qs00SZTlA6f7sc+C",
+	"tmsKz1LrYh87/bGOQo5u4Zn8v5H6ku3nqsnZHORdlrz2A34ntxNW8ssCordhjtChOqcQEwWTLDSgkAzv",
+	"yzfTvgIAAP//mT+m2CQCAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/externalref/packageB/spec.yaml
+++ b/internal/test/externalref/packageB/spec.yaml
@@ -4,3 +4,31 @@ components:
       properties:
         name:
           type: string
+    Role:
+      type: string
+      enum: [admin, user]
+    User:
+      type: object
+      required: [id, username]
+      properties:
+        id:
+          type: string
+        username:
+          type: string
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/Role'
+    StatusEnum:
+      type: string
+      enum: [active, inactive]
+    # StatusV1 uses allOf internally with a local ref to StatusEnum.
+    # This exercises the case where an external schema's own allOf
+    # sub-schemas contain local refs that must be rewritten.
+    StatusV1:
+      allOf:
+        - type: object
+          required: [status]
+          properties:
+            status:
+              $ref: '#/components/schemas/StatusEnum'

--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -168,14 +168,59 @@ func valueWithPropagatedRef(ref *openapi3.SchemaRef) (openapi3.Schema, error) {
 	}
 	remoteComponent := pathParts[0]
 
+	propagateRemoteRefs(remoteComponent, &schema)
+
+	return schema, nil
+}
+
+// propagateRemoteRefs rewrites local "#/..." refs within a schema to be
+// qualified with the remote component path. This is needed so that when an
+// external schema is flattened via allOf, nested type references (array items,
+// additionalProperties, sub-object properties) retain their external
+// qualification. See https://github.com/oapi-codegen/oapi-codegen/issues/2288
+func propagateRemoteRefs(remoteComponent string, schema *openapi3.Schema) {
 	for _, value := range schema.Properties {
 		if len(value.Ref) > 0 && value.Ref[0] == '#' {
-			// local reference, should propagate remote
 			value.Ref = remoteComponent + value.Ref
+		} else if value.Value != nil {
+			propagateRemoteRefs(remoteComponent, value.Value)
 		}
 	}
 
-	return schema, nil
+	if schema.Items != nil {
+		if len(schema.Items.Ref) > 0 && schema.Items.Ref[0] == '#' {
+			schema.Items.Ref = remoteComponent + schema.Items.Ref
+		} else if schema.Items.Value != nil {
+			propagateRemoteRefs(remoteComponent, schema.Items.Value)
+		}
+	}
+
+	if schema.AdditionalProperties.Schema != nil {
+		ap := schema.AdditionalProperties.Schema
+		if len(ap.Ref) > 0 && ap.Ref[0] == '#' {
+			ap.Ref = remoteComponent + ap.Ref
+		} else if ap.Value != nil {
+			propagateRemoteRefs(remoteComponent, ap.Value)
+		}
+	}
+
+	for _, list := range [][]*openapi3.SchemaRef{schema.AllOf, schema.AnyOf, schema.OneOf} {
+		for _, ref := range list {
+			if len(ref.Ref) > 0 && ref.Ref[0] == '#' {
+				ref.Ref = remoteComponent + ref.Ref
+			} else if ref.Value != nil {
+				propagateRemoteRefs(remoteComponent, ref.Value)
+			}
+		}
+	}
+
+	if schema.Not != nil {
+		if len(schema.Not.Ref) > 0 && schema.Not.Ref[0] == '#' {
+			schema.Not.Ref = remoteComponent + schema.Not.Ref
+		} else if schema.Not.Value != nil {
+			propagateRemoteRefs(remoteComponent, schema.Not.Value)
+		}
+	}
 }
 
 func mergeAllOf(allOf []*openapi3.SchemaRef, seenSchemaRef map[string]bool) (openapi3.Schema, error) {


### PR DESCRIPTION
Closes: #2288

When allOf references an external schema, valueWithPropagatedRef was only rewriting direct property $refs to include the remote file path. Nested refs — array items, additionalProperties, and sub-object properties — were left as local "#/..." refs, producing unqualified Go type names that fail to compile.

Extract the propagation logic into a recursive propagateRemoteRefs function that walks Properties, Items, and AdditionalProperties, rewriting any local ref it finds. This ensures types like `*[]externalRef0.Role` are correctly qualified instead of the broken `*[]Role`.

Extend the externalref test with a User/Role/EnrichedUser scenario that exercises the array-items case from the issue report.