### PR TITLE
fix: allOf cycle detection oversight

### DIFF
--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -32,6 +32,13 @@ func mergeSchemas(allOf []*openapi3.SchemaRef, path []string) (Schema, error) {
 		return Schema{}, err
 	}
 
+	// Seed allOf[0]'s ref so that if s1's own AllOf contains a back-reference
+	// to itself, the cycle is detected during recursive merging.
+	seenTopLevel := make(map[string]bool)
+	if allOf[0].Ref != "" {
+		seenTopLevel[allOf[0].Ref] = true
+	}
+
 	for i := 1; i < n; i++ {
 		var err error
 		oneOfSchema, err := valueWithPropagatedRef(allOf[i])
@@ -40,8 +47,12 @@ func mergeSchemas(allOf []*openapi3.SchemaRef, path []string) (Schema, error) {
 		}
 
 		seenSchemaRef := make(map[string]bool)
+		for k := range seenTopLevel {
+			seenSchemaRef[k] = true
+		}
 		if allOf[i].Ref != "" {
 			seenSchemaRef[allOf[i].Ref] = true
+			seenTopLevel[allOf[i].Ref] = true
 		}
 		schema, err = mergeOpenapiSchemas(schema, oneOfSchema, true, seenSchemaRef)
 		if err != nil {


### PR DESCRIPTION
PR #1377 was merged too early. This is a small follow-up tweak to make sure that #1373 is fixed properly.

seed allOf[0] ref into cycle detection to prevent stack overflow when self-ref is first

When the self-referencing $ref appears at position 0 in allOf, its ref was never added to seenSchemaRef. If s1's own AllOf contained a back-reference to itself, mergeAllOf would not detect the cycle.

Seed allOf[0].Ref into a top-level seen set that is copied into each iteration's seenSchemaRef map, closing this gap.