### PR TITLE
Update release-drafter config for V7

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,1 +1,0 @@
-_extends: oapi-codegen/.github


### PR DESCRIPTION
We no longer need to explicitly inherit release drafter settings from the org, and the V6 syntax no longer works, so I'm deleting the file.