### PR TITLE
docs: remove non-breaking spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -2134,11 +2134,11 @@ To get `oapi-codegen`'s multi-package support working, we need to set up our dir
 
 ```
 ├── admin
-│   ├── cfg.yaml
-│   └── generate.go
+│   ├── cfg.yaml
+│   └── generate.go
 └── common
     ├── cfg.yaml
-    └── generate.go
+    └── generate.go
 ```
 
 We could start with our configuration file for our admin API spec:


### PR DESCRIPTION
Although they're safe in this case, Renovate's "hidden whitespace"
detection is flagging it. As we don't need them, we can remove them.
