### PR TITLE
Flagify enum validator generation

### DIFF
--- a/configuration-schema.json
+++ b/configuration-schema.json
@@ -135,6 +135,10 @@
           "type": "boolean",
           "description": "Whether to skip pruning unused components on the generated code"
         },
+        "skip-enum-validate": {
+          "type": "boolean",
+          "description": "Whether to skip generation of the Valid() method on enum types"
+        },
         "include-tags": {
           "type": "array",
           "description": "Only include operations that have one of these tags. Ignored when empty.",

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -1045,7 +1045,10 @@ func GenerateEnums(t *template.Template, types []TypeDefinition) (string, error)
 
 	// Now see if enums conflict with any non-enum typenames
 
-	return GenerateTemplates([]string{"constants.tmpl"}, t, Constants{EnumDefinitions: enums})
+	return GenerateTemplates([]string{"constants.tmpl"}, t, Constants{
+		EnumDefinitions:  enums,
+		SkipEnumValidate: globalState.options.OutputOptions.SkipEnumValidate,
+	})
 }
 
 // GenerateImports generates our import statements and package definition.

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -319,6 +319,12 @@ type OutputOptions struct {
 	SkipFmt bool `yaml:"skip-fmt,omitempty"`
 	// Whether to skip pruning unused components on the generated code
 	SkipPrune bool `yaml:"skip-prune,omitempty"`
+	// SkipEnumValidate disables the generation of the `Valid()` method on
+	// enum types. By default each generated enum type includes a `Valid()
+	// bool` method which returns true when the value matches one of the
+	// defined constants; set this to true to suppress that method when it
+	// conflicts with user-defined methods of the same name.
+	SkipEnumValidate bool `yaml:"skip-enum-validate,omitempty"`
 	// Only include operations that have one of these tags. Ignored when empty.
 	IncludeTags []string `yaml:"include-tags,omitempty"`
 	// Exclude operations that have one of these tags. Ignored when empty.

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -200,6 +200,9 @@ type Constants struct {
 	SecuritySchemeProviderNames []string
 	// EnumDefinitions holds type and value information for all enums
 	EnumDefinitions []EnumDefinition
+	// SkipEnumValidate suppresses generation of the `Valid()` method on
+	// enum types. Mirrors OutputOptions.SkipEnumValidate.
+	SkipEnumValidate bool
 }
 
 // TypeDefinition describes a Go type definition in generated code.

--- a/pkg/codegen/templates/constants.tmpl
+++ b/pkg/codegen/templates/constants.tmpl
@@ -12,7 +12,7 @@ const (
   {{$name}} {{$Enum.TypeName}} = {{$Enum.ValueWrapper}}{{$value}}{{$Enum.ValueWrapper -}}
 {{end}}
 )
-
+{{if not $.SkipEnumValidate}}
 // Valid indicates whether the value is a known member of the {{$Enum.TypeName}} enum.
 func (e {{$Enum.TypeName}}) Valid() bool {
     switch e {
@@ -22,4 +22,5 @@ func (e {{$Enum.TypeName}}) Valid() bool {
         return false
     }
 }
+{{end}}
 {{end}}


### PR DESCRIPTION
Add an `output-options.skip-enum-validate` flag that suppresses the `Valid()` method generated on enum types. The method is still emitted by default; users whose code defines its own `Valid()` on the same type can now opt out instead of seeing a compile-time conflict.

Relates to PR #2227, which introduced the `Valid()` method.