### PR TITLE
Strict server: gate no-content response headers on nullable/optional

### DIFF
--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -39,6 +39,9 @@ type ServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(w http.ResponseWriter, r *http.Request)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(w http.ResponseWriter, r *http.Request)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(w http.ResponseWriter, r *http.Request)
 
@@ -91,6 +94,11 @@ func (_ Unimplemented) MultipartRelatedExample(w http.ResponseWriter, r *http.Re
 
 // (POST /multiple)
 func (_ Unimplemented) MultipleRequestAndResponseTypes(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// (POST /no-content-headers)
+func (_ Unimplemented) NoContentHeaders(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -200,6 +208,20 @@ func (siw *ServerInterfaceWrapper) MultipleRequestAndResponseTypes(w http.Respon
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.MultipleRequestAndResponseTypes(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// NoContentHeaders operation middleware
+func (siw *ServerInterfaceWrapper) NoContentHeaders(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.NoContentHeaders(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -537,6 +559,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/multiple", wrapper.MultipleRequestAndResponseTypes)
 	})
 	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/no-content-headers", wrapper.NoContentHeaders)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/required-json-body", wrapper.RequiredJSONBody)
 	})
 	r.Group(func(r chi.Router) {
@@ -780,6 +805,33 @@ type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.WriteHeader(400)
+	return nil
+}
+
+type NoContentHeadersRequestObject struct {
+}
+
+type NoContentHeadersResponseObject interface {
+	VisitNoContentHeadersResponse(w http.ResponseWriter) error
+}
+
+type NoContentHeaders204ResponseHeaders struct {
+	NullableHeader *string
+	OptionalHeader *string
+}
+
+type NoContentHeaders204Response struct {
+	Headers NoContentHeaders204ResponseHeaders
+}
+
+func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http.ResponseWriter) error {
+	if response.Headers.NullableHeader != nil {
+		w.Header().Set("nullable-header", fmt.Sprint(*response.Headers.NullableHeader))
+	}
+	if response.Headers.OptionalHeader != nil {
+		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
+	}
+	w.WriteHeader(204)
 	return nil
 }
 
@@ -1233,6 +1285,9 @@ type StrictServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(ctx context.Context, request RequiredJSONBodyRequestObject) (RequiredJSONBodyResponseObject, error)
 
@@ -1456,6 +1511,30 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(w http.ResponseWriter, 
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
 		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// NoContentHeaders operation middleware
+func (sh *strictHandler) NoContentHeaders(w http.ResponseWriter, r *http.Request) {
+	var request NoContentHeadersRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.NoContentHeaders(ctx, request.(NoContentHeadersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "NoContentHeaders")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(NoContentHeadersResponseObject); ok {
+		if err := validResponse.VisitNoContentHeadersResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -1782,26 +1861,27 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZzXLbNhB+FQzaUwqatuOTbo0nk7Zp645snzo+QMRKQgICCLAUrdHo3TsgQP3SjpRK",
-	"lieTm0TuH75vd7kAZrQwpTUaNHram1EH3hrtofkz4MLBlwo8hn8CfOGkRWk07dF3XPTTuzmjDirPBwpa",
-	"9SBfGI2gG1VurZIFD6r5Jx/0Z9QXYyh5+PWzgyHt0Z/yZSh5fOtzeOSlVUDn8znbiODmI2V0DFyAa6KN",
-	"Py/iKr5U0oGgPXQVsBVfOLVAe9Sjk3pEg9GodrmTmtQII3AhmqCaggwCbZy9GbXOWHAoI4YTriro9pye",
-	"mMEnKDCuUOqh2cb62mjkUnsi5HAIDjSSBC4JNjzxlbXGIQgymJLgoUDiwU3AUUZRYgiM3q4+JylgTxmd",
-	"gPPR0cXZ+dl54NNY0NxK2qNvm0eMWo7jZkELAq3pyos/bm/+JtITXqEpOcqCKzUlJXd+zBUIIjWaEGJV",
-	"oD+jjSfXJMbvImm/T1AympLvnRHTYyRUk7cr6X55fv5CeTtn9Co667KxCCpfKcDGzJBXqgPze/1Zm1oT",
-	"cM64tLK8rBRKyx2ucrWO9l+tyC6QL+zlQ+PKTHDkR0L9UJ5ODXzmQHEM7eSrBPSj5H48rJg/Kgv/x89J",
-	"OUj9uLNP3Y5N7cnY1AQNEcAVqSWOSau40WClJpx4qUcKSBsU6yRTQfos/qpFP63lLtg4ej9ja1Yes7qu",
-	"s6aAKqdAF0Z8G4WMypKPILd6tK4ebHOkPTqYYkjZ7Q/cgQqZUYRHzK3icgOYTZcv1NJ/IH2wwo7l2g5e",
-	"WWAkG6T66C7cVF4kSIVBo9VlxBtSSh+qNL70Y1MpQbiq+dTH/rA9cfSTepg8msI8+tjBNubM73sMWVAb",
-	"Mus01N7BI36V2j0Sf1/6Xrqm9qeo2ROIbGSyzzCtjROZ5Y6XgOB8PgtxzoOtEXSY/GchSQquyQCI5iUI",
-	"wocIjnwwJJn0HfxEvx/MxyiyNNVsOBZ/ev/OaACv2YRQRoMD2ov4sT02ew/HpapFM26FszVXTyV8Emmh",
-	"czD0YSDp4rgDv+ipvyJxmi3T87m5dTjwEkkdmHx68A4tYZdh+4CDx2vvAlV8+DRmSWsX2L5xjtkBxYkU",
-	"YPLSXu1p+WSgeguFHEoQWVpFFmN7qiVcG104wPUNSPgYaoNkYYwMpgTHQCICzfexBlJWHonl3hOJTRdR",
-	"Mp4VCdhqHvfLyK6jp7tlO32O1TdH4vTNqRi9Or/YX+XtkfNmbSPxRD32/3wfZfY9MTvYjmXP/dbh/J6o",
-	"nGuJ42zlyLm7hH+LAstvegFyEiYiLYgDrJwGQSaSt8egW7WZDCxp7ZqFYhjLaag9/t5nIGLP2rqkzx6B",
-	"P3zHB7Snu1hgVFdKNQNkYmVtSe3L1tK2W9Msg6tO9a7u/DJVU2n53LXBfXhN0kS/+aWSRr/SSwGuEJzm",
-	"KCfwy2FOk7atGA03w6buN9hjO3p4eH2XZ8fOujmj8Z4rNszKqdDVEG0vz+P92Jmv+WgE7kyanFsZUPov",
-	"AAD//ysZ4qQMHQAA",
+	"H4sIAAAAAAAC/+xZ23LbNhN+lR38/0Wbkqbi+Ep3TSaTtmmTjmxfdXwBESsJCQkgwFKyRqOZPkSfsE/S",
+	"AQHqSNtSqoMn0zuJ3BP3211+S8xYrkujFSpyrDtjFp3RymH9p8+FxS8VOvL/BLrcSkNSK9Zlr7noxXvz",
+	"hFmsHO8X2Kh7+VwrQlWrcmMKmXOvmn1yXn/GXD7Ckvtf/7c4YF32v2wZShbuugzveWkKZPP5PNmI4ON7",
+	"lrARcoG2jjb8fBme4kslLQrWJVthsuKLpgZZlzmyUg2ZNxrULndSk4pwiNZH41VjkF6gibM7Y8Zqg5Zk",
+	"yOGYFxW2e45XdP8T5hSeUKqB3s71G62IS+VAyMEALSqCmFzwNhy4yhhtCQX0p+A95AQO7RgtSxhJ8oGx",
+	"69XrEAN2LGFjtC44ennRueh4PLVBxY1kXfaqvpQww2lUP9ACQKPb6uKX648fQDrgFemSk8x5UUyh5NaN",
+	"eIECpCLtQ6xyches9mTrwvhZRO23MZUJi8X3WovpMQqqrtuVcr/sdE5Ut/OEXQVnbTYWQWUrDVibGfCq",
+	"aMn5rfqs9EQBWqttfLKsrAqShltaxWo92781IrukfGEvG2hbpoITP1LWD+Xp3IlPLRac/Dh5EoBekNwP",
+	"hxXzR0Xh3/g5KwZxHrfOqeuRnjgY6QmQBoG8gImkETSKGwNWKuDgpBoWCE1QSSuYBcbX4o9K9OKz3Hgb",
+	"R59nyZqV+3QymaR1A1W2QJVr8XUQJkyWfIiZUcN1dW+bE+uy/pR8yW6/4A7UyAkjvKfMFFxuJGbT5YlG",
+	"+n+ZPlhjh3ZVOo0QpSuErr1xPyxk4bvLztX30BgODaxrOV4AVwJUVRSeli5lonn4+8+/AO/R5tKhAxpx",
+	"gko5pIUAtwi6lORJ1cDqEmi0NLPV+x/0mxDTTzH8rTq8ansSiFrrRLaJOuZiHYjmZsNRt2uhyUCr+nbH",
+	"BAQa6pv6nkj7cUK1IxAHHHgpT/Ua3QSchlI6PyfDTTfSVSGAFxM+dWFCb3O+XlT33K8ejUcnfskG0/+2",
+	"ieACWt/b54H2Bu/pSWj3GD37wnfqqbY/RPVWJtKhTj/jdKKtSA23vERC67KZj3PubQ2xxeTvC0nIuYI+",
+	"guIlCuADQgvvNESTrgWf4Pedfh9ElqbqlW/xp/vHjPnk1WsgS5h3wLohf8ke6/bdcaFqshk+RqRrrh4q",
+	"+CjSpM7iwHlK2IZxS/6Cp96KxHmW1sdrc+vzzCmK2iP58OrjR8Iu684Bqd9znwJVuPhwzqLWLmn7Sia5",
+	"QxbHUqDOSnO1p+WzJdUZzOVAolhwzBDbQyPhjVa5RVpfAf3LUGmChTHoT2tKGDJQvx8nCGXlCAx3DiTV",
+	"U6SQ4Wud2OaMt8vIIg28WY7Tx1B9cSRMX5wL0avOy/1VXh25btZWuQf6sffr2yCz7zfLg+2Me268h/N7",
+	"pnb2O97TO2Lcwpbv9Bzl2DMiJcAiVVahgLHkzYford6MBpawtnGhuF8t2FBzALEPIUoetXXJHj2EuPuG",
+	"P5Gf72gnOfECfqquqZR87ODm1t+GyOg331RSq2d6LMMLQqs4yTH+cJjvedtWtMKPg7rvN9BLdvRw9/yO",
+	"L49ddfOEhZPGMDArW/ipRmS6WRZOKC/chA+HaC+kzriRPkv/BAAA///qGF+njh4AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/chi/server.go
+++ b/internal/test/strict-server/chi/server.go
@@ -122,6 +122,10 @@ func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExample
 	return HeadersExample200JSONResponse{Body: *request.Body, Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
+func (s StrictServer) NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error) {
+	return NoContentHeaders204Response{}, nil
+}
+
 func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
 	return ReusableResponses200JSONResponse{ReusableresponseJSONResponse: ReusableresponseJSONResponse{Body: *request.Body}}, nil
 }

--- a/internal/test/strict-server/client/client.gen.go
+++ b/internal/test/strict-server/client/client.gen.go
@@ -244,6 +244,9 @@ type ClientInterface interface {
 
 	MultipleRequestAndResponseTypesWithTextBody(ctx context.Context, body MultipleRequestAndResponseTypesTextRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// NoContentHeaders request
+	NoContentHeaders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RequiredJSONBodyWithBody request with any body
 	RequiredJSONBodyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -375,6 +378,18 @@ func (c *Client) MultipleRequestAndResponseTypesWithFormdataBody(ctx context.Con
 
 func (c *Client) MultipleRequestAndResponseTypesWithTextBody(ctx context.Context, body MultipleRequestAndResponseTypesTextRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewMultipleRequestAndResponseTypesRequestWithTextBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) NoContentHeaders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewNoContentHeadersRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -745,6 +760,33 @@ func NewMultipleRequestAndResponseTypesRequestWithBody(server string, contentTyp
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewNoContentHeadersRequest generates requests for NoContentHeaders
+func NewNoContentHeadersRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/no-content-headers")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -1208,6 +1250,9 @@ type ClientWithResponsesInterface interface {
 
 	MultipleRequestAndResponseTypesWithTextBodyWithResponse(ctx context.Context, body MultipleRequestAndResponseTypesTextRequestBody, reqEditors ...RequestEditorFn) (*MultipleRequestAndResponseTypesResponse, error)
 
+	// NoContentHeadersWithResponse request
+	NoContentHeadersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*NoContentHeadersResponse, error)
+
 	// RequiredJSONBodyWithBodyWithResponse request with any body
 	RequiredJSONBodyWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequiredJSONBodyResponse, error)
 
@@ -1365,6 +1410,35 @@ func (r MultipleRequestAndResponseTypesResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r MultipleRequestAndResponseTypesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type NoContentHeadersResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r NoContentHeadersResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r NoContentHeadersResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r NoContentHeadersResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -1734,6 +1808,15 @@ func (c *ClientWithResponses) MultipleRequestAndResponseTypesWithTextBodyWithRes
 	return ParseMultipleRequestAndResponseTypesResponse(rsp)
 }
 
+// NoContentHeadersWithResponse request returning *NoContentHeadersResponse
+func (c *ClientWithResponses) NoContentHeadersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*NoContentHeadersResponse, error) {
+	rsp, err := c.NoContentHeaders(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseNoContentHeadersResponse(rsp)
+}
+
 // RequiredJSONBodyWithBodyWithResponse request with arbitrary body returning *RequiredJSONBodyResponse
 func (c *ClientWithResponses) RequiredJSONBodyWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequiredJSONBodyResponse, error) {
 	rsp, err := c.RequiredJSONBodyWithBody(ctx, contentType, body, reqEditors...)
@@ -1962,6 +2045,22 @@ func ParseMultipleRequestAndResponseTypesResponse(rsp *http.Response) (*Multiple
 	case rsp.StatusCode == 200:
 		// Content-type (text/plain) unsupported
 
+	}
+
+	return response, nil
+}
+
+// ParseNoContentHeadersResponse parses an HTTP response from a NoContentHeadersWithResponse call
+func ParseNoContentHeadersResponse(rsp *http.Response) (*NoContentHeadersResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &NoContentHeadersResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
 	}
 
 	return response, nil

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -39,6 +39,9 @@ type ServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(ctx echo.Context) error
 
+	// (POST /no-content-headers)
+	NoContentHeaders(ctx echo.Context) error
+
 	// (POST /required-json-body)
 	RequiredJSONBody(ctx echo.Context) error
 
@@ -108,6 +111,15 @@ func (w *ServerInterfaceWrapper) MultipleRequestAndResponseTypes(ctx echo.Contex
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.MultipleRequestAndResponseTypes(ctx)
+	return err
+}
+
+// NoContentHeaders converts echo context to params.
+func (w *ServerInterfaceWrapper) NoContentHeaders(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.NoContentHeaders(ctx)
 	return err
 }
 
@@ -277,6 +289,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/multipart", wrapper.MultipartExample)
 	router.POST(baseURL+"/multipart-related", wrapper.MultipartRelatedExample)
 	router.POST(baseURL+"/multiple", wrapper.MultipleRequestAndResponseTypes)
+	router.POST(baseURL+"/no-content-headers", wrapper.NoContentHeaders)
 	router.POST(baseURL+"/required-json-body", wrapper.RequiredJSONBody)
 	router.POST(baseURL+"/required-text-body", wrapper.RequiredTextBody)
 	router.GET(baseURL+"/reserved-go-keyword-parameters/:type", wrapper.ReservedGoKeywordParameters)
@@ -500,6 +513,33 @@ type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.WriteHeader(400)
+	return nil
+}
+
+type NoContentHeadersRequestObject struct {
+}
+
+type NoContentHeadersResponseObject interface {
+	VisitNoContentHeadersResponse(w http.ResponseWriter) error
+}
+
+type NoContentHeaders204ResponseHeaders struct {
+	NullableHeader *string
+	OptionalHeader *string
+}
+
+type NoContentHeaders204Response struct {
+	Headers NoContentHeaders204ResponseHeaders
+}
+
+func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http.ResponseWriter) error {
+	if response.Headers.NullableHeader != nil {
+		w.Header().Set("nullable-header", fmt.Sprint(*response.Headers.NullableHeader))
+	}
+	if response.Headers.OptionalHeader != nil {
+		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
+	}
+	w.WriteHeader(204)
 	return nil
 }
 
@@ -953,6 +993,9 @@ type StrictServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(ctx context.Context, request RequiredJSONBodyRequestObject) (RequiredJSONBodyResponseObject, error)
 
@@ -1147,6 +1190,29 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx echo.Context) error
 		return err
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
 		return validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// NoContentHeaders operation middleware
+func (sh *strictHandler) NoContentHeaders(ctx echo.Context) error {
+	var request NoContentHeadersRequestObject
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.NoContentHeaders(ctx.Request().Context(), request.(NoContentHeadersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "NoContentHeaders")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(NoContentHeadersResponseObject); ok {
+		return validResponse.VisitNoContentHeadersResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -1455,26 +1521,27 @@ func (sh *strictHandler) UnionExample(ctx echo.Context) error {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZzXLbNhB+FQzaUwqatuOTbo0nk7Zp645snzo+QMRKQgICCLAUrdHo3TsgQP3SjpRK",
-	"lieTm0TuH75vd7kAZrQwpTUaNHram1EH3hrtofkz4MLBlwo8hn8CfOGkRWk07dF3XPTTuzmjDirPBwpa",
-	"9SBfGI2gG1VurZIFD6r5Jx/0Z9QXYyh5+PWzgyHt0Z/yZSh5fOtzeOSlVUDn8znbiODmI2V0DFyAa6KN",
-	"Py/iKr5U0oGgPXQVsBVfOLVAe9Sjk3pEg9GodrmTmtQII3AhmqCaggwCbZy9GbXOWHAoI4YTriro9pye",
-	"mMEnKDCuUOqh2cb62mjkUnsi5HAIDjSSBC4JNjzxlbXGIQgymJLgoUDiwU3AUUZRYgiM3q4+JylgTxmd",
-	"gPPR0cXZ+dl54NNY0NxK2qNvm0eMWo7jZkELAq3pyos/bm/+JtITXqEpOcqCKzUlJXd+zBUIIjWaEGJV",
-	"oD+jjSfXJMbvImm/T1AympLvnRHTYyRUk7cr6X55fv5CeTtn9Co667KxCCpfKcDGzJBXqgPze/1Zm1oT",
-	"cM64tLK8rBRKyx2ucrWO9l+tyC6QL+zlQ+PKTHDkR0L9UJ5ODXzmQHEM7eSrBPSj5H48rJg/Kgv/x89J",
-	"OUj9uLNP3Y5N7cnY1AQNEcAVqSWOSau40WClJpx4qUcKSBsU6yRTQfos/qpFP63lLtg4ej9ja1Yes7qu",
-	"s6aAKqdAF0Z8G4WMypKPILd6tK4ebHOkPTqYYkjZ7Q/cgQqZUYRHzK3icgOYTZcv1NJ/IH2wwo7l2g5e",
-	"WWAkG6T66C7cVF4kSIVBo9VlxBtSSh+qNL70Y1MpQbiq+dTH/rA9cfSTepg8msI8+tjBNubM73sMWVAb",
-	"Mus01N7BI36V2j0Sf1/6Xrqm9qeo2ROIbGSyzzCtjROZ5Y6XgOB8PgtxzoOtEXSY/GchSQquyQCI5iUI",
-	"wocIjnwwJJn0HfxEvx/MxyiyNNVsOBZ/ev/OaACv2YRQRoMD2ov4sT02ew/HpapFM26FszVXTyV8Emmh",
-	"czD0YSDp4rgDv+ipvyJxmi3T87m5dTjwEkkdmHx68A4tYZdh+4CDx2vvAlV8+DRmSWsX2L5xjtkBxYkU",
-	"YPLSXu1p+WSgeguFHEoQWVpFFmN7qiVcG104wPUNSPgYaoNkYYwMpgTHQCICzfexBlJWHonl3hOJTRdR",
-	"Mp4VCdhqHvfLyK6jp7tlO32O1TdH4vTNqRi9Or/YX+XtkfNmbSPxRD32/3wfZfY9MTvYjmXP/dbh/J6o",
-	"nGuJ42zlyLm7hH+LAstvegFyEiYiLYgDrJwGQSaSt8egW7WZDCxp7ZqFYhjLaag9/t5nIGLP2rqkzx6B",
-	"P3zHB7Snu1hgVFdKNQNkYmVtSe3L1tK2W9Msg6tO9a7u/DJVU2n53LXBfXhN0kS/+aWSRr/SSwGuEJzm",
-	"KCfwy2FOk7atGA03w6buN9hjO3p4eH2XZ8fOujmj8Z4rNszKqdDVEG0vz+P92Jmv+WgE7kyanFsZUPov",
-	"AAD//ysZ4qQMHQAA",
+	"H4sIAAAAAAAC/+xZ23LbNhN+lR38/0Wbkqbi+Ep3TSaTtmmTjmxfdXwBESsJCQkgwFKyRqOZPkSfsE/S",
+	"AQHqSNtSqoMn0zuJ3BP3211+S8xYrkujFSpyrDtjFp3RymH9p8+FxS8VOvL/BLrcSkNSK9Zlr7noxXvz",
+	"hFmsHO8X2Kh7+VwrQlWrcmMKmXOvmn1yXn/GXD7Ckvtf/7c4YF32v2wZShbuugzveWkKZPP5PNmI4ON7",
+	"lrARcoG2jjb8fBme4kslLQrWJVthsuKLpgZZlzmyUg2ZNxrULndSk4pwiNZH41VjkF6gibM7Y8Zqg5Zk",
+	"yOGYFxW2e45XdP8T5hSeUKqB3s71G62IS+VAyMEALSqCmFzwNhy4yhhtCQX0p+A95AQO7RgtSxhJ8oGx",
+	"69XrEAN2LGFjtC44ennRueh4PLVBxY1kXfaqvpQww2lUP9ACQKPb6uKX648fQDrgFemSk8x5UUyh5NaN",
+	"eIECpCLtQ6xyches9mTrwvhZRO23MZUJi8X3WovpMQqqrtuVcr/sdE5Ut/OEXQVnbTYWQWUrDVibGfCq",
+	"aMn5rfqs9EQBWqttfLKsrAqShltaxWo92781IrukfGEvG2hbpoITP1LWD+Xp3IlPLRac/Dh5EoBekNwP",
+	"hxXzR0Xh3/g5KwZxHrfOqeuRnjgY6QmQBoG8gImkETSKGwNWKuDgpBoWCE1QSSuYBcbX4o9K9OKz3Hgb",
+	"R59nyZqV+3QymaR1A1W2QJVr8XUQJkyWfIiZUcN1dW+bE+uy/pR8yW6/4A7UyAkjvKfMFFxuJGbT5YlG",
+	"+n+ZPlhjh3ZVOo0QpSuErr1xPyxk4bvLztX30BgODaxrOV4AVwJUVRSeli5lonn4+8+/AO/R5tKhAxpx",
+	"gko5pIUAtwi6lORJ1cDqEmi0NLPV+x/0mxDTTzH8rTq8ansSiFrrRLaJOuZiHYjmZsNRt2uhyUCr+nbH",
+	"BAQa6pv6nkj7cUK1IxAHHHgpT/Ua3QSchlI6PyfDTTfSVSGAFxM+dWFCb3O+XlT33K8ejUcnfskG0/+2",
+	"ieACWt/b54H2Bu/pSWj3GD37wnfqqbY/RPVWJtKhTj/jdKKtSA23vERC67KZj3PubQ2xxeTvC0nIuYI+",
+	"guIlCuADQgvvNESTrgWf4Pedfh9ElqbqlW/xp/vHjPnk1WsgS5h3wLohf8ke6/bdcaFqshk+RqRrrh4q",
+	"+CjSpM7iwHlK2IZxS/6Cp96KxHmW1sdrc+vzzCmK2iP58OrjR8Iu684Bqd9znwJVuPhwzqLWLmn7Sia5",
+	"QxbHUqDOSnO1p+WzJdUZzOVAolhwzBDbQyPhjVa5RVpfAf3LUGmChTHoT2tKGDJQvx8nCGXlCAx3DiTV",
+	"U6SQ4Wud2OaMt8vIIg28WY7Tx1B9cSRMX5wL0avOy/1VXh25btZWuQf6sffr2yCz7zfLg+2Me268h/N7",
+	"pnb2O97TO2Lcwpbv9Bzl2DMiJcAiVVahgLHkzYford6MBpawtnGhuF8t2FBzALEPIUoetXXJHj2EuPuG",
+	"P5Gf72gnOfECfqquqZR87ODm1t+GyOg331RSq2d6LMMLQqs4yTH+cJjvedtWtMKPg7rvN9BLdvRw9/yO",
+	"L49ddfOEhZPGMDArW/ipRmS6WRZOKC/chA+HaC+kzriRPkv/BAAA///qGF+njh4AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/echo/server.go
+++ b/internal/test/strict-server/echo/server.go
@@ -122,6 +122,10 @@ func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExample
 	return HeadersExample200JSONResponse{Body: *request.Body, Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
+func (s StrictServer) NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error) {
+	return NoContentHeaders204Response{}, nil
+}
+
 func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
 	return ReusableResponses200JSONResponse{ReusableresponseJSONResponse: ReusableresponseJSONResponse{Body: *request.Body}}, nil
 }

--- a/internal/test/strict-server/fiber/fiber_strict_test.go
+++ b/internal/test/strict-server/fiber/fiber_strict_test.go
@@ -196,6 +196,12 @@ func testImpl(t *testing.T, handler http.Handler) {
 		assert.Equal(t, header1, rr.Header().Get("header1"))
 		assert.Equal(t, header2, rr.Header().Get("header2"))
 	})
+	t.Run("NoContentHeadersOmitUnset", func(t *testing.T) {
+		rr := testutil.NewRequest().Post("/no-content-headers").GoWithHTTPHandler(t, handler).Recorder
+		assert.Equal(t, http.StatusNoContent, rr.Code)
+		assert.Empty(t, rr.Header().Values("optional-header"), "optional-header should be omitted when the response field is nil")
+		assert.Empty(t, rr.Header().Values("nullable-header"), "nullable-header should be omitted when the response field is unspecified")
+	})
 	t.Run("UnspecifiedContentType", func(t *testing.T) {
 		data := []byte("image data")
 		contentType := "image/jpeg"

--- a/internal/test/strict-server/fiber/server.gen.go
+++ b/internal/test/strict-server/fiber/server.gen.go
@@ -38,6 +38,9 @@ type ServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(c *fiber.Ctx) error
 
+	// (POST /no-content-headers)
+	NoContentHeaders(c *fiber.Ctx) error
+
 	// (POST /required-json-body)
 	RequiredJSONBody(c *fiber.Ctx) error
 
@@ -137,6 +140,24 @@ func (siw *ServerInterfaceWrapper) MultipleRequestAndResponseTypes(c *fiber.Ctx)
 
 	handler := func(c *fiber.Ctx) error {
 		return siw.Handler.MultipleRequestAndResponseTypes(c)
+	}
+
+	for i := len(siw.HandlerMiddlewares) - 1; i >= 0; i-- {
+		m := siw.HandlerMiddlewares[i]
+		next := handler
+		handler = func(c *fiber.Ctx) error {
+			return m(c, next)
+		}
+	}
+
+	return handler(c)
+}
+
+// NoContentHeaders operation middleware
+func (siw *ServerInterfaceWrapper) NoContentHeaders(c *fiber.Ctx) error {
+
+	handler := func(c *fiber.Ctx) error {
+		return siw.Handler.NoContentHeaders(c)
 	}
 
 	for i := len(siw.HandlerMiddlewares) - 1; i >= 0; i-- {
@@ -417,6 +438,8 @@ func RegisterHandlersWithOptions(router fiber.Router, si ServerInterface, option
 
 	router.Post(options.BaseURL+"/multiple", wrapper.MultipleRequestAndResponseTypes)
 
+	router.Post(options.BaseURL+"/no-content-headers", wrapper.NoContentHeaders)
+
 	router.Post(options.BaseURL+"/required-json-body", wrapper.RequiredJSONBody)
 
 	router.Post(options.BaseURL+"/required-text-body", wrapper.RequiredTextBody)
@@ -634,6 +657,33 @@ type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(ctx *fiber.Ctx) error {
 	ctx.Status(400)
+	return nil
+}
+
+type NoContentHeadersRequestObject struct {
+}
+
+type NoContentHeadersResponseObject interface {
+	VisitNoContentHeadersResponse(ctx *fiber.Ctx) error
+}
+
+type NoContentHeaders204ResponseHeaders struct {
+	NullableHeader *string
+	OptionalHeader *string
+}
+
+type NoContentHeaders204Response struct {
+	Headers NoContentHeaders204ResponseHeaders
+}
+
+func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(ctx *fiber.Ctx) error {
+	if response.Headers.NullableHeader != nil {
+		ctx.Response().Header.Set("nullable-header", fmt.Sprint(*response.Headers.NullableHeader))
+	}
+	if response.Headers.OptionalHeader != nil {
+		ctx.Response().Header.Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
+	}
+	ctx.Status(204)
 	return nil
 }
 
@@ -1057,6 +1107,9 @@ type StrictServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(ctx context.Context, request RequiredJSONBodyRequestObject) (RequiredJSONBodyResponseObject, error)
 
@@ -1243,6 +1296,31 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
 		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// NoContentHeaders operation middleware
+func (sh *strictHandler) NoContentHeaders(ctx *fiber.Ctx) error {
+	var request NoContentHeadersRequestObject
+
+	handler := func(ctx *fiber.Ctx, request interface{}) (interface{}, error) {
+		return sh.ssi.NoContentHeaders(ctx.UserContext(), request.(NoContentHeadersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "NoContentHeaders")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	} else if validResponse, ok := response.(NoContentHeadersResponseObject); ok {
+		if err := validResponse.VisitNoContentHeadersResponse(ctx); err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
@@ -1563,26 +1641,27 @@ func (sh *strictHandler) UnionExample(ctx *fiber.Ctx) error {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZzXLbNhB+FQzaUwqatuOTbo0nk7Zp645snzo+QMRKQgICCLAUrdHo3TsgQP3SjpRK",
-	"lieTm0TuH75vd7kAZrQwpTUaNHram1EH3hrtofkz4MLBlwo8hn8CfOGkRWk07dF3XPTTuzmjDirPBwpa",
-	"9SBfGI2gG1VurZIFD6r5Jx/0Z9QXYyh5+PWzgyHt0Z/yZSh5fOtzeOSlVUDn8znbiODmI2V0DFyAa6KN",
-	"Py/iKr5U0oGgPXQVsBVfOLVAe9Sjk3pEg9GodrmTmtQII3AhmqCaggwCbZy9GbXOWHAoI4YTriro9pye",
-	"mMEnKDCuUOqh2cb62mjkUnsi5HAIDjSSBC4JNjzxlbXGIQgymJLgoUDiwU3AUUZRYgiM3q4+JylgTxmd",
-	"gPPR0cXZ+dl54NNY0NxK2qNvm0eMWo7jZkELAq3pyos/bm/+JtITXqEpOcqCKzUlJXd+zBUIIjWaEGJV",
-	"oD+jjSfXJMbvImm/T1AympLvnRHTYyRUk7cr6X55fv5CeTtn9Co667KxCCpfKcDGzJBXqgPze/1Zm1oT",
-	"cM64tLK8rBRKyx2ucrWO9l+tyC6QL+zlQ+PKTHDkR0L9UJ5ODXzmQHEM7eSrBPSj5H48rJg/Kgv/x89J",
-	"OUj9uLNP3Y5N7cnY1AQNEcAVqSWOSau40WClJpx4qUcKSBsU6yRTQfos/qpFP63lLtg4ej9ja1Yes7qu",
-	"s6aAKqdAF0Z8G4WMypKPILd6tK4ebHOkPTqYYkjZ7Q/cgQqZUYRHzK3icgOYTZcv1NJ/IH2wwo7l2g5e",
-	"WWAkG6T66C7cVF4kSIVBo9VlxBtSSh+qNL70Y1MpQbiq+dTH/rA9cfSTepg8msI8+tjBNubM73sMWVAb",
-	"Mus01N7BI36V2j0Sf1/6Xrqm9qeo2ROIbGSyzzCtjROZ5Y6XgOB8PgtxzoOtEXSY/GchSQquyQCI5iUI",
-	"wocIjnwwJJn0HfxEvx/MxyiyNNVsOBZ/ev/OaACv2YRQRoMD2ov4sT02ew/HpapFM26FszVXTyV8Emmh",
-	"czD0YSDp4rgDv+ipvyJxmi3T87m5dTjwEkkdmHx68A4tYZdh+4CDx2vvAlV8+DRmSWsX2L5xjtkBxYkU",
-	"YPLSXu1p+WSgeguFHEoQWVpFFmN7qiVcG104wPUNSPgYaoNkYYwMpgTHQCICzfexBlJWHonl3hOJTRdR",
-	"Mp4VCdhqHvfLyK6jp7tlO32O1TdH4vTNqRi9Or/YX+XtkfNmbSPxRD32/3wfZfY9MTvYjmXP/dbh/J6o",
-	"nGuJ42zlyLm7hH+LAstvegFyEiYiLYgDrJwGQSaSt8egW7WZDCxp7ZqFYhjLaag9/t5nIGLP2rqkzx6B",
-	"P3zHB7Snu1hgVFdKNQNkYmVtSe3L1tK2W9Msg6tO9a7u/DJVU2n53LXBfXhN0kS/+aWSRr/SSwGuEJzm",
-	"KCfwy2FOk7atGA03w6buN9hjO3p4eH2XZ8fOujmj8Z4rNszKqdDVEG0vz+P92Jmv+WgE7kyanFsZUPov",
-	"AAD//ysZ4qQMHQAA",
+	"H4sIAAAAAAAC/+xZ23LbNhN+lR38/0Wbkqbi+Ep3TSaTtmmTjmxfdXwBESsJCQkgwFKyRqOZPkSfsE/S",
+	"AQHqSNtSqoMn0zuJ3BP3211+S8xYrkujFSpyrDtjFp3RymH9p8+FxS8VOvL/BLrcSkNSK9Zlr7noxXvz",
+	"hFmsHO8X2Kh7+VwrQlWrcmMKmXOvmn1yXn/GXD7Ckvtf/7c4YF32v2wZShbuugzveWkKZPP5PNmI4ON7",
+	"lrARcoG2jjb8fBme4kslLQrWJVthsuKLpgZZlzmyUg2ZNxrULndSk4pwiNZH41VjkF6gibM7Y8Zqg5Zk",
+	"yOGYFxW2e45XdP8T5hSeUKqB3s71G62IS+VAyMEALSqCmFzwNhy4yhhtCQX0p+A95AQO7RgtSxhJ8oGx",
+	"69XrEAN2LGFjtC44ennRueh4PLVBxY1kXfaqvpQww2lUP9ACQKPb6uKX648fQDrgFemSk8x5UUyh5NaN",
+	"eIECpCLtQ6xyches9mTrwvhZRO23MZUJi8X3WovpMQqqrtuVcr/sdE5Ut/OEXQVnbTYWQWUrDVibGfCq",
+	"aMn5rfqs9EQBWqttfLKsrAqShltaxWo92781IrukfGEvG2hbpoITP1LWD+Xp3IlPLRac/Dh5EoBekNwP",
+	"hxXzR0Xh3/g5KwZxHrfOqeuRnjgY6QmQBoG8gImkETSKGwNWKuDgpBoWCE1QSSuYBcbX4o9K9OKz3Hgb",
+	"R59nyZqV+3QymaR1A1W2QJVr8XUQJkyWfIiZUcN1dW+bE+uy/pR8yW6/4A7UyAkjvKfMFFxuJGbT5YlG",
+	"+n+ZPlhjh3ZVOo0QpSuErr1xPyxk4bvLztX30BgODaxrOV4AVwJUVRSeli5lonn4+8+/AO/R5tKhAxpx",
+	"gko5pIUAtwi6lORJ1cDqEmi0NLPV+x/0mxDTTzH8rTq8ansSiFrrRLaJOuZiHYjmZsNRt2uhyUCr+nbH",
+	"BAQa6pv6nkj7cUK1IxAHHHgpT/Ua3QSchlI6PyfDTTfSVSGAFxM+dWFCb3O+XlT33K8ejUcnfskG0/+2",
+	"ieACWt/b54H2Bu/pSWj3GD37wnfqqbY/RPVWJtKhTj/jdKKtSA23vERC67KZj3PubQ2xxeTvC0nIuYI+",
+	"guIlCuADQgvvNESTrgWf4Pedfh9ElqbqlW/xp/vHjPnk1WsgS5h3wLohf8ke6/bdcaFqshk+RqRrrh4q",
+	"+CjSpM7iwHlK2IZxS/6Cp96KxHmW1sdrc+vzzCmK2iP58OrjR8Iu684Bqd9znwJVuPhwzqLWLmn7Sia5",
+	"QxbHUqDOSnO1p+WzJdUZzOVAolhwzBDbQyPhjVa5RVpfAf3LUGmChTHoT2tKGDJQvx8nCGXlCAx3DiTV",
+	"U6SQ4Wud2OaMt8vIIg28WY7Tx1B9cSRMX5wL0avOy/1VXh25btZWuQf6sffr2yCz7zfLg+2Me268h/N7",
+	"pnb2O97TO2Lcwpbv9Bzl2DMiJcAiVVahgLHkzYford6MBpawtnGhuF8t2FBzALEPIUoetXXJHj2EuPuG",
+	"P5Gf72gnOfECfqquqZR87ODm1t+GyOg331RSq2d6LMMLQqs4yTH+cJjvedtWtMKPg7rvN9BLdvRw9/yO",
+	"L49ddfOEhZPGMDArW/ipRmS6WRZOKC/chA+HaC+kzriRPkv/BAAA///qGF+njh4AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/fiber/server.go
+++ b/internal/test/strict-server/fiber/server.go
@@ -122,6 +122,10 @@ func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExample
 	return HeadersExample200JSONResponse{Body: *request.Body, Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
+func (s StrictServer) NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error) {
+	return NoContentHeaders204Response{}, nil
+}
+
 func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
 	return ReusableResponses200JSONResponse{ReusableresponseJSONResponse: ReusableresponseJSONResponse{Body: *request.Body}}, nil
 }

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -39,6 +39,9 @@ type ServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(c *gin.Context)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(c *gin.Context)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(c *gin.Context)
 
@@ -129,6 +132,19 @@ func (siw *ServerInterfaceWrapper) MultipleRequestAndResponseTypes(c *gin.Contex
 	}
 
 	siw.Handler.MultipleRequestAndResponseTypes(c)
+}
+
+// NoContentHeaders operation middleware
+func (siw *ServerInterfaceWrapper) NoContentHeaders(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.NoContentHeaders(c)
 }
 
 // RequiredJSONBody operation middleware
@@ -353,6 +369,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/multipart", wrapper.MultipartExample)
 	router.POST(options.BaseURL+"/multipart-related", wrapper.MultipartRelatedExample)
 	router.POST(options.BaseURL+"/multiple", wrapper.MultipleRequestAndResponseTypes)
+	router.POST(options.BaseURL+"/no-content-headers", wrapper.NoContentHeaders)
 	router.POST(options.BaseURL+"/required-json-body", wrapper.RequiredJSONBody)
 	router.POST(options.BaseURL+"/required-text-body", wrapper.RequiredTextBody)
 	router.GET(options.BaseURL+"/reserved-go-keyword-parameters/:type", wrapper.ReservedGoKeywordParameters)
@@ -575,6 +592,33 @@ type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.WriteHeader(400)
+	return nil
+}
+
+type NoContentHeadersRequestObject struct {
+}
+
+type NoContentHeadersResponseObject interface {
+	VisitNoContentHeadersResponse(w http.ResponseWriter) error
+}
+
+type NoContentHeaders204ResponseHeaders struct {
+	NullableHeader *string
+	OptionalHeader *string
+}
+
+type NoContentHeaders204Response struct {
+	Headers NoContentHeaders204ResponseHeaders
+}
+
+func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http.ResponseWriter) error {
+	if response.Headers.NullableHeader != nil {
+		w.Header().Set("nullable-header", fmt.Sprint(*response.Headers.NullableHeader))
+	}
+	if response.Headers.OptionalHeader != nil {
+		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
+	}
+	w.WriteHeader(204)
 	return nil
 }
 
@@ -1028,6 +1072,9 @@ type StrictServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(ctx context.Context, request RequiredJSONBodyRequestObject) (RequiredJSONBodyResponseObject, error)
 
@@ -1279,6 +1326,30 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx *gin.Context) {
 		sh.options.HandlerErrorFunc(ctx, err)
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
 		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Writer); err != nil {
+			sh.options.ResponseErrorHandlerFunc(ctx, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(ctx, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// NoContentHeaders operation middleware
+func (sh *strictHandler) NoContentHeaders(ctx *gin.Context) {
+	var request NoContentHeadersRequestObject
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.NoContentHeaders(ctx, request.(NoContentHeadersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "NoContentHeaders")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		sh.options.HandlerErrorFunc(ctx, err)
+	} else if validResponse, ok := response.(NoContentHeadersResponseObject); ok {
+		if err := validResponse.VisitNoContentHeadersResponse(ctx.Writer); err != nil {
 			sh.options.ResponseErrorHandlerFunc(ctx, err)
 		}
 	} else if response != nil {
@@ -1605,26 +1676,27 @@ func (sh *strictHandler) UnionExample(ctx *gin.Context) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZzXLbNhB+FQzaUwqatuOTbo0nk7Zp645snzo+QMRKQgICCLAUrdHo3TsgQP3SjpRK",
-	"lieTm0TuH75vd7kAZrQwpTUaNHram1EH3hrtofkz4MLBlwo8hn8CfOGkRWk07dF3XPTTuzmjDirPBwpa",
-	"9SBfGI2gG1VurZIFD6r5Jx/0Z9QXYyh5+PWzgyHt0Z/yZSh5fOtzeOSlVUDn8znbiODmI2V0DFyAa6KN",
-	"Py/iKr5U0oGgPXQVsBVfOLVAe9Sjk3pEg9GodrmTmtQII3AhmqCaggwCbZy9GbXOWHAoI4YTriro9pye",
-	"mMEnKDCuUOqh2cb62mjkUnsi5HAIDjSSBC4JNjzxlbXGIQgymJLgoUDiwU3AUUZRYgiM3q4+JylgTxmd",
-	"gPPR0cXZ+dl54NNY0NxK2qNvm0eMWo7jZkELAq3pyos/bm/+JtITXqEpOcqCKzUlJXd+zBUIIjWaEGJV",
-	"oD+jjSfXJMbvImm/T1AympLvnRHTYyRUk7cr6X55fv5CeTtn9Co667KxCCpfKcDGzJBXqgPze/1Zm1oT",
-	"cM64tLK8rBRKyx2ucrWO9l+tyC6QL+zlQ+PKTHDkR0L9UJ5ODXzmQHEM7eSrBPSj5H48rJg/Kgv/x89J",
-	"OUj9uLNP3Y5N7cnY1AQNEcAVqSWOSau40WClJpx4qUcKSBsU6yRTQfos/qpFP63lLtg4ej9ja1Yes7qu",
-	"s6aAKqdAF0Z8G4WMypKPILd6tK4ebHOkPTqYYkjZ7Q/cgQqZUYRHzK3icgOYTZcv1NJ/IH2wwo7l2g5e",
-	"WWAkG6T66C7cVF4kSIVBo9VlxBtSSh+qNL70Y1MpQbiq+dTH/rA9cfSTepg8msI8+tjBNubM73sMWVAb",
-	"Mus01N7BI36V2j0Sf1/6Xrqm9qeo2ROIbGSyzzCtjROZ5Y6XgOB8PgtxzoOtEXSY/GchSQquyQCI5iUI",
-	"wocIjnwwJJn0HfxEvx/MxyiyNNVsOBZ/ev/OaACv2YRQRoMD2ov4sT02ew/HpapFM26FszVXTyV8Emmh",
-	"czD0YSDp4rgDv+ipvyJxmi3T87m5dTjwEkkdmHx68A4tYZdh+4CDx2vvAlV8+DRmSWsX2L5xjtkBxYkU",
-	"YPLSXu1p+WSgeguFHEoQWVpFFmN7qiVcG104wPUNSPgYaoNkYYwMpgTHQCICzfexBlJWHonl3hOJTRdR",
-	"Mp4VCdhqHvfLyK6jp7tlO32O1TdH4vTNqRi9Or/YX+XtkfNmbSPxRD32/3wfZfY9MTvYjmXP/dbh/J6o",
-	"nGuJ42zlyLm7hH+LAstvegFyEiYiLYgDrJwGQSaSt8egW7WZDCxp7ZqFYhjLaag9/t5nIGLP2rqkzx6B",
-	"P3zHB7Snu1hgVFdKNQNkYmVtSe3L1tK2W9Msg6tO9a7u/DJVU2n53LXBfXhN0kS/+aWSRr/SSwGuEJzm",
-	"KCfwy2FOk7atGA03w6buN9hjO3p4eH2XZ8fOujmj8Z4rNszKqdDVEG0vz+P92Jmv+WgE7kyanFsZUPov",
-	"AAD//ysZ4qQMHQAA",
+	"H4sIAAAAAAAC/+xZ23LbNhN+lR38/0Wbkqbi+Ep3TSaTtmmTjmxfdXwBESsJCQkgwFKyRqOZPkSfsE/S",
+	"AQHqSNtSqoMn0zuJ3BP3211+S8xYrkujFSpyrDtjFp3RymH9p8+FxS8VOvL/BLrcSkNSK9Zlr7noxXvz",
+	"hFmsHO8X2Kh7+VwrQlWrcmMKmXOvmn1yXn/GXD7Ckvtf/7c4YF32v2wZShbuugzveWkKZPP5PNmI4ON7",
+	"lrARcoG2jjb8fBme4kslLQrWJVthsuKLpgZZlzmyUg2ZNxrULndSk4pwiNZH41VjkF6gibM7Y8Zqg5Zk",
+	"yOGYFxW2e45XdP8T5hSeUKqB3s71G62IS+VAyMEALSqCmFzwNhy4yhhtCQX0p+A95AQO7RgtSxhJ8oGx",
+	"69XrEAN2LGFjtC44ennRueh4PLVBxY1kXfaqvpQww2lUP9ACQKPb6uKX648fQDrgFemSk8x5UUyh5NaN",
+	"eIECpCLtQ6xyches9mTrwvhZRO23MZUJi8X3WovpMQqqrtuVcr/sdE5Ut/OEXQVnbTYWQWUrDVibGfCq",
+	"aMn5rfqs9EQBWqttfLKsrAqShltaxWo92781IrukfGEvG2hbpoITP1LWD+Xp3IlPLRac/Dh5EoBekNwP",
+	"hxXzR0Xh3/g5KwZxHrfOqeuRnjgY6QmQBoG8gImkETSKGwNWKuDgpBoWCE1QSSuYBcbX4o9K9OKz3Hgb",
+	"R59nyZqV+3QymaR1A1W2QJVr8XUQJkyWfIiZUcN1dW+bE+uy/pR8yW6/4A7UyAkjvKfMFFxuJGbT5YlG",
+	"+n+ZPlhjh3ZVOo0QpSuErr1xPyxk4bvLztX30BgODaxrOV4AVwJUVRSeli5lonn4+8+/AO/R5tKhAxpx",
+	"gko5pIUAtwi6lORJ1cDqEmi0NLPV+x/0mxDTTzH8rTq8ansSiFrrRLaJOuZiHYjmZsNRt2uhyUCr+nbH",
+	"BAQa6pv6nkj7cUK1IxAHHHgpT/Ua3QSchlI6PyfDTTfSVSGAFxM+dWFCb3O+XlT33K8ejUcnfskG0/+2",
+	"ieACWt/b54H2Bu/pSWj3GD37wnfqqbY/RPVWJtKhTj/jdKKtSA23vERC67KZj3PubQ2xxeTvC0nIuYI+",
+	"guIlCuADQgvvNESTrgWf4Pedfh9ElqbqlW/xp/vHjPnk1WsgS5h3wLohf8ke6/bdcaFqshk+RqRrrh4q",
+	"+CjSpM7iwHlK2IZxS/6Cp96KxHmW1sdrc+vzzCmK2iP58OrjR8Iu684Bqd9znwJVuPhwzqLWLmn7Sia5",
+	"QxbHUqDOSnO1p+WzJdUZzOVAolhwzBDbQyPhjVa5RVpfAf3LUGmChTHoT2tKGDJQvx8nCGXlCAx3DiTV",
+	"U6SQ4Wud2OaMt8vIIg28WY7Tx1B9cSRMX5wL0avOy/1VXh25btZWuQf6sffr2yCz7zfLg+2Me268h/N7",
+	"pnb2O97TO2Lcwpbv9Bzl2DMiJcAiVVahgLHkzYford6MBpawtnGhuF8t2FBzALEPIUoetXXJHj2EuPuG",
+	"P5Gf72gnOfECfqquqZR87ODm1t+GyOg331RSq2d6LMMLQqs4yTH+cJjvedtWtMKPg7rvN9BLdvRw9/yO",
+	"L49ddfOEhZPGMDArW/ipRmS6WRZOKC/chA+HaC+kzriRPkv/BAAA///qGF+njh4AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/gin/server.go
+++ b/internal/test/strict-server/gin/server.go
@@ -122,6 +122,10 @@ func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExample
 	return HeadersExample200JSONResponse{Body: *request.Body, Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
+func (s StrictServer) NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error) {
+	return NoContentHeaders204Response{}, nil
+}
+
 func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
 	return ReusableResponses200JSONResponse{ReusableresponseJSONResponse: ReusableresponseJSONResponse{Body: *request.Body}}, nil
 }

--- a/internal/test/strict-server/gorilla/server.gen.go
+++ b/internal/test/strict-server/gorilla/server.gen.go
@@ -39,6 +39,9 @@ type ServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(w http.ResponseWriter, r *http.Request)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(w http.ResponseWriter, r *http.Request)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(w http.ResponseWriter, r *http.Request)
 
@@ -126,6 +129,20 @@ func (siw *ServerInterfaceWrapper) MultipleRequestAndResponseTypes(w http.Respon
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.MultipleRequestAndResponseTypes(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// NoContentHeaders operation middleware
+func (siw *ServerInterfaceWrapper) NoContentHeaders(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.NoContentHeaders(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -458,6 +475,8 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 
 	r.HandleFunc(options.BaseURL+"/multiple", wrapper.MultipleRequestAndResponseTypes).Methods(http.MethodPost)
 
+	r.HandleFunc(options.BaseURL+"/no-content-headers", wrapper.NoContentHeaders).Methods(http.MethodPost)
+
 	r.HandleFunc(options.BaseURL+"/required-json-body", wrapper.RequiredJSONBody).Methods(http.MethodPost)
 
 	r.HandleFunc(options.BaseURL+"/required-text-body", wrapper.RequiredTextBody).Methods(http.MethodPost)
@@ -691,6 +710,33 @@ type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.WriteHeader(400)
+	return nil
+}
+
+type NoContentHeadersRequestObject struct {
+}
+
+type NoContentHeadersResponseObject interface {
+	VisitNoContentHeadersResponse(w http.ResponseWriter) error
+}
+
+type NoContentHeaders204ResponseHeaders struct {
+	NullableHeader *string
+	OptionalHeader *string
+}
+
+type NoContentHeaders204Response struct {
+	Headers NoContentHeaders204ResponseHeaders
+}
+
+func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http.ResponseWriter) error {
+	if response.Headers.NullableHeader != nil {
+		w.Header().Set("nullable-header", fmt.Sprint(*response.Headers.NullableHeader))
+	}
+	if response.Headers.OptionalHeader != nil {
+		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
+	}
+	w.WriteHeader(204)
 	return nil
 }
 
@@ -1144,6 +1190,9 @@ type StrictServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(ctx context.Context, request RequiredJSONBodyRequestObject) (RequiredJSONBodyResponseObject, error)
 
@@ -1367,6 +1416,30 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(w http.ResponseWriter, 
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
 		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// NoContentHeaders operation middleware
+func (sh *strictHandler) NoContentHeaders(w http.ResponseWriter, r *http.Request) {
+	var request NoContentHeadersRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.NoContentHeaders(ctx, request.(NoContentHeadersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "NoContentHeaders")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(NoContentHeadersResponseObject); ok {
+		if err := validResponse.VisitNoContentHeadersResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -1693,26 +1766,27 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZzXLbNhB+FQzaUwqatuOTbo0nk7Zp645snzo+QMRKQgICCLAUrdHo3TsgQP3SjpRK",
-	"lieTm0TuH75vd7kAZrQwpTUaNHram1EH3hrtofkz4MLBlwo8hn8CfOGkRWk07dF3XPTTuzmjDirPBwpa",
-	"9SBfGI2gG1VurZIFD6r5Jx/0Z9QXYyh5+PWzgyHt0Z/yZSh5fOtzeOSlVUDn8znbiODmI2V0DFyAa6KN",
-	"Py/iKr5U0oGgPXQVsBVfOLVAe9Sjk3pEg9GodrmTmtQII3AhmqCaggwCbZy9GbXOWHAoI4YTriro9pye",
-	"mMEnKDCuUOqh2cb62mjkUnsi5HAIDjSSBC4JNjzxlbXGIQgymJLgoUDiwU3AUUZRYgiM3q4+JylgTxmd",
-	"gPPR0cXZ+dl54NNY0NxK2qNvm0eMWo7jZkELAq3pyos/bm/+JtITXqEpOcqCKzUlJXd+zBUIIjWaEGJV",
-	"oD+jjSfXJMbvImm/T1AympLvnRHTYyRUk7cr6X55fv5CeTtn9Co667KxCCpfKcDGzJBXqgPze/1Zm1oT",
-	"cM64tLK8rBRKyx2ucrWO9l+tyC6QL+zlQ+PKTHDkR0L9UJ5ODXzmQHEM7eSrBPSj5H48rJg/Kgv/x89J",
-	"OUj9uLNP3Y5N7cnY1AQNEcAVqSWOSau40WClJpx4qUcKSBsU6yRTQfos/qpFP63lLtg4ej9ja1Yes7qu",
-	"s6aAKqdAF0Z8G4WMypKPILd6tK4ebHOkPTqYYkjZ7Q/cgQqZUYRHzK3icgOYTZcv1NJ/IH2wwo7l2g5e",
-	"WWAkG6T66C7cVF4kSIVBo9VlxBtSSh+qNL70Y1MpQbiq+dTH/rA9cfSTepg8msI8+tjBNubM73sMWVAb",
-	"Mus01N7BI36V2j0Sf1/6Xrqm9qeo2ROIbGSyzzCtjROZ5Y6XgOB8PgtxzoOtEXSY/GchSQquyQCI5iUI",
-	"wocIjnwwJJn0HfxEvx/MxyiyNNVsOBZ/ev/OaACv2YRQRoMD2ov4sT02ew/HpapFM26FszVXTyV8Emmh",
-	"czD0YSDp4rgDv+ipvyJxmi3T87m5dTjwEkkdmHx68A4tYZdh+4CDx2vvAlV8+DRmSWsX2L5xjtkBxYkU",
-	"YPLSXu1p+WSgeguFHEoQWVpFFmN7qiVcG104wPUNSPgYaoNkYYwMpgTHQCICzfexBlJWHonl3hOJTRdR",
-	"Mp4VCdhqHvfLyK6jp7tlO32O1TdH4vTNqRi9Or/YX+XtkfNmbSPxRD32/3wfZfY9MTvYjmXP/dbh/J6o",
-	"nGuJ42zlyLm7hH+LAstvegFyEiYiLYgDrJwGQSaSt8egW7WZDCxp7ZqFYhjLaag9/t5nIGLP2rqkzx6B",
-	"P3zHB7Snu1hgVFdKNQNkYmVtSe3L1tK2W9Msg6tO9a7u/DJVU2n53LXBfXhN0kS/+aWSRr/SSwGuEJzm",
-	"KCfwy2FOk7atGA03w6buN9hjO3p4eH2XZ8fOujmj8Z4rNszKqdDVEG0vz+P92Jmv+WgE7kyanFsZUPov",
-	"AAD//ysZ4qQMHQAA",
+	"H4sIAAAAAAAC/+xZ23LbNhN+lR38/0Wbkqbi+Ep3TSaTtmmTjmxfdXwBESsJCQkgwFKyRqOZPkSfsE/S",
+	"AQHqSNtSqoMn0zuJ3BP3211+S8xYrkujFSpyrDtjFp3RymH9p8+FxS8VOvL/BLrcSkNSK9Zlr7noxXvz",
+	"hFmsHO8X2Kh7+VwrQlWrcmMKmXOvmn1yXn/GXD7Ckvtf/7c4YF32v2wZShbuugzveWkKZPP5PNmI4ON7",
+	"lrARcoG2jjb8fBme4kslLQrWJVthsuKLpgZZlzmyUg2ZNxrULndSk4pwiNZH41VjkF6gibM7Y8Zqg5Zk",
+	"yOGYFxW2e45XdP8T5hSeUKqB3s71G62IS+VAyMEALSqCmFzwNhy4yhhtCQX0p+A95AQO7RgtSxhJ8oGx",
+	"69XrEAN2LGFjtC44ennRueh4PLVBxY1kXfaqvpQww2lUP9ACQKPb6uKX648fQDrgFemSk8x5UUyh5NaN",
+	"eIECpCLtQ6xyches9mTrwvhZRO23MZUJi8X3WovpMQqqrtuVcr/sdE5Ut/OEXQVnbTYWQWUrDVibGfCq",
+	"aMn5rfqs9EQBWqttfLKsrAqShltaxWo92781IrukfGEvG2hbpoITP1LWD+Xp3IlPLRac/Dh5EoBekNwP",
+	"hxXzR0Xh3/g5KwZxHrfOqeuRnjgY6QmQBoG8gImkETSKGwNWKuDgpBoWCE1QSSuYBcbX4o9K9OKz3Hgb",
+	"R59nyZqV+3QymaR1A1W2QJVr8XUQJkyWfIiZUcN1dW+bE+uy/pR8yW6/4A7UyAkjvKfMFFxuJGbT5YlG",
+	"+n+ZPlhjh3ZVOo0QpSuErr1xPyxk4bvLztX30BgODaxrOV4AVwJUVRSeli5lonn4+8+/AO/R5tKhAxpx",
+	"gko5pIUAtwi6lORJ1cDqEmi0NLPV+x/0mxDTTzH8rTq8ansSiFrrRLaJOuZiHYjmZsNRt2uhyUCr+nbH",
+	"BAQa6pv6nkj7cUK1IxAHHHgpT/Ua3QSchlI6PyfDTTfSVSGAFxM+dWFCb3O+XlT33K8ejUcnfskG0/+2",
+	"ieACWt/b54H2Bu/pSWj3GD37wnfqqbY/RPVWJtKhTj/jdKKtSA23vERC67KZj3PubQ2xxeTvC0nIuYI+",
+	"guIlCuADQgvvNESTrgWf4Pedfh9ElqbqlW/xp/vHjPnk1WsgS5h3wLohf8ke6/bdcaFqshk+RqRrrh4q",
+	"+CjSpM7iwHlK2IZxS/6Cp96KxHmW1sdrc+vzzCmK2iP58OrjR8Iu684Bqd9znwJVuPhwzqLWLmn7Sia5",
+	"QxbHUqDOSnO1p+WzJdUZzOVAolhwzBDbQyPhjVa5RVpfAf3LUGmChTHoT2tKGDJQvx8nCGXlCAx3DiTV",
+	"U6SQ4Wud2OaMt8vIIg28WY7Tx1B9cSRMX5wL0avOy/1VXh25btZWuQf6sffr2yCz7zfLg+2Me268h/N7",
+	"pnb2O97TO2Lcwpbv9Bzl2DMiJcAiVVahgLHkzYford6MBpawtnGhuF8t2FBzALEPIUoetXXJHj2EuPuG",
+	"P5Gf72gnOfECfqquqZR87ODm1t+GyOg331RSq2d6LMMLQqs4yTH+cJjvedtWtMKPg7rvN9BLdvRw9/yO",
+	"L49ddfOEhZPGMDArW/ipRmS6WRZOKC/chA+HaC+kzriRPkv/BAAA///qGF+njh4AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/gorilla/server.go
+++ b/internal/test/strict-server/gorilla/server.go
@@ -98,6 +98,10 @@ func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExample
 	return HeadersExample200JSONResponse{Body: *request.Body, Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
+func (s StrictServer) NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error) {
+	return NoContentHeaders204Response{}, nil
+}
+
 func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
 	return ReusableResponses200JSONResponse{ReusableresponseJSONResponse: ReusableresponseJSONResponse{Body: *request.Body}}, nil
 }

--- a/internal/test/strict-server/iris/server.gen.go
+++ b/internal/test/strict-server/iris/server.gen.go
@@ -38,6 +38,9 @@ type ServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(ctx iris.Context)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(ctx iris.Context)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(ctx iris.Context)
 
@@ -102,6 +105,13 @@ func (w *ServerInterfaceWrapper) MultipleRequestAndResponseTypes(ctx iris.Contex
 
 	// Invoke the callback with all the unmarshaled arguments
 	w.Handler.MultipleRequestAndResponseTypes(ctx)
+}
+
+// NoContentHeaders converts iris context to params.
+func (w *ServerInterfaceWrapper) NoContentHeaders(ctx iris.Context) {
+
+	// Invoke the callback with all the unmarshaled arguments
+	w.Handler.NoContentHeaders(ctx)
 }
 
 // RequiredJSONBody converts iris context to params.
@@ -259,6 +269,7 @@ func RegisterHandlersWithOptions(router *iris.Application, si ServerInterface, o
 	router.Post(options.BaseURL+"/multipart", wrapper.MultipartExample)
 	router.Post(options.BaseURL+"/multipart-related", wrapper.MultipartRelatedExample)
 	router.Post(options.BaseURL+"/multiple", wrapper.MultipleRequestAndResponseTypes)
+	router.Post(options.BaseURL+"/no-content-headers", wrapper.NoContentHeaders)
 	router.Post(options.BaseURL+"/required-json-body", wrapper.RequiredJSONBody)
 	router.Post(options.BaseURL+"/required-text-body", wrapper.RequiredTextBody)
 	router.Get(options.BaseURL+"/reserved-go-keyword-parameters/:type", wrapper.ReservedGoKeywordParameters)
@@ -468,6 +479,33 @@ type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(ctx iris.Context) error {
 	ctx.StatusCode(400)
+	return nil
+}
+
+type NoContentHeadersRequestObject struct {
+}
+
+type NoContentHeadersResponseObject interface {
+	VisitNoContentHeadersResponse(ctx iris.Context) error
+}
+
+type NoContentHeaders204ResponseHeaders struct {
+	NullableHeader *string
+	OptionalHeader *string
+}
+
+type NoContentHeaders204Response struct {
+	Headers NoContentHeaders204ResponseHeaders
+}
+
+func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(ctx iris.Context) error {
+	if response.Headers.NullableHeader != nil {
+		ctx.ResponseWriter().Header().Set("nullable-header", fmt.Sprint(*response.Headers.NullableHeader))
+	}
+	if response.Headers.OptionalHeader != nil {
+		ctx.ResponseWriter().Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
+	}
+	ctx.StatusCode(204)
 	return nil
 }
 
@@ -891,6 +929,9 @@ type StrictServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(ctx context.Context, request RequiredJSONBodyRequestObject) (RequiredJSONBodyResponseObject, error)
 
@@ -1107,6 +1148,33 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx iris.Context) {
 		return
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
 		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx); err != nil {
+			ctx.StopWithError(http.StatusBadRequest, err)
+			return
+		}
+	} else if response != nil {
+		ctx.Writef("Unexpected response type: %T", response)
+		return
+	}
+}
+
+// NoContentHeaders operation middleware
+func (sh *strictHandler) NoContentHeaders(ctx iris.Context) {
+	var request NoContentHeadersRequestObject
+
+	handler := func(ctx iris.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.NoContentHeaders(ctx, request.(NoContentHeadersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "NoContentHeaders")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.StopWithError(http.StatusBadRequest, err)
+		return
+	} else if validResponse, ok := response.(NoContentHeadersResponseObject); ok {
+		if err := validResponse.VisitNoContentHeadersResponse(ctx); err != nil {
 			ctx.StopWithError(http.StatusBadRequest, err)
 			return
 		}
@@ -1465,26 +1533,27 @@ func (sh *strictHandler) UnionExample(ctx iris.Context) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZzXLbNhB+FQzaUwqatuOTbo0nk7Zp645snzo+QMRKQgICCLAUrdHo3TsgQP3SjpRK",
-	"lieTm0TuH75vd7kAZrQwpTUaNHram1EH3hrtofkz4MLBlwo8hn8CfOGkRWk07dF3XPTTuzmjDirPBwpa",
-	"9SBfGI2gG1VurZIFD6r5Jx/0Z9QXYyh5+PWzgyHt0Z/yZSh5fOtzeOSlVUDn8znbiODmI2V0DFyAa6KN",
-	"Py/iKr5U0oGgPXQVsBVfOLVAe9Sjk3pEg9GodrmTmtQII3AhmqCaggwCbZy9GbXOWHAoI4YTriro9pye",
-	"mMEnKDCuUOqh2cb62mjkUnsi5HAIDjSSBC4JNjzxlbXGIQgymJLgoUDiwU3AUUZRYgiM3q4+JylgTxmd",
-	"gPPR0cXZ+dl54NNY0NxK2qNvm0eMWo7jZkELAq3pyos/bm/+JtITXqEpOcqCKzUlJXd+zBUIIjWaEGJV",
-	"oD+jjSfXJMbvImm/T1AympLvnRHTYyRUk7cr6X55fv5CeTtn9Co667KxCCpfKcDGzJBXqgPze/1Zm1oT",
-	"cM64tLK8rBRKyx2ucrWO9l+tyC6QL+zlQ+PKTHDkR0L9UJ5ODXzmQHEM7eSrBPSj5H48rJg/Kgv/x89J",
-	"OUj9uLNP3Y5N7cnY1AQNEcAVqSWOSau40WClJpx4qUcKSBsU6yRTQfos/qpFP63lLtg4ej9ja1Yes7qu",
-	"s6aAKqdAF0Z8G4WMypKPILd6tK4ebHOkPTqYYkjZ7Q/cgQqZUYRHzK3icgOYTZcv1NJ/IH2wwo7l2g5e",
-	"WWAkG6T66C7cVF4kSIVBo9VlxBtSSh+qNL70Y1MpQbiq+dTH/rA9cfSTepg8msI8+tjBNubM73sMWVAb",
-	"Mus01N7BI36V2j0Sf1/6Xrqm9qeo2ROIbGSyzzCtjROZ5Y6XgOB8PgtxzoOtEXSY/GchSQquyQCI5iUI",
-	"wocIjnwwJJn0HfxEvx/MxyiyNNVsOBZ/ev/OaACv2YRQRoMD2ov4sT02ew/HpapFM26FszVXTyV8Emmh",
-	"czD0YSDp4rgDv+ipvyJxmi3T87m5dTjwEkkdmHx68A4tYZdh+4CDx2vvAlV8+DRmSWsX2L5xjtkBxYkU",
-	"YPLSXu1p+WSgeguFHEoQWVpFFmN7qiVcG104wPUNSPgYaoNkYYwMpgTHQCICzfexBlJWHonl3hOJTRdR",
-	"Mp4VCdhqHvfLyK6jp7tlO32O1TdH4vTNqRi9Or/YX+XtkfNmbSPxRD32/3wfZfY9MTvYjmXP/dbh/J6o",
-	"nGuJ42zlyLm7hH+LAstvegFyEiYiLYgDrJwGQSaSt8egW7WZDCxp7ZqFYhjLaag9/t5nIGLP2rqkzx6B",
-	"P3zHB7Snu1hgVFdKNQNkYmVtSe3L1tK2W9Msg6tO9a7u/DJVU2n53LXBfXhN0kS/+aWSRr/SSwGuEJzm",
-	"KCfwy2FOk7atGA03w6buN9hjO3p4eH2XZ8fOujmj8Z4rNszKqdDVEG0vz+P92Jmv+WgE7kyanFsZUPov",
-	"AAD//ysZ4qQMHQAA",
+	"H4sIAAAAAAAC/+xZ23LbNhN+lR38/0Wbkqbi+Ep3TSaTtmmTjmxfdXwBESsJCQkgwFKyRqOZPkSfsE/S",
+	"AQHqSNtSqoMn0zuJ3BP3211+S8xYrkujFSpyrDtjFp3RymH9p8+FxS8VOvL/BLrcSkNSK9Zlr7noxXvz",
+	"hFmsHO8X2Kh7+VwrQlWrcmMKmXOvmn1yXn/GXD7Ckvtf/7c4YF32v2wZShbuugzveWkKZPP5PNmI4ON7",
+	"lrARcoG2jjb8fBme4kslLQrWJVthsuKLpgZZlzmyUg2ZNxrULndSk4pwiNZH41VjkF6gibM7Y8Zqg5Zk",
+	"yOGYFxW2e45XdP8T5hSeUKqB3s71G62IS+VAyMEALSqCmFzwNhy4yhhtCQX0p+A95AQO7RgtSxhJ8oGx",
+	"69XrEAN2LGFjtC44ennRueh4PLVBxY1kXfaqvpQww2lUP9ACQKPb6uKX648fQDrgFemSk8x5UUyh5NaN",
+	"eIECpCLtQ6xyches9mTrwvhZRO23MZUJi8X3WovpMQqqrtuVcr/sdE5Ut/OEXQVnbTYWQWUrDVibGfCq",
+	"aMn5rfqs9EQBWqttfLKsrAqShltaxWo92781IrukfGEvG2hbpoITP1LWD+Xp3IlPLRac/Dh5EoBekNwP",
+	"hxXzR0Xh3/g5KwZxHrfOqeuRnjgY6QmQBoG8gImkETSKGwNWKuDgpBoWCE1QSSuYBcbX4o9K9OKz3Hgb",
+	"R59nyZqV+3QymaR1A1W2QJVr8XUQJkyWfIiZUcN1dW+bE+uy/pR8yW6/4A7UyAkjvKfMFFxuJGbT5YlG",
+	"+n+ZPlhjh3ZVOo0QpSuErr1xPyxk4bvLztX30BgODaxrOV4AVwJUVRSeli5lonn4+8+/AO/R5tKhAxpx",
+	"gko5pIUAtwi6lORJ1cDqEmi0NLPV+x/0mxDTTzH8rTq8ansSiFrrRLaJOuZiHYjmZsNRt2uhyUCr+nbH",
+	"BAQa6pv6nkj7cUK1IxAHHHgpT/Ua3QSchlI6PyfDTTfSVSGAFxM+dWFCb3O+XlT33K8ejUcnfskG0/+2",
+	"ieACWt/b54H2Bu/pSWj3GD37wnfqqbY/RPVWJtKhTj/jdKKtSA23vERC67KZj3PubQ2xxeTvC0nIuYI+",
+	"guIlCuADQgvvNESTrgWf4Pedfh9ElqbqlW/xp/vHjPnk1WsgS5h3wLohf8ke6/bdcaFqshk+RqRrrh4q",
+	"+CjSpM7iwHlK2IZxS/6Cp96KxHmW1sdrc+vzzCmK2iP58OrjR8Iu684Bqd9znwJVuPhwzqLWLmn7Sia5",
+	"QxbHUqDOSnO1p+WzJdUZzOVAolhwzBDbQyPhjVa5RVpfAf3LUGmChTHoT2tKGDJQvx8nCGXlCAx3DiTV",
+	"U6SQ4Wud2OaMt8vIIg28WY7Tx1B9cSRMX5wL0avOy/1VXh25btZWuQf6sffr2yCz7zfLg+2Me268h/N7",
+	"pnb2O97TO2Lcwpbv9Bzl2DMiJcAiVVahgLHkzYford6MBpawtnGhuF8t2FBzALEPIUoetXXJHj2EuPuG",
+	"P5Gf72gnOfECfqquqZR87ODm1t+GyOg331RSq2d6LMMLQqs4yTH+cJjvedtWtMKPg7rvN9BLdvRw9/yO",
+	"L49ddfOEhZPGMDArW/ipRmS6WRZOKC/chA+HaC+kzriRPkv/BAAA///qGF+njh4AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/iris/server.go
+++ b/internal/test/strict-server/iris/server.go
@@ -121,6 +121,10 @@ func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExample
 	return HeadersExample200JSONResponse{Body: *request.Body, Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
+func (s StrictServer) NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error) {
+	return NoContentHeaders204Response{}, nil
+}
+
 func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
 	return ReusableResponses200JSONResponse{ReusableresponseJSONResponse: ReusableresponseJSONResponse{Body: *request.Body}}, nil
 }

--- a/internal/test/strict-server/stdhttp/server.gen.go
+++ b/internal/test/strict-server/stdhttp/server.gen.go
@@ -40,6 +40,9 @@ type ServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(w http.ResponseWriter, r *http.Request)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(w http.ResponseWriter, r *http.Request)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(w http.ResponseWriter, r *http.Request)
 
@@ -127,6 +130,20 @@ func (siw *ServerInterfaceWrapper) MultipleRequestAndResponseTypes(w http.Respon
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.MultipleRequestAndResponseTypes(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// NoContentHeaders operation middleware
+func (siw *ServerInterfaceWrapper) NoContentHeaders(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.NoContentHeaders(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -462,6 +479,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/multipart", wrapper.MultipartExample)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/multipart-related", wrapper.MultipartRelatedExample)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/multiple", wrapper.MultipleRequestAndResponseTypes)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/no-content-headers", wrapper.NoContentHeaders)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/required-json-body", wrapper.RequiredJSONBody)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/required-text-body", wrapper.RequiredTextBody)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/reserved-go-keyword-parameters/{type}", wrapper.ReservedGoKeywordParameters)
@@ -686,6 +704,33 @@ type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 	w.WriteHeader(400)
+	return nil
+}
+
+type NoContentHeadersRequestObject struct {
+}
+
+type NoContentHeadersResponseObject interface {
+	VisitNoContentHeadersResponse(w http.ResponseWriter) error
+}
+
+type NoContentHeaders204ResponseHeaders struct {
+	NullableHeader *string
+	OptionalHeader *string
+}
+
+type NoContentHeaders204Response struct {
+	Headers NoContentHeaders204ResponseHeaders
+}
+
+func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http.ResponseWriter) error {
+	if response.Headers.NullableHeader != nil {
+		w.Header().Set("nullable-header", fmt.Sprint(*response.Headers.NullableHeader))
+	}
+	if response.Headers.OptionalHeader != nil {
+		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
+	}
+	w.WriteHeader(204)
 	return nil
 }
 
@@ -1139,6 +1184,9 @@ type StrictServerInterface interface {
 	// (POST /multiple)
 	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
+	// (POST /no-content-headers)
+	NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error)
+
 	// (POST /required-json-body)
 	RequiredJSONBody(ctx context.Context, request RequiredJSONBodyRequestObject) (RequiredJSONBodyResponseObject, error)
 
@@ -1362,6 +1410,30 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(w http.ResponseWriter, 
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
 		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// NoContentHeaders operation middleware
+func (sh *strictHandler) NoContentHeaders(w http.ResponseWriter, r *http.Request) {
+	var request NoContentHeadersRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.NoContentHeaders(ctx, request.(NoContentHeadersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "NoContentHeaders")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(NoContentHeadersResponseObject); ok {
+		if err := validResponse.VisitNoContentHeadersResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -1688,26 +1760,27 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZzXLbNhB+FQzaUwqatuOTbo0nk7Zp645snzo+QMRKQgICCLAUrdHo3TsgQP3SjpRK",
-	"lieTm0TuH75vd7kAZrQwpTUaNHram1EH3hrtofkz4MLBlwo8hn8CfOGkRWk07dF3XPTTuzmjDirPBwpa",
-	"9SBfGI2gG1VurZIFD6r5Jx/0Z9QXYyh5+PWzgyHt0Z/yZSh5fOtzeOSlVUDn8znbiODmI2V0DFyAa6KN",
-	"Py/iKr5U0oGgPXQVsBVfOLVAe9Sjk3pEg9GodrmTmtQII3AhmqCaggwCbZy9GbXOWHAoI4YTriro9pye",
-	"mMEnKDCuUOqh2cb62mjkUnsi5HAIDjSSBC4JNjzxlbXGIQgymJLgoUDiwU3AUUZRYgiM3q4+JylgTxmd",
-	"gPPR0cXZ+dl54NNY0NxK2qNvm0eMWo7jZkELAq3pyos/bm/+JtITXqEpOcqCKzUlJXd+zBUIIjWaEGJV",
-	"oD+jjSfXJMbvImm/T1AympLvnRHTYyRUk7cr6X55fv5CeTtn9Co667KxCCpfKcDGzJBXqgPze/1Zm1oT",
-	"cM64tLK8rBRKyx2ucrWO9l+tyC6QL+zlQ+PKTHDkR0L9UJ5ODXzmQHEM7eSrBPSj5H48rJg/Kgv/x89J",
-	"OUj9uLNP3Y5N7cnY1AQNEcAVqSWOSau40WClJpx4qUcKSBsU6yRTQfos/qpFP63lLtg4ej9ja1Yes7qu",
-	"s6aAKqdAF0Z8G4WMypKPILd6tK4ebHOkPTqYYkjZ7Q/cgQqZUYRHzK3icgOYTZcv1NJ/IH2wwo7l2g5e",
-	"WWAkG6T66C7cVF4kSIVBo9VlxBtSSh+qNL70Y1MpQbiq+dTH/rA9cfSTepg8msI8+tjBNubM73sMWVAb",
-	"Mus01N7BI36V2j0Sf1/6Xrqm9qeo2ROIbGSyzzCtjROZ5Y6XgOB8PgtxzoOtEXSY/GchSQquyQCI5iUI",
-	"wocIjnwwJJn0HfxEvx/MxyiyNNVsOBZ/ev/OaACv2YRQRoMD2ov4sT02ew/HpapFM26FszVXTyV8Emmh",
-	"czD0YSDp4rgDv+ipvyJxmi3T87m5dTjwEkkdmHx68A4tYZdh+4CDx2vvAlV8+DRmSWsX2L5xjtkBxYkU",
-	"YPLSXu1p+WSgeguFHEoQWVpFFmN7qiVcG104wPUNSPgYaoNkYYwMpgTHQCICzfexBlJWHonl3hOJTRdR",
-	"Mp4VCdhqHvfLyK6jp7tlO32O1TdH4vTNqRi9Or/YX+XtkfNmbSPxRD32/3wfZfY9MTvYjmXP/dbh/J6o",
-	"nGuJ42zlyLm7hH+LAstvegFyEiYiLYgDrJwGQSaSt8egW7WZDCxp7ZqFYhjLaag9/t5nIGLP2rqkzx6B",
-	"P3zHB7Snu1hgVFdKNQNkYmVtSe3L1tK2W9Msg6tO9a7u/DJVU2n53LXBfXhN0kS/+aWSRr/SSwGuEJzm",
-	"KCfwy2FOk7atGA03w6buN9hjO3p4eH2XZ8fOujmj8Z4rNszKqdDVEG0vz+P92Jmv+WgE7kyanFsZUPov",
-	"AAD//ysZ4qQMHQAA",
+	"H4sIAAAAAAAC/+xZ23LbNhN+lR38/0Wbkqbi+Ep3TSaTtmmTjmxfdXwBESsJCQkgwFKyRqOZPkSfsE/S",
+	"AQHqSNtSqoMn0zuJ3BP3211+S8xYrkujFSpyrDtjFp3RymH9p8+FxS8VOvL/BLrcSkNSK9Zlr7noxXvz",
+	"hFmsHO8X2Kh7+VwrQlWrcmMKmXOvmn1yXn/GXD7Ckvtf/7c4YF32v2wZShbuugzveWkKZPP5PNmI4ON7",
+	"lrARcoG2jjb8fBme4kslLQrWJVthsuKLpgZZlzmyUg2ZNxrULndSk4pwiNZH41VjkF6gibM7Y8Zqg5Zk",
+	"yOGYFxW2e45XdP8T5hSeUKqB3s71G62IS+VAyMEALSqCmFzwNhy4yhhtCQX0p+A95AQO7RgtSxhJ8oGx",
+	"69XrEAN2LGFjtC44ennRueh4PLVBxY1kXfaqvpQww2lUP9ACQKPb6uKX648fQDrgFemSk8x5UUyh5NaN",
+	"eIECpCLtQ6xyches9mTrwvhZRO23MZUJi8X3WovpMQqqrtuVcr/sdE5Ut/OEXQVnbTYWQWUrDVibGfCq",
+	"aMn5rfqs9EQBWqttfLKsrAqShltaxWo92781IrukfGEvG2hbpoITP1LWD+Xp3IlPLRac/Dh5EoBekNwP",
+	"hxXzR0Xh3/g5KwZxHrfOqeuRnjgY6QmQBoG8gImkETSKGwNWKuDgpBoWCE1QSSuYBcbX4o9K9OKz3Hgb",
+	"R59nyZqV+3QymaR1A1W2QJVr8XUQJkyWfIiZUcN1dW+bE+uy/pR8yW6/4A7UyAkjvKfMFFxuJGbT5YlG",
+	"+n+ZPlhjh3ZVOo0QpSuErr1xPyxk4bvLztX30BgODaxrOV4AVwJUVRSeli5lonn4+8+/AO/R5tKhAxpx",
+	"gko5pIUAtwi6lORJ1cDqEmi0NLPV+x/0mxDTTzH8rTq8ansSiFrrRLaJOuZiHYjmZsNRt2uhyUCr+nbH",
+	"BAQa6pv6nkj7cUK1IxAHHHgpT/Ua3QSchlI6PyfDTTfSVSGAFxM+dWFCb3O+XlT33K8ejUcnfskG0/+2",
+	"ieACWt/b54H2Bu/pSWj3GD37wnfqqbY/RPVWJtKhTj/jdKKtSA23vERC67KZj3PubQ2xxeTvC0nIuYI+",
+	"guIlCuADQgvvNESTrgWf4Pedfh9ElqbqlW/xp/vHjPnk1WsgS5h3wLohf8ke6/bdcaFqshk+RqRrrh4q",
+	"+CjSpM7iwHlK2IZxS/6Cp96KxHmW1sdrc+vzzCmK2iP58OrjR8Iu684Bqd9znwJVuPhwzqLWLmn7Sia5",
+	"QxbHUqDOSnO1p+WzJdUZzOVAolhwzBDbQyPhjVa5RVpfAf3LUGmChTHoT2tKGDJQvx8nCGXlCAx3DiTV",
+	"U6SQ4Wud2OaMt8vIIg28WY7Tx1B9cSRMX5wL0avOy/1VXh25btZWuQf6sffr2yCz7zfLg+2Me268h/N7",
+	"pnb2O97TO2Lcwpbv9Bzl2DMiJcAiVVahgLHkzYford6MBpawtnGhuF8t2FBzALEPIUoetXXJHj2EuPuG",
+	"P5Gf72gnOfECfqquqZR87ODm1t+GyOg331RSq2d6LMMLQqs4yTH+cJjvedtWtMKPg7rvN9BLdvRw9/yO",
+	"L49ddfOEhZPGMDArW/ipRmS6WRZOKC/chA+HaC+kzriRPkv/BAAA///qGF+njh4AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/strict-server/stdhttp/server.go
+++ b/internal/test/strict-server/stdhttp/server.go
@@ -124,6 +124,10 @@ func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExample
 	return HeadersExample200JSONResponse{Body: *request.Body, Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
+func (s StrictServer) NoContentHeaders(ctx context.Context, request NoContentHeadersRequestObject) (NoContentHeadersResponseObject, error) {
+	return NoContentHeaders204Response{}, nil
+}
+
 func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
 	return ReusableResponses200JSONResponse{ReusableresponseJSONResponse: ReusableresponseJSONResponse{Body: *request.Body}}, nil
 }

--- a/internal/test/strict-server/stdhttp/std_strict_test.go
+++ b/internal/test/strict-server/stdhttp/std_strict_test.go
@@ -196,6 +196,12 @@ func testImpl(t *testing.T, handler http.Handler) {
 		assert.Equal(t, header1, rr.Header().Get("header1"))
 		assert.Equal(t, header2, rr.Header().Get("header2"))
 	})
+	t.Run("NoContentHeadersOmitUnset", func(t *testing.T) {
+		rr := testutil.NewRequest().Post("/no-content-headers").GoWithHTTPHandler(t, handler).Recorder
+		assert.Equal(t, http.StatusNoContent, rr.Code)
+		assert.Empty(t, rr.Header().Values("optional-header"), "optional-header should be omitted when the response field is nil")
+		assert.Empty(t, rr.Header().Values("nullable-header"), "nullable-header should be omitted when the response field is unspecified")
+	})
 	t.Run("UnspecifiedContentType", func(t *testing.T) {
 		data := []byte("image data")
 		contentType := "image/jpeg"

--- a/internal/test/strict-server/strict-schema.yaml
+++ b/internal/test/strict-server/strict-schema.yaml
@@ -215,6 +215,22 @@ paths:
           $ref: "#/components/responses/badrequest"
         default:
           description: Unknown error
+  /no-content-headers:
+    post:
+      operationId: NoContentHeaders
+      description: No-content (204) response with optional and nullable response headers — exercises that unset headers are omitted from the response
+      responses:
+        204:
+          description: No Content
+          headers:
+            optional-header:
+              required: false
+              schema:
+                type: string
+            nullable-header:
+              schema:
+                type: string
+                nullable: true
   /reusable-responses:
     post:
       operationId: ReusableResponses

--- a/internal/test/strict-server/strict_test.go
+++ b/internal/test/strict-server/strict_test.go
@@ -228,6 +228,12 @@ func testImpl(t *testing.T, handler http.Handler) {
 		assert.Equal(t, header1, rr.Header().Get("header1"))
 		assert.Equal(t, header2, rr.Header().Get("header2"))
 	})
+	t.Run("NoContentHeadersOmitUnset", func(t *testing.T) {
+		rr := testutil.NewRequest().Post("/no-content-headers").GoWithHTTPHandler(t, handler).Recorder
+		assert.Equal(t, http.StatusNoContent, rr.Code)
+		assert.Empty(t, rr.Header().Values("optional-header"), "optional-header should be omitted when the response field is nil")
+		assert.Empty(t, rr.Header().Values("nullable-header"), "nullable-header should be omitted when the response field is unspecified")
+	})
 	t.Run("UnspecifiedContentType", func(t *testing.T) {
 		data := []byte("image data")
 		contentType := "image/jpeg"

--- a/pkg/codegen/templates/strict/strict-fiber-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-fiber-interface.tmpl
@@ -173,7 +173,17 @@
             {{end -}}
             func (response {{$opid}}{{$statusCode}}Response) Visit{{$opid}}Response(ctx *fiber.Ctx) error {
                 {{range $headers -}}
-                    ctx.Response().Header.Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                    {{if .IsNullable -}}
+                        if response.Headers.{{.GoName}}.IsSpecified() {
+                            ctx.Response().Header.Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}.MustGet()))
+                        }
+                    {{else if .IsOptional -}}
+                        if response.Headers.{{.GoName}} != nil {
+                            ctx.Response().Header.Set("{{.Name}}", fmt.Sprint(*response.Headers.{{.GoName}}))
+                        }
+                    {{else -}}
+                        ctx.Response().Header.Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                    {{end -}}
                 {{end -}}
                 ctx.Status({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
                 return nil

--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -212,7 +212,17 @@
             {{end -}}
             func (response {{$opid}}{{$statusCode}}Response) Visit{{$opid}}Response(w http.ResponseWriter) error {
                 {{range $headers -}}
-                    w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                    {{if .IsNullable -}}
+                        if response.Headers.{{.GoName}}.IsSpecified() {
+                            w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}.MustGet()))
+                        }
+                    {{else if .IsOptional -}}
+                        if response.Headers.{{.GoName}} != nil {
+                            w.Header().Set("{{.Name}}", fmt.Sprint(*response.Headers.{{.GoName}}))
+                        }
+                    {{else -}}
+                        w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                    {{end -}}
                 {{end -}}
                 w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
                 return nil

--- a/pkg/codegen/templates/strict/strict-iris-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-iris-interface.tmpl
@@ -174,7 +174,17 @@
             {{end -}}
             func (response {{$opid}}{{$statusCode}}Response) Visit{{$opid}}Response(ctx iris.Context) error {
                 {{range $headers -}}
-                    ctx.ResponseWriter().Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                    {{if .IsNullable -}}
+                        if response.Headers.{{.GoName}}.IsSpecified() {
+                            ctx.ResponseWriter().Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}.MustGet()))
+                        }
+                    {{else if .IsOptional -}}
+                        if response.Headers.{{.GoName}} != nil {
+                            ctx.ResponseWriter().Header().Set("{{.Name}}", fmt.Sprint(*response.Headers.{{.GoName}}))
+                        }
+                    {{else -}}
+                        ctx.ResponseWriter().Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                    {{end -}}
                 {{end -}}
                 ctx.StatusCode({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
                 return nil


### PR DESCRIPTION
The no-content branch of the three strict-server interface templates (`strict-interface.tmpl`, `strict-fiber-interface.tmpl`, `strict-iris-interface.tmpl`) was rendering response headers unconditionally, missing the three-way `.IsNullable` / `.IsOptional` / default switch that PR #2301 added to the typed-body branch.

Because the `{{$opid}}{{$statusCode}}ResponseHeaders` struct is shared between the typed-body and no-content branches and uses `{{.GoTypeDef}}` (since #2301 / #2331), an unset optional header field is `*string(nil)` and an unspecified nullable header is a zero `runtime.Nullable[T]`. The bare `fmt.Sprint(...)` in the no-content branch was therefore stringifying these to `<nil>` / a typed zero-value and emitting a junk header rather than omitting it. A 204-style response declaring an optional or nullable header — with the caller leaving it unset — produced a wrong header value instead of no header at all.

Apply the same three-way switch to the no-content branch in all three templates so unset values are skipped, matching the typed-body branch behavior and matching what callers expect for OpenAPI `required: false` / `nullable: true` response headers.

Add regression coverage:

- `strict-schema.yaml` gains a `/no-content-headers` POST operation whose only response is 204 with `optional-header` (`required: false`) and `nullable-header` (`nullable: true`).
- `NoContentHeaders` handler stub returning an empty `NoContentHeaders204Response{}` is wired into all seven framework server implementations (chi, echo, fiber, gin, gorilla, iris, stdhttp).
- `NoContentHeadersOmitUnset` subtest added to the three `testImpl` copies (shared, stdhttp, fiber). Asserts both headers are absent from `rr.Header().Values(...)` when the response struct's header fields are left at their zero values.

The shared `testImpl` covers chi, echo, gin, and iris in one place; stdhttp and fiber maintain their own copies because they live in separate test files (stdhttp because of its own go.mod, fiber because of its package boundary). Gorilla generates code but has no test driver — the handler stub is still required so the generated `StrictServerInterface` is satisfied.

Fixes: #2349