### PR TITLE
respect output file path on gofmt failure

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -320,21 +320,27 @@ func main() {
 		opts.NoVCSVersionOverride = &noVCSVersionOverride
 	}
 
-	code, err := codegen.Generate(swagger, opts.Configuration)
-	if err != nil {
-		errExit("error generating code: %s\n", err)
+	code, genErr := codegen.Generate(swagger, opts.Configuration)
+
+	// Always emit any generated code to the requested destination, even when
+	// generation returned an error (e.g. the formatter rejected the output).
+	// Writing to the output file lets the user inspect the broken source
+	// directly instead of having it interleaved with stderr.
+	if code != "" {
+		if opts.OutputFile != "" {
+			if err := os.MkdirAll(filepath.Dir(opts.OutputFile), 0o755); err != nil {
+				errExit("error unable to create directory: %s\n", err)
+			}
+			if err := os.WriteFile(opts.OutputFile, []byte(code), 0o644); err != nil {
+				errExit("error writing generated code to file: %s\n", err)
+			}
+		} else {
+			fmt.Print(code)
+		}
 	}
 
-	if opts.OutputFile != "" {
-		if err := os.MkdirAll(filepath.Dir(opts.OutputFile), 0o755); err != nil {
-			errExit("error unable to create directory: %s\n", err)
-		}
-		err = os.WriteFile(opts.OutputFile, []byte(code), 0o644)
-		if err != nil {
-			errExit("error writing generated code to file: %s\n", err)
-		}
-	} else {
-		fmt.Print(code)
+	if genErr != nil {
+		errExit("error generating code: %s\n", genErr)
 	}
 }
 

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -517,34 +517,17 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 
 	outBytes, err := imports.Process(opts.PackageName+".go", []byte(goCode), nil)
 	if err != nil {
-		// if we don't get a line number
 		errLine := -1
 		var scanErr scanner.ErrorList
 		if errors.As(err, &scanErr) && scanErr.Len() > 0 {
-			// for now, only return the first error's information
 			errLine = scanErr[0].Pos.Line
 		}
-		return "", fmt.Errorf("error formatting Go code:\n%s\nerror was: %w", addLineNumbers(goCode, errLine), err)
+		if errLine > 0 {
+			return goCode, fmt.Errorf("error formatting Go code at line %d: %w", errLine, err)
+		}
+		return goCode, fmt.Errorf("error formatting Go code: %w", err)
 	}
 	return string(outBytes), nil
-}
-
-func addLineNumbers(goCode string, lineWithError int) string {
-	var out []string
-	lines := strings.Split(goCode, "\n")
-	for i, line := range lines {
-		// lines for humans start at 1
-		lineNumber := i + 1
-
-		errLine := "  "
-		if lineNumber == lineWithError {
-			errLine = "❗"
-		}
-
-		out = append(out, fmt.Sprintf("%s%5d: %s", errLine, lineNumber, line))
-	}
-
-	return strings.Join(out, "\n")
 }
 
 func GenerateTypeDefinitions(t *template.Template, swagger *openapi3.T, ops []OperationDefinition, excludeSchemas []string) (string, error) {


### PR DESCRIPTION
When `imports.Process` rejected the generated source, `Generate()` discarded the code and stuffed a line-numbered dump of it into the returned error. The CLI then printed that error to stderr and never wrote the requested `-o` (or config `output:`) file, so users saw a huge stderr spew with no output file produced.

Return the raw pre-format code from `Generate()` alongside the error, and have the CLI write it to the configured destination before exiting. The error message itself is now a single line referencing the failing source line; users can open the written file to inspect the broken code directly. `addLineNumbers` is dropped — it was only used by the removed in-error code dump.

Closes: #2340