### PR TITLE
Route server enums through general enums codegen

### DIFF
--- a/examples/generate/serverurls/api.yaml
+++ b/examples/generate/serverurls/api.yaml
@@ -54,6 +54,21 @@ servers:
 # callers can fill it in.
 - url: https://{tenant}.api.example.com
   description: Undeclared placeholder server
+# A server whose enum has two values that fold to the same Go
+# identifier suffix (`foo` and `Foo` both `ucFirst` to `Foo`). The
+# previous codegen would have emitted two `const ...VariableFoo`
+# declarations and failed to compile; the synthesizer now appends a
+# numeric suffix to disambiguate, and the typed default-pointer
+# references the correct (post-suffix) enum constant — addressing the
+# concern raised in PR #2358 review.
+- url: https://api.example.com/{mode}
+  description: Case-only enum collision
+  variables:
+    mode:
+      enum:
+        - 'foo'
+        - 'Foo'
+      default: 'Foo'
 # clash with the previous definition of `Development server` to trigger a new name
 - url: http://localhost:80
   description: Development server

--- a/examples/generate/serverurls/api.yaml
+++ b/examples/generate/serverurls/api.yaml
@@ -26,22 +26,42 @@ servers:
     basePath:
       # open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`
       default: v2
-    # an example of a type that's defined, but doesn't have a default
+    # an example of a variable declared but NOT referenced in the URL.
+    # `oapi-codegen` filters these out so they don't pollute the
+    # generated function signature with no-op parameters
+    # (https://github.com/oapi-codegen/oapi-codegen/issues/2004).
     noDefault: {}
-    # # TODO this conflict will cause broken generated code https://github.com/oapi-codegen/oapi-codegen/issues/2003
-    # conflicting:
-    #   enum:
-    #     - 'default'
-    #     - '443'
-    #   default: 'default'
+# A server whose `port` enum literally includes the string `default`.
+# The previous codegen tripped over this because the enum constant for
+# the value `default` collided with the named default-pointer constant
+# (https://github.com/oapi-codegen/oapi-codegen/issues/2003); the fix
+# routes server-URL enums through the generic enum path and renames
+# the default-pointer constant to `…VariableDefaultValue`.
+- url: https://api.example.com/{port}
+  description: Conflicting default enum
+  variables:
+    port:
+      enum:
+        - 'default'
+        - '443'
+      default: 'default'
+# A server whose URL contains a `{token}` placeholder for which there
+# is no entry in `variables`. The previous codegen happily emitted a
+# function that left `{token}` in the URL, which then tripped the
+# trailing `{`/`}` runtime check on every call
+# (https://github.com/oapi-codegen/oapi-codegen/issues/2005). The fix
+# emits the undeclared placeholder as a plain `string` parameter so
+# callers can fill it in.
+- url: https://{tenant}.api.example.com
+  description: Undeclared placeholder server
 # clash with the previous definition of `Development server` to trigger a new name
 - url: http://localhost:80
   description: Development server
 # clash with the previous definition of `Development server` to trigger a new name (again)
-- url: http://localhost:80
+- url: http://localhost:81
   description: Development server
 # make sure that the lowercase `description` gets converted to an uppercase
-- url: http://localhost:80
+- url: http://localhost:82
   description: some lowercase name
 # there may be URLs on their own, without a `description`
 - url: http://localhost:443

--- a/examples/generate/serverurls/gen.go
+++ b/examples/generate/serverurls/gen.go
@@ -8,8 +8,70 @@ import (
 	"strings"
 )
 
+// ServerUrlConflictingDefaultEnumPortVariable defines model for port.
+type ServerUrlConflictingDefaultEnumPortVariable string
+
+// ServerUrlTheProductionAPIServerPortVariable defines model for port.
+type ServerUrlTheProductionAPIServerPortVariable string
+
+// Defines values for ServerUrlConflictingDefaultEnumPortVariable.
+const (
+	ServerUrlConflictingDefaultEnumPortVariableDefault ServerUrlConflictingDefaultEnumPortVariable = "default"
+	ServerUrlConflictingDefaultEnumPortVariableN443    ServerUrlConflictingDefaultEnumPortVariable = "443"
+)
+
+// Valid indicates whether the value is a known member of the ServerUrlConflictingDefaultEnumPortVariable enum.
+func (e ServerUrlConflictingDefaultEnumPortVariable) Valid() bool {
+	switch e {
+	case ServerUrlConflictingDefaultEnumPortVariableDefault:
+		return true
+	case ServerUrlConflictingDefaultEnumPortVariableN443:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ServerUrlTheProductionAPIServerPortVariable.
+const (
+	ServerUrlTheProductionAPIServerPortVariableN443  ServerUrlTheProductionAPIServerPortVariable = "443"
+	ServerUrlTheProductionAPIServerPortVariableN8443 ServerUrlTheProductionAPIServerPortVariable = "8443"
+)
+
+// Valid indicates whether the value is a known member of the ServerUrlTheProductionAPIServerPortVariable enum.
+func (e ServerUrlTheProductionAPIServerPortVariable) Valid() bool {
+	switch e {
+	case ServerUrlTheProductionAPIServerPortVariableN443:
+		return true
+	case ServerUrlTheProductionAPIServerPortVariableN8443:
+		return true
+	default:
+		return false
+	}
+}
+
 // MyCustomAPIServer defines the Server URL for Custom named server
 const MyCustomAPIServer = "https://api.example.com/v2"
+
+// ServerUrlConflictingDefaultEnumPortVariableDefaultValue is the default choice, for the accepted values for the `port` variable for ServerUrlConflictingDefaultEnum
+const ServerUrlConflictingDefaultEnumPortVariableDefaultValue ServerUrlConflictingDefaultEnumPortVariable = ServerUrlConflictingDefaultEnumPortVariableDefault
+
+// NewServerUrlConflictingDefaultEnum constructs the Server URL for Conflicting default enum, with the provided variables.
+func NewServerUrlConflictingDefaultEnum(port ServerUrlConflictingDefaultEnumPortVariable) (string, error) {
+	if !port.Valid() {
+		return "", fmt.Errorf("`%v` is not one of the accepted values for the `port` variable", port)
+	}
+
+	u := "https://api.example.com/{port}"
+
+	u = strings.ReplaceAll(u, "{port}", string(port))
+
+	if strings.Contains(u, "{") || strings.Contains(u, "}") {
+		return "", fmt.Errorf("after mapping variables, there were still `{` or `}` characters in the string: %#v", u)
+	}
+
+	return u, nil
+}
 
 // ServerUrlDevelopmentServer defines the Server URL for Development server
 const ServerUrlDevelopmentServer = "https://development.gigantic-server.com/v1"
@@ -18,7 +80,7 @@ const ServerUrlDevelopmentServer = "https://development.gigantic-server.com/v1"
 const ServerUrlDevelopmentServer1 = "http://localhost:80"
 
 // ServerUrlDevelopmentServer2 defines the Server URL for Development server
-const ServerUrlDevelopmentServer2 = "http://localhost:80"
+const ServerUrlDevelopmentServer2 = "http://localhost:81"
 
 // ServerUrlHttplocalhost443 defines the Server URL for http://localhost:443
 const ServerUrlHttplocalhost443 = "http://localhost:443"
@@ -27,7 +89,7 @@ const ServerUrlHttplocalhost443 = "http://localhost:443"
 const ServerUrlProductionServer = "https://api.gigantic-server.com/v1"
 
 // ServerUrlSomeLowercaseName defines the Server URL for some lowercase name
-const ServerUrlSomeLowercaseName = "http://localhost:80"
+const ServerUrlSomeLowercaseName = "http://localhost:82"
 
 // ServerUrlStagingServer defines the Server URL for Staging server
 const ServerUrlStagingServer = "https://staging.gigantic-server.com/v1"
@@ -38,20 +100,8 @@ type ServerUrlTheProductionAPIServerBasePathVariable string
 // ServerUrlTheProductionAPIServerBasePathVariableDefault is the default value for the `basePath` variable for ServerUrlTheProductionAPIServer
 const ServerUrlTheProductionAPIServerBasePathVariableDefault = "v2"
 
-// ServerUrlTheProductionAPIServerNoDefaultVariable is the `noDefault` variable for ServerUrlTheProductionAPIServer
-type ServerUrlTheProductionAPIServerNoDefaultVariable string
-
-// ServerUrlTheProductionAPIServerPortVariable is the `port` variable for ServerUrlTheProductionAPIServer
-type ServerUrlTheProductionAPIServerPortVariable string
-
-// ServerUrlTheProductionAPIServerPortVariable8443 is one of the accepted values for the `port` variable for ServerUrlTheProductionAPIServer
-const ServerUrlTheProductionAPIServerPortVariable8443 ServerUrlTheProductionAPIServerPortVariable = "8443"
-
-// ServerUrlTheProductionAPIServerPortVariable443 is one of the accepted values for the `port` variable for ServerUrlTheProductionAPIServer
-const ServerUrlTheProductionAPIServerPortVariable443 ServerUrlTheProductionAPIServerPortVariable = "443"
-
-// ServerUrlTheProductionAPIServerPortVariableDefault is the default choice, for the accepted values for the `port` variable for ServerUrlTheProductionAPIServer
-const ServerUrlTheProductionAPIServerPortVariableDefault ServerUrlTheProductionAPIServerPortVariable = ServerUrlTheProductionAPIServerPortVariable8443
+// ServerUrlTheProductionAPIServerPortVariableDefaultValue is the default choice, for the accepted values for the `port` variable for ServerUrlTheProductionAPIServer
+const ServerUrlTheProductionAPIServerPortVariableDefaultValue ServerUrlTheProductionAPIServerPortVariable = ServerUrlTheProductionAPIServerPortVariableN8443
 
 // ServerUrlTheProductionAPIServerUsernameVariable is the `username` variable for ServerUrlTheProductionAPIServer
 type ServerUrlTheProductionAPIServerUsernameVariable string
@@ -60,15 +110,30 @@ type ServerUrlTheProductionAPIServerUsernameVariable string
 const ServerUrlTheProductionAPIServerUsernameVariableDefault = "demo"
 
 // NewServerUrlTheProductionAPIServer constructs the Server URL for The production API server, with the provided variables.
-func NewServerUrlTheProductionAPIServer(basePath ServerUrlTheProductionAPIServerBasePathVariable, noDefault ServerUrlTheProductionAPIServerNoDefaultVariable, port ServerUrlTheProductionAPIServerPortVariable, username ServerUrlTheProductionAPIServerUsernameVariable) (string, error) {
+func NewServerUrlTheProductionAPIServer(basePath ServerUrlTheProductionAPIServerBasePathVariable, port ServerUrlTheProductionAPIServerPortVariable, username ServerUrlTheProductionAPIServerUsernameVariable) (string, error) {
+	if !port.Valid() {
+		return "", fmt.Errorf("`%v` is not one of the accepted values for the `port` variable", port)
+	}
+
 	u := "https://{username}.gigantic-server.com:{port}/{basePath}"
 
 	u = strings.ReplaceAll(u, "{basePath}", string(basePath))
-	u = strings.ReplaceAll(u, "{noDefault}", string(noDefault))
-
-	// TODO in the future, this will validate that the value is part of the ServerUrlTheProductionAPIServerPortVariable enum
 	u = strings.ReplaceAll(u, "{port}", string(port))
 	u = strings.ReplaceAll(u, "{username}", string(username))
+
+	if strings.Contains(u, "{") || strings.Contains(u, "}") {
+		return "", fmt.Errorf("after mapping variables, there were still `{` or `}` characters in the string: %#v", u)
+	}
+
+	return u, nil
+}
+
+// NewServerUrlUndeclaredPlaceholderServer constructs the Server URL for Undeclared placeholder server, with the provided variables.
+func NewServerUrlUndeclaredPlaceholderServer(tenant string) (string, error) {
+
+	u := "https://{tenant}.api.example.com"
+
+	u = strings.ReplaceAll(u, "{tenant}", tenant)
 
 	if strings.Contains(u, "{") || strings.Contains(u, "}") {
 		return "", fmt.Errorf("after mapping variables, there were still `{` or `}` characters in the string: %#v", u)

--- a/examples/generate/serverurls/gen.go
+++ b/examples/generate/serverurls/gen.go
@@ -8,24 +8,45 @@ import (
 	"strings"
 )
 
+// ServerUrlCaseOnlyEnumCollisionModeVariable defines model for mode.
+type ServerUrlCaseOnlyEnumCollisionModeVariable string
+
 // ServerUrlConflictingDefaultEnumPortVariable defines model for port.
 type ServerUrlConflictingDefaultEnumPortVariable string
 
 // ServerUrlTheProductionAPIServerPortVariable defines model for port.
 type ServerUrlTheProductionAPIServerPortVariable string
 
+// Defines values for ServerUrlCaseOnlyEnumCollisionModeVariable.
+const (
+	ServerUrlCaseOnlyEnumCollisionModeVariableFoo  ServerUrlCaseOnlyEnumCollisionModeVariable = "foo"
+	ServerUrlCaseOnlyEnumCollisionModeVariableFoo1 ServerUrlCaseOnlyEnumCollisionModeVariable = "Foo"
+)
+
+// Valid indicates whether the value is a known member of the ServerUrlCaseOnlyEnumCollisionModeVariable enum.
+func (e ServerUrlCaseOnlyEnumCollisionModeVariable) Valid() bool {
+	switch e {
+	case ServerUrlCaseOnlyEnumCollisionModeVariableFoo:
+		return true
+	case ServerUrlCaseOnlyEnumCollisionModeVariableFoo1:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ServerUrlConflictingDefaultEnumPortVariable.
 const (
+	ServerUrlConflictingDefaultEnumPortVariable443     ServerUrlConflictingDefaultEnumPortVariable = "443"
 	ServerUrlConflictingDefaultEnumPortVariableDefault ServerUrlConflictingDefaultEnumPortVariable = "default"
-	ServerUrlConflictingDefaultEnumPortVariableN443    ServerUrlConflictingDefaultEnumPortVariable = "443"
 )
 
 // Valid indicates whether the value is a known member of the ServerUrlConflictingDefaultEnumPortVariable enum.
 func (e ServerUrlConflictingDefaultEnumPortVariable) Valid() bool {
 	switch e {
-	case ServerUrlConflictingDefaultEnumPortVariableDefault:
+	case ServerUrlConflictingDefaultEnumPortVariable443:
 		return true
-	case ServerUrlConflictingDefaultEnumPortVariableN443:
+	case ServerUrlConflictingDefaultEnumPortVariableDefault:
 		return true
 	default:
 		return false
@@ -34,16 +55,16 @@ func (e ServerUrlConflictingDefaultEnumPortVariable) Valid() bool {
 
 // Defines values for ServerUrlTheProductionAPIServerPortVariable.
 const (
-	ServerUrlTheProductionAPIServerPortVariableN443  ServerUrlTheProductionAPIServerPortVariable = "443"
-	ServerUrlTheProductionAPIServerPortVariableN8443 ServerUrlTheProductionAPIServerPortVariable = "8443"
+	ServerUrlTheProductionAPIServerPortVariable443  ServerUrlTheProductionAPIServerPortVariable = "443"
+	ServerUrlTheProductionAPIServerPortVariable8443 ServerUrlTheProductionAPIServerPortVariable = "8443"
 )
 
 // Valid indicates whether the value is a known member of the ServerUrlTheProductionAPIServerPortVariable enum.
 func (e ServerUrlTheProductionAPIServerPortVariable) Valid() bool {
 	switch e {
-	case ServerUrlTheProductionAPIServerPortVariableN443:
+	case ServerUrlTheProductionAPIServerPortVariable443:
 		return true
-	case ServerUrlTheProductionAPIServerPortVariableN8443:
+	case ServerUrlTheProductionAPIServerPortVariable8443:
 		return true
 	default:
 		return false
@@ -53,7 +74,27 @@ func (e ServerUrlTheProductionAPIServerPortVariable) Valid() bool {
 // MyCustomAPIServer defines the Server URL for Custom named server
 const MyCustomAPIServer = "https://api.example.com/v2"
 
-// ServerUrlConflictingDefaultEnumPortVariableDefaultValue is the default choice, for the accepted values for the `port` variable for ServerUrlConflictingDefaultEnum
+// ServerUrlCaseOnlyEnumCollisionModeVariableDefault is the default choice, for the accepted values for the `mode` variable
+const ServerUrlCaseOnlyEnumCollisionModeVariableDefault ServerUrlCaseOnlyEnumCollisionModeVariable = ServerUrlCaseOnlyEnumCollisionModeVariableFoo1
+
+// NewServerUrlCaseOnlyEnumCollision constructs the Server URL for Case-only enum collision, with the provided variables.
+func NewServerUrlCaseOnlyEnumCollision(mode ServerUrlCaseOnlyEnumCollisionModeVariable) (string, error) {
+	if !mode.Valid() {
+		return "", fmt.Errorf("`%v` is not one of the accepted values for the `mode` variable", mode)
+	}
+
+	u := "https://api.example.com/{mode}"
+
+	u = strings.ReplaceAll(u, "{mode}", string(mode))
+
+	if strings.Contains(u, "{") || strings.Contains(u, "}") {
+		return "", fmt.Errorf("after mapping variables, there were still `{` or `}` characters in the string: %#v", u)
+	}
+
+	return u, nil
+}
+
+// ServerUrlConflictingDefaultEnumPortVariableDefaultValue is the default choice, for the accepted values for the `port` variable
 const ServerUrlConflictingDefaultEnumPortVariableDefaultValue ServerUrlConflictingDefaultEnumPortVariable = ServerUrlConflictingDefaultEnumPortVariableDefault
 
 // NewServerUrlConflictingDefaultEnum constructs the Server URL for Conflicting default enum, with the provided variables.
@@ -100,14 +141,14 @@ type ServerUrlTheProductionAPIServerBasePathVariable string
 // ServerUrlTheProductionAPIServerBasePathVariableDefault is the default value for the `basePath` variable for ServerUrlTheProductionAPIServer
 const ServerUrlTheProductionAPIServerBasePathVariableDefault = "v2"
 
-// ServerUrlTheProductionAPIServerPortVariableDefaultValue is the default choice, for the accepted values for the `port` variable for ServerUrlTheProductionAPIServer
-const ServerUrlTheProductionAPIServerPortVariableDefaultValue ServerUrlTheProductionAPIServerPortVariable = ServerUrlTheProductionAPIServerPortVariableN8443
-
 // ServerUrlTheProductionAPIServerUsernameVariable is the `username` variable for ServerUrlTheProductionAPIServer
 type ServerUrlTheProductionAPIServerUsernameVariable string
 
 // ServerUrlTheProductionAPIServerUsernameVariableDefault is the default value for the `username` variable for ServerUrlTheProductionAPIServer
 const ServerUrlTheProductionAPIServerUsernameVariableDefault = "demo"
+
+// ServerUrlTheProductionAPIServerPortVariableDefault is the default choice, for the accepted values for the `port` variable
+const ServerUrlTheProductionAPIServerPortVariableDefault ServerUrlTheProductionAPIServerPortVariable = ServerUrlTheProductionAPIServerPortVariable8443
 
 // NewServerUrlTheProductionAPIServer constructs the Server URL for The production API server, with the provided variables.
 func NewServerUrlTheProductionAPIServer(basePath ServerUrlTheProductionAPIServerBasePathVariable, port ServerUrlTheProductionAPIServerPortVariable, username ServerUrlTheProductionAPIServerUsernameVariable) (string, error) {

--- a/examples/generate/serverurls/gen_test.go
+++ b/examples/generate/serverurls/gen_test.go
@@ -9,41 +9,47 @@ import (
 )
 
 func TestServerUrlTheProductionAPIServer(t *testing.T) {
-	t.Run("when no values are provided, it does not error", func(t *testing.T) {
-		serverUrl, err := NewServerUrlTheProductionAPIServer("", "", "", "")
-		require.NoError(t, err)
-
-		assert.Equal(t, "https://.gigantic-server.com:/", serverUrl)
-
-		// NOTE that ideally this should fail as it doesn't /seem/ to provide a valid URL, but it does seem to be valid
-		_, err = url.Parse(serverUrl)
-		require.NoError(t, err)
+	t.Run("when an empty value is provided for an enum-typed variable, it errors", func(t *testing.T) {
+		// `port` is enum-typed; the empty string is not in {"443", "8443"}.
+		_, err := NewServerUrlTheProductionAPIServer("", "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "port")
 	})
 
-	// TODO:when we validate enums, this will need more testing https://github.com/oapi-codegen/oapi-codegen/issues/2006
-	t.Run("when values that are not part of the enum are provided, it does not error", func(t *testing.T) {
+	t.Run("when a value not in the enum is provided, it errors", func(t *testing.T) {
 		invalidPort := ServerUrlTheProductionAPIServerPortVariable("12345")
-		serverUrl, err := NewServerUrlTheProductionAPIServer(
+		_, err := NewServerUrlTheProductionAPIServer(
 			ServerUrlTheProductionAPIServerBasePathVariableDefault,
-			ServerUrlTheProductionAPIServerNoDefaultVariable(""),
 			invalidPort,
 			ServerUrlTheProductionAPIServerUsernameVariableDefault,
 		)
-		require.NoError(t, err)
-
-		assert.Equal(t, "https://demo.gigantic-server.com:12345/v2", serverUrl)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "port")
 	})
 
 	t.Run("when default values are provided, it does not error", func(t *testing.T) {
 		serverUrl, err := NewServerUrlTheProductionAPIServer(
 			ServerUrlTheProductionAPIServerBasePathVariableDefault,
-			ServerUrlTheProductionAPIServerNoDefaultVariable(""),
-			ServerUrlTheProductionAPIServerPortVariableDefault,
+			ServerUrlTheProductionAPIServerPortVariableDefaultValue,
 			ServerUrlTheProductionAPIServerUsernameVariableDefault,
 		)
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://demo.gigantic-server.com:8443/v2", serverUrl)
+
+		_, err = url.Parse(serverUrl)
+		require.NoError(t, err)
+	})
+
+	t.Run("a valid non-default enum value is accepted", func(t *testing.T) {
+		serverUrl, err := NewServerUrlTheProductionAPIServer(
+			ServerUrlTheProductionAPIServerBasePathVariableDefault,
+			ServerUrlTheProductionAPIServerPortVariableN443,
+			ServerUrlTheProductionAPIServerUsernameVariableDefault,
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, "https://demo.gigantic-server.com:443/v2", serverUrl)
 	})
 }
 
@@ -51,4 +57,39 @@ func TestXGoName(t *testing.T) {
 	t.Run("x-go-name overrides the auto-generated server name", func(t *testing.T) {
 		assert.Equal(t, "https://api.example.com/v2", MyCustomAPIServer)
 	})
+}
+
+// Regression test for #2003: an `enum` value `default` no longer
+// collides with the default-pointer constant — both are emitted and
+// the typed default-pointer correctly references the enum constant.
+func TestServerUrlConflictingDefaultEnum(t *testing.T) {
+	t.Run("the default-pointer references the enum constant for `default`", func(t *testing.T) {
+		assert.Equal(t,
+			ServerUrlConflictingDefaultEnumPortVariable("default"),
+			ServerUrlConflictingDefaultEnumPortVariableDefaultValue,
+		)
+	})
+
+	t.Run("New… accepts the default and the other enum value, errors on others", func(t *testing.T) {
+		got, err := NewServerUrlConflictingDefaultEnum(ServerUrlConflictingDefaultEnumPortVariableDefaultValue)
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.example.com/default", got)
+
+		got, err = NewServerUrlConflictingDefaultEnum(ServerUrlConflictingDefaultEnumPortVariableN443)
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.example.com/443", got)
+
+		_, err = NewServerUrlConflictingDefaultEnum("nope")
+		require.Error(t, err)
+	})
+}
+
+// Regression test for #2005: a `{placeholder}` in the URL with no
+// matching entry in `variables` is generated as a plain `string`
+// parameter so the function returns a usable URL instead of always
+// erroring on the trailing `{` / `}` check.
+func TestServerUrlUndeclaredPlaceholderServer(t *testing.T) {
+	got, err := NewServerUrlUndeclaredPlaceholderServer("acme")
+	require.NoError(t, err)
+	assert.Equal(t, "https://acme.api.example.com", got)
 }

--- a/examples/generate/serverurls/gen_test.go
+++ b/examples/generate/serverurls/gen_test.go
@@ -28,9 +28,13 @@ func TestServerUrlTheProductionAPIServer(t *testing.T) {
 	})
 
 	t.Run("when default values are provided, it does not error", func(t *testing.T) {
+		// The default-pointer keeps its historical name on this server
+		// because the enum doesn't collide (no enum value folds to
+		// "Default") — the asymmetric rename for #2003 only kicks in
+		// when collision is detected.
 		serverUrl, err := NewServerUrlTheProductionAPIServer(
 			ServerUrlTheProductionAPIServerBasePathVariableDefault,
-			ServerUrlTheProductionAPIServerPortVariableDefaultValue,
+			ServerUrlTheProductionAPIServerPortVariableDefault,
 			ServerUrlTheProductionAPIServerUsernameVariableDefault,
 		)
 		require.NoError(t, err)
@@ -44,7 +48,7 @@ func TestServerUrlTheProductionAPIServer(t *testing.T) {
 	t.Run("a valid non-default enum value is accepted", func(t *testing.T) {
 		serverUrl, err := NewServerUrlTheProductionAPIServer(
 			ServerUrlTheProductionAPIServerBasePathVariableDefault,
-			ServerUrlTheProductionAPIServerPortVariableN443,
+			ServerUrlTheProductionAPIServerPortVariable443,
 			ServerUrlTheProductionAPIServerUsernameVariableDefault,
 		)
 		require.NoError(t, err)
@@ -75,7 +79,7 @@ func TestServerUrlConflictingDefaultEnum(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "https://api.example.com/default", got)
 
-		got, err = NewServerUrlConflictingDefaultEnum(ServerUrlConflictingDefaultEnumPortVariableN443)
+		got, err = NewServerUrlConflictingDefaultEnum(ServerUrlConflictingDefaultEnumPortVariable443)
 		require.NoError(t, err)
 		assert.Equal(t, "https://api.example.com/443", got)
 
@@ -92,4 +96,37 @@ func TestServerUrlUndeclaredPlaceholderServer(t *testing.T) {
 	got, err := NewServerUrlUndeclaredPlaceholderServer("acme")
 	require.NoError(t, err)
 	assert.Equal(t, "https://acme.api.example.com", got)
+}
+
+// Regression test for the case-only-different-enum scenario raised in
+// PR #2358 review: `enum: [foo, Foo]` produces two values that
+// `ucFirst`-fold to the same identifier `Foo`. The synthesizer dedups
+// with a numeric suffix (`Foo` and `Foo1`) and the typed default-pointer
+// references the post-suffix const that actually exists. Under the old
+// codegen this would have emitted two `const ...VariableFoo`
+// declarations and failed to compile.
+func TestServerUrlCaseOnlyEnumCollision(t *testing.T) {
+	t.Run("default-pointer references the post-dedup constant", func(t *testing.T) {
+		// The spec sets default: "Foo"; the post-dedup const is
+		// ...VariableFoo1, which is exactly what the pointer must
+		// resolve to.
+		assert.Equal(t,
+			ServerUrlCaseOnlyEnumCollisionModeVariable("Foo"),
+			ServerUrlCaseOnlyEnumCollisionModeVariableDefault,
+		)
+		assert.Equal(t,
+			ServerUrlCaseOnlyEnumCollisionModeVariableDefault,
+			ServerUrlCaseOnlyEnumCollisionModeVariableFoo1,
+		)
+	})
+
+	t.Run("both case-variant constants are distinct and accepted", func(t *testing.T) {
+		got, err := NewServerUrlCaseOnlyEnumCollision(ServerUrlCaseOnlyEnumCollisionModeVariableFoo)
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.example.com/foo", got)
+
+		got, err = NewServerUrlCaseOnlyEnumCollision(ServerUrlCaseOnlyEnumCollisionModeVariableFoo1)
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.example.com/Foo", got)
+	})
 }

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -271,10 +271,31 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 
 	var serverURLsDefinitions string
 	if opts.Generate.ServerURLs {
-		serverURLsDefinitions, err = GenerateServerURLs(t, spec)
+		// Server-URL enum-typed variables are routed through the same
+		// typedef.tmpl + constants.tmpl pipelines as any other
+		// enum-bearing schema, so they get matching `type X string`,
+		// `const ( … )` block, and `Valid()` method. We do this here
+		// (rather than in GenerateTypeDefinitions) so the types are
+		// emitted even when `generate.models` is disabled.
+		serverURLEnumTypes, err := BuildServerURLTypeDefinitions(spec)
+		if err != nil {
+			return "", fmt.Errorf("error generating Go types for server URL variables: %w", err)
+		}
+		serverURLEnumTypeDecls, err := GenerateTypes(t, serverURLEnumTypes)
+		if err != nil {
+			return "", fmt.Errorf("error generating type declarations for server URL variables: %w", err)
+		}
+		serverURLEnumConstants, err := GenerateEnums(t, serverURLEnumTypes)
+		if err != nil {
+			return "", fmt.Errorf("error generating enums for server URL variables: %w", err)
+		}
+
+		serverURLsBody, err := GenerateServerURLs(t, spec)
 		if err != nil {
 			return "", fmt.Errorf("error generating Server URLs: %w", err)
 		}
+
+		serverURLsDefinitions = serverURLEnumTypeDecls + serverURLEnumConstants + serverURLsBody
 	}
 
 	var irisServerOut string
@@ -993,7 +1014,7 @@ func GenerateEnums(t *template.Template, types []TypeDefinition) (string, error)
 				Schema:         tp.Schema,
 				TypeName:       tp.TypeName,
 				ValueWrapper:   wrapper,
-				PrefixTypeName: globalState.options.Compatibility.AlwaysPrefixEnumValues,
+				PrefixTypeName: globalState.options.Compatibility.AlwaysPrefixEnumValues || tp.ForceEnumPrefix,
 			})
 		}
 	}

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -259,6 +259,14 @@ type TypeDefinition struct {
 
 	// This is the Schema wrapper is used to populate the type description
 	Schema Schema
+
+	// ForceEnumPrefix, when true, forces the enum-value constants generated
+	// from this TypeDefinition to be prefixed with the type name, regardless
+	// of whether GenerateEnums detects a cross-enum conflict. Used for
+	// synthesised enum types (e.g. server-URL variable enums) whose
+	// generated identifiers must remain stable to avoid colliding with
+	// other constants emitted alongside them.
+	ForceEnumPrefix bool
 }
 
 // ResponseTypeDefinition is an extension of TypeDefinition, specifically for

--- a/pkg/codegen/server_urls.go
+++ b/pkg/codegen/server_urls.go
@@ -2,6 +2,8 @@ package codegen
 
 import (
 	"fmt"
+	"regexp"
+	"sort"
 	"strconv"
 	"text/template"
 
@@ -10,6 +12,28 @@ import (
 
 const serverURLPrefix = "ServerUrl"
 const serverURLSuffixIterations = 10
+
+// serverURLPlaceholderRE captures `{name}` placeholders in a Server URL
+// template. Per OpenAPI 3.0.3 §4.7.7, server-variable names are bound to
+// the {name} tokens in `Server Object` URL templates; we treat anything
+// matching `{[^/{}]+}` as a placeholder candidate. The character class
+// excludes `/` so we don't accidentally span path segments, and `{`/`}`
+// so nested braces (which the spec doesn't define anyway) don't merge.
+var serverURLPlaceholderRE = regexp.MustCompile(`\{([^/{}]+)\}`)
+
+// urlPlaceholders returns the set of variable names referenced as
+// `{name}` placeholders in a Server URL template, deduplicated.
+func urlPlaceholders(url string) map[string]struct{} {
+	matches := serverURLPlaceholderRE.FindAllStringSubmatch(url, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		set[m[1]] = struct{}{}
+	}
+	return set
+}
 
 // ServerObjectDefinition defines the definition of an OpenAPI Server object (https://spec.openapis.org/oas/v3.0.3#server-object) as it is provided to code generation in `oapi-codegen`
 type ServerObjectDefinition struct {
@@ -20,7 +44,63 @@ type ServerObjectDefinition struct {
 	OAPISchema *openapi3.Server
 }
 
-func GenerateServerURLs(t *template.Template, spec *openapi3.T) (string, error) {
+// UsedVariables returns the subset of OAPISchema.Variables whose
+// `{name}` placeholder actually appears in OAPISchema.URL. Variables
+// declared but unused are skipped — they would otherwise produce a
+// type, constant, function parameter, and a no-op `strings.ReplaceAll`
+// (https://github.com/oapi-codegen/oapi-codegen/issues/2004). Used by
+// both server-urls.tmpl and BuildServerURLTypeDefinitions so that
+// emitted types and the generated function signature stay in sync.
+func (s ServerObjectDefinition) UsedVariables() map[string]*openapi3.ServerVariable {
+	if s.OAPISchema == nil || len(s.OAPISchema.Variables) == 0 {
+		return nil
+	}
+	placeholders := urlPlaceholders(s.OAPISchema.URL)
+	used := make(map[string]*openapi3.ServerVariable, len(s.OAPISchema.Variables))
+	for name, v := range s.OAPISchema.Variables {
+		if _, ok := placeholders[name]; ok {
+			used[name] = v
+		}
+	}
+	return used
+}
+
+// UndeclaredPlaceholders returns the sorted list of `{name}`
+// placeholder names that appear in OAPISchema.URL but have no
+// corresponding entry in OAPISchema.Variables. The previous code
+// generated a function that referenced only declared variables, so
+// any undeclared placeholder remained in the URL after substitution
+// and the trailing `{`/`}` runtime check tripped on every call —
+// making the generated function permanently unusable
+// (https://github.com/oapi-codegen/oapi-codegen/issues/2005). The
+// template now adds these as plain `string` parameters so callers
+// can fill them in directly.
+func (s ServerObjectDefinition) UndeclaredPlaceholders() []string {
+	if s.OAPISchema == nil {
+		return nil
+	}
+	placeholders := urlPlaceholders(s.OAPISchema.URL)
+	if len(placeholders) == 0 {
+		return nil
+	}
+	var undeclared []string
+	for name := range placeholders {
+		if _, declared := s.OAPISchema.Variables[name]; !declared {
+			undeclared = append(undeclared, name)
+		}
+	}
+	if len(undeclared) == 0 {
+		return nil
+	}
+	sort.Strings(undeclared)
+	return undeclared
+}
+
+// serverObjectDefinitions deconflicts server names and returns the
+// stable, deterministically-named ServerObjectDefinitions for `spec`.
+// Used by both BuildServerURLTypeDefinitions and GenerateServerURLs so
+// they generate identifiers that match.
+func serverObjectDefinitions(spec *openapi3.T) ([]ServerObjectDefinition, error) {
 	names := make(map[string]*openapi3.Server)
 
 	for _, server := range spec.Servers {
@@ -28,7 +108,7 @@ func GenerateServerURLs(t *template.Template, spec *openapi3.T) (string, error) 
 		if goNameExt, ok := server.Extensions[extGoName]; ok {
 			customName, err := extParseGoFieldName(goNameExt)
 			if err != nil {
-				return "", fmt.Errorf("invalid value for %q: %w", extGoName, err)
+				return nil, fmt.Errorf("invalid value for %q: %w", extGoName, err)
 			}
 			if customName != "" {
 				name = customName
@@ -49,20 +129,11 @@ func GenerateServerURLs(t *template.Template, spec *openapi3.T) (string, error) 
 			continue
 		}
 
-		// otherwise, try appending a number to the name
+		// otherwise, try appending a number to the name. Start at 1 so
+		// `Foo` / `Foo1` reads better than `Foo` / `Foo0`.
 		saved := false
-		// NOTE that we start at 1 on purpose, as
-		//
-		//  ... ServerURLDevelopmentServer
-		//  ... ServerURLDevelopmentServer1`
-		//
-		// reads better than:
-		//
-		//  ... ServerURLDevelopmentServer
-		//  ... ServerURLDevelopmentServer0
 		for i := 1; i < 1+serverURLSuffixIterations; i++ {
 			suffixed := name + strconv.Itoa(i)
-			// and then store it if there's no conflict
 			if _, suffixConflict := names[suffixed]; !suffixConflict {
 				names[suffixed] = server
 				saved = true
@@ -74,20 +145,102 @@ func GenerateServerURLs(t *template.Template, spec *openapi3.T) (string, error) 
 			continue
 		}
 
-		// otherwise, error
-		return "", fmt.Errorf("failed to create a unique name for the Server URL (%#v) with description (%#v) after %d iterations", server.URL, server.Description, serverURLSuffixIterations)
+		return nil, fmt.Errorf("failed to create a unique name for the Server URL (%#v) with description (%#v) after %d iterations", server.URL, server.Description, serverURLSuffixIterations)
 	}
 
 	keys := SortedMapKeys(names)
 	servers := make([]ServerObjectDefinition, len(keys))
-	i := 0
-	for _, k := range keys {
+	for i, k := range keys {
 		servers[i] = ServerObjectDefinition{
 			GoName:     k,
 			OAPISchema: names[k],
 		}
-		i++
+	}
+	return servers, nil
+}
+
+// serverURLVariableTypeName returns the Go type identifier for the
+// `enum`-typed variable `varName` on the server with deconflicted Go
+// name `serverGoName`. Mirrors the naming scheme used by
+// server-urls.tmpl (`<server>%sVariable`) so that synthesized
+// TypeDefinitions, the function signature emitted by the template,
+// and any user references all resolve to the same identifier.
+func serverURLVariableTypeName(serverGoName, varName string) string {
+	return serverGoName + UppercaseFirstCharacter(varName) + "Variable"
+}
+
+// BuildServerURLTypeDefinitions synthesizes a TypeDefinition for every
+// server-URL variable that defines an `enum`. These are appended into
+// the same TypeDefinition slices used by GenerateTypes (typedef.tmpl)
+// and GenerateEnums (constants.tmpl), so that server-URL enum
+// variables get the same `type X string`, `const ( … )` block, and
+// `Valid()` method as any other enum-bearing schema. The
+// server-urls.tmpl template no longer emits these declarations
+// directly.
+//
+// Variables without an `enum` are not handled here: server-urls.tmpl
+// continues to emit their `type` and (optional) default constant
+// inline, since the generic enum path has nothing to contribute for a
+// non-enum string.
+func BuildServerURLTypeDefinitions(spec *openapi3.T) ([]TypeDefinition, error) {
+	servers, err := serverObjectDefinitions(spec)
+	if err != nil {
+		return nil, err
 	}
 
+	var defs []TypeDefinition
+	for _, srv := range servers {
+		used := srv.UsedVariables()
+		// Iterate variables in deterministic order.
+		for _, varName := range SortedMapKeys(used) {
+			v := used[varName]
+			if v == nil || len(v.Enum) == 0 {
+				continue
+			}
+			// Validate that `default`, if set, is one of the
+			// declared `enum` values. Per OpenAPI 3.0.3 §4.7.10,
+			// the default MUST be in the enum list when both are
+			// present; the previous template trusted the spec
+			// blindly and emitted a const referencing an
+			// undeclared identifier when the spec violated the
+			// rule, producing a confusing user-side compile error
+			// (https://github.com/oapi-codegen/oapi-codegen/issues/2007).
+			// Catch the violation at codegen time so the user sees
+			// a clear message pointing at their spec.
+			if v.Default != "" {
+				inEnum := false
+				for _, ev := range v.Enum {
+					if ev == v.Default {
+						inEnum = true
+						break
+					}
+				}
+				if !inEnum {
+					return nil, fmt.Errorf("server URL %q: variable %q has default value %q which is not one of the declared enum values %v",
+						srv.OAPISchema.URL, varName, v.Default, v.Enum)
+				}
+			}
+			typeName := serverURLVariableTypeName(srv.GoName, varName)
+			enumValues := SanitizeEnumNames(nil, v.Enum)
+			defs = append(defs, TypeDefinition{
+				TypeName: typeName,
+				JsonName: varName,
+				Schema: Schema{
+					GoType:      "string",
+					EnumValues:  enumValues,
+					Description: v.Description,
+				},
+				ForceEnumPrefix: true,
+			})
+		}
+	}
+	return defs, nil
+}
+
+func GenerateServerURLs(t *template.Template, spec *openapi3.T) (string, error) {
+	servers, err := serverObjectDefinitions(spec)
+	if err != nil {
+		return "", err
+	}
 	return GenerateTemplates([]string{"server-urls.tmpl"}, t, servers)
 }

--- a/pkg/codegen/server_urls.go
+++ b/pkg/codegen/server_urls.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -169,6 +170,162 @@ func serverURLVariableTypeName(serverGoName, varName string) string {
 	return serverGoName + UppercaseFirstCharacter(varName) + "Variable"
 }
 
+// serverURLEnumKeys returns deterministic identifier suffixes for each
+// enum value of `v`, in `v.Enum` order. Each suffix is just the value
+// with its first character upper-cased — matching what the previous
+// template-only path produced for happy-path specs (`<Prefix><Value | ucFirst>`),
+// so adopters with non-colliding enums keep their existing identifiers.
+//
+// When two values fold to the same suffix (e.g. `enum: ["foo", "FOO"]`,
+// both → `Foo`), later occurrences get a numeric suffix (`Foo`, `Foo1`,
+// `Foo2`, …) — same scheme as `SanitizeEnumNames`. The previous
+// template path didn't dedup at all and would have produced a
+// duplicate-const compile error for these specs; this is purely a
+// correctness improvement, not a naming change for any spec that
+// actually compiled before.
+func serverURLEnumKeys(v *openapi3.ServerVariable) []string {
+	keys := make([]string, len(v.Enum))
+	seen := make(map[string]int, len(v.Enum))
+	for i, val := range v.Enum {
+		base := UppercaseFirstCharacter(val)
+		if n, dup := seen[base]; dup {
+			keys[i] = base + strconv.Itoa(n)
+			seen[base] = n + 1
+		} else {
+			keys[i] = base
+			seen[base] = 1
+		}
+	}
+	return keys
+}
+
+// serverURLEnumValues returns the EnumValues map handed to GenerateEnums
+// for variable `v`: key is the deduplicated identifier suffix from
+// serverURLEnumKeys, value is the original enum string.
+func serverURLEnumValues(v *openapi3.ServerVariable) map[string]string {
+	keys := serverURLEnumKeys(v)
+	out := make(map[string]string, len(keys))
+	for i, k := range keys {
+		out[k] = v.Enum[i]
+	}
+	return out
+}
+
+// ServerURLDefaultPointer carries the pre-computed identifier names
+// needed to emit a typed default-pointer constant for an enum-typed
+// server-URL variable. Computed in Go (not the template) so that the
+// pointer's reference to the enum-value constant always agrees with
+// the identifier the const-block actually emitted, including in
+// dedup-suffix cases (e.g. `enum: ["foo", "FOO"]` with `default: "FOO"`
+// → enum const is `<Prefix>Foo1`, pointer must reference exactly that).
+type ServerURLDefaultPointer struct {
+	// VariableName is the OpenAPI variable name (for doc comments).
+	VariableName string
+	// TypeName is the enum's Go type, e.g. `ServerUrlFooBarVariable`.
+	TypeName string
+	// PointerName is the constant being declared. Normally it is
+	// `<TypeName>Default` (matching the historical naming). Switches
+	// to `<TypeName>DefaultValue` only when the variable's enum
+	// contains a value whose identifier suffix is the literal string
+	// "Default" — i.e. exactly the case that produced #2003's
+	// duplicate-const compile error under the old codegen. Specs that
+	// compiled cleanly before keep their `Default` name.
+	PointerName string
+	// TargetName is the fully-qualified enum-value constant that the
+	// pointer references, e.g. `<TypeName>N443` or `<TypeName>Foo1`.
+	TargetName string
+	// Description is the variable's OpenAPI description (doc comment).
+	Description string
+}
+
+// NewServerFunctionParams returns the formatted parameter list for
+// the generated `New<ServerName>(...)` function — one typed parameter
+// per declared-and-used variable, plus one `string` parameter per
+// `{name}` placeholder that appears in the URL but isn't in
+// `variables` (#2005). The two groups are sorted together
+// alphabetically so the generated signature is deterministic.
+//
+// Equivalent to calling `genServerURLWithVariablesFunctionParams` for
+// the typed half and concatenating the undeclared half — but exposing
+// it as a method keeps server-urls.tmpl free of that combination
+// logic and means the template helper itself stayed at its
+// pre-existing two-argument shape (so any user-supplied custom
+// `server-urls.tmpl` override that calls the helper directly is
+// unaffected).
+func (s ServerObjectDefinition) NewServerFunctionParams() string {
+	used := s.UsedVariables()
+	undeclared := s.UndeclaredPlaceholders()
+	if len(used) == 0 && len(undeclared) == 0 {
+		return ""
+	}
+
+	type param struct {
+		name string
+		typ  string
+	}
+	parts := make([]param, 0, len(used)+len(undeclared))
+	for _, k := range SortedMapKeys(used) {
+		parts = append(parts, param{
+			name: k,
+			typ:  serverURLVariableTypeName(s.GoName, k),
+		})
+	}
+	for _, k := range undeclared {
+		parts = append(parts, param{name: k, typ: "string"})
+	}
+	sort.Slice(parts, func(i, j int) bool { return parts[i].name < parts[j].name })
+
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = p.name + " " + p.typ
+	}
+	return strings.Join(out, ", ")
+}
+
+// EnumDefaultPointers returns one entry per enum-typed used variable
+// with a `default` set. The template iterates this directly rather
+// than recomputing identifier names from `$v.Default`.
+func (s ServerObjectDefinition) EnumDefaultPointers() []ServerURLDefaultPointer {
+	used := s.UsedVariables()
+	var out []ServerURLDefaultPointer
+	for _, varName := range SortedMapKeys(used) {
+		v := used[varName]
+		if v == nil || len(v.Enum) == 0 || v.Default == "" {
+			continue
+		}
+		keys := serverURLEnumKeys(v)
+		var targetKey string
+		for i, val := range v.Enum {
+			if val == v.Default {
+				targetKey = keys[i]
+				break
+			}
+		}
+		if targetKey == "" {
+			// `default` not in `enum`; BuildServerURLTypeDefinitions
+			// already errors on this at codegen time, so we'd never
+			// actually reach the template emission. Skip defensively.
+			continue
+		}
+		prefix := serverURLVariableTypeName(s.GoName, varName)
+		pointerName := prefix + "Default"
+		for _, k := range keys {
+			if k == "Default" {
+				pointerName = prefix + "DefaultValue"
+				break
+			}
+		}
+		out = append(out, ServerURLDefaultPointer{
+			VariableName: varName,
+			TypeName:     prefix,
+			PointerName:  pointerName,
+			TargetName:   prefix + targetKey,
+			Description:  v.Description,
+		})
+	}
+	return out
+}
+
 // BuildServerURLTypeDefinitions synthesizes a TypeDefinition for every
 // server-URL variable that defines an `enum`. These are appended into
 // the same TypeDefinition slices used by GenerateTypes (typedef.tmpl)
@@ -221,7 +378,7 @@ func BuildServerURLTypeDefinitions(spec *openapi3.T) ([]TypeDefinition, error) {
 				}
 			}
 			typeName := serverURLVariableTypeName(srv.GoName, varName)
-			enumValues := SanitizeEnumNames(nil, v.Enum)
+			enumValues := serverURLEnumValues(v)
 			defs = append(defs, TypeDefinition{
 				TypeName: typeName,
 				JsonName: varName,

--- a/pkg/codegen/server_urls_test.go
+++ b/pkg/codegen/server_urls_test.go
@@ -128,10 +128,10 @@ func TestBuildServerURLTypeDefinitions(t *testing.T) {
 	})
 
 	t.Run("an enum value 'default' does not collide with the default-pointer (#2003)", func(t *testing.T) {
-		// The fix routes enum values through GenerateEnums (ForceEnumPrefix=true)
-		// and renames the default-pointer constant emitted by server-urls.tmpl
-		// to ...VariableDefaultValue, so an enum literal "default" no longer
-		// produces a duplicate const declaration with the default pointer.
+		// Routing through GenerateEnums + emitting the default-pointer
+		// const with the asymmetric `…DefaultValue` rename means an
+		// enum literal "default" no longer produces a duplicate const
+		// declaration with the default pointer.
 		spec := &openapi3.T{
 			Servers: openapi3.Servers{
 				{
@@ -145,10 +145,90 @@ func TestBuildServerURLTypeDefinitions(t *testing.T) {
 		defs, err := BuildServerURLTypeDefinitions(spec)
 		require.NoError(t, err)
 		require.Len(t, defs, 1)
-		// Both enum values are present in the synthesized EnumValues
-		// without the "Default" identifier alone shadowing the
-		// default-pointer constant — that lives outside this map and
-		// is named ...VariableDefaultValue in the template.
 		assert.Len(t, defs[0].Schema.EnumValues, 2)
+	})
+}
+
+// TestEnumDefaultPointers verifies the asymmetric default-pointer
+// naming and the dedup-aware target reference — the two behaviours
+// raised in the PR #2358 review.
+func TestEnumDefaultPointers(t *testing.T) {
+	t.Run("happy-path enum keeps the historical `…Default` name", func(t *testing.T) {
+		// No enum value folds to the literal "Default", so there's no
+		// collision and the default-pointer keeps the pre-fix name.
+		// This is the asymmetric-rename criterion: only specs that
+		// would have collided under the old codegen see the rename.
+		srv := ServerObjectDefinition{
+			GoName: "ServerUrlExample",
+			OAPISchema: &openapi3.Server{
+				URL: "https://api.example.com:{port}",
+				Variables: map[string]*openapi3.ServerVariable{
+					"port": {Default: "8443", Enum: []string{"443", "8443"}},
+				},
+			},
+		}
+		ptrs := srv.EnumDefaultPointers()
+		require.Len(t, ptrs, 1)
+		assert.Equal(t, "ServerUrlExamplePortVariableDefault", ptrs[0].PointerName)
+		assert.Equal(t, "ServerUrlExamplePortVariable8443", ptrs[0].TargetName)
+	})
+
+	t.Run("colliding enum value triggers `…DefaultValue` rename (#2003)", func(t *testing.T) {
+		srv := ServerObjectDefinition{
+			GoName: "ServerUrlExample",
+			OAPISchema: &openapi3.Server{
+				URL: "https://api.example.com/{port}",
+				Variables: map[string]*openapi3.ServerVariable{
+					"port": {Default: "default", Enum: []string{"default", "443"}},
+				},
+			},
+		}
+		ptrs := srv.EnumDefaultPointers()
+		require.Len(t, ptrs, 1)
+		assert.Equal(t, "ServerUrlExamplePortVariableDefaultValue", ptrs[0].PointerName)
+		assert.Equal(t, "ServerUrlExamplePortVariableDefault", ptrs[0].TargetName,
+			"the target const for value \"default\" is …VariableDefault; the pointer is …VariableDefaultValue and references it")
+	})
+
+	t.Run("dedup-suffix value is referenced by the right name", func(t *testing.T) {
+		// `enum: [foo, Foo]` both `ucFirst`-fold to `Foo`; the second
+		// becomes `Foo1`. With `default: "Foo"` the pointer must
+		// reference …VariableFoo1, not …VariableFoo (which holds "foo").
+		// Greptile flagged this in PR #2358 review.
+		srv := ServerObjectDefinition{
+			GoName: "ServerUrlExample",
+			OAPISchema: &openapi3.Server{
+				URL: "https://api.example.com/{mode}",
+				Variables: map[string]*openapi3.ServerVariable{
+					"mode": {Default: "Foo", Enum: []string{"foo", "Foo"}},
+				},
+			},
+		}
+		ptrs := srv.EnumDefaultPointers()
+		require.Len(t, ptrs, 1)
+		assert.Equal(t, "ServerUrlExampleModeVariableDefault", ptrs[0].PointerName,
+			"no enum value folds to `Default`, so no rename")
+		assert.Equal(t, "ServerUrlExampleModeVariableFoo1", ptrs[0].TargetName,
+			"target must be the post-suffix const for `Foo`, not the unsuffixed `Foo` which holds `foo`")
+	})
+
+	t.Run("digit-leading enum values do not pick up an `N` prefix", func(t *testing.T) {
+		// The previous PR-2358 implementation routed values through
+		// SchemaNameToTypeName, which prefixed digit-leading values
+		// with `N`. The current synthesis uses UppercaseFirstCharacter
+		// directly, so `8443` stays `8443` — preserving the
+		// pre-fix-PR identifier shape for happy-path adopters.
+		srv := ServerObjectDefinition{
+			GoName: "ServerUrlExample",
+			OAPISchema: &openapi3.Server{
+				URL: "https://api.example.com:{port}",
+				Variables: map[string]*openapi3.ServerVariable{
+					"port": {Default: "443", Enum: []string{"443", "8443"}},
+				},
+			},
+		}
+		ptrs := srv.EnumDefaultPointers()
+		require.Len(t, ptrs, 1)
+		assert.Equal(t, "ServerUrlExamplePortVariable443", ptrs[0].TargetName)
 	})
 }

--- a/pkg/codegen/server_urls_test.go
+++ b/pkg/codegen/server_urls_test.go
@@ -1,0 +1,154 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestURLPlaceholders(t *testing.T) {
+	t.Run("returns nil for a URL with no placeholders", func(t *testing.T) {
+		assert.Nil(t, urlPlaceholders("https://api.example.com/v1"))
+	})
+
+	t.Run("extracts a single placeholder", func(t *testing.T) {
+		got := urlPlaceholders("https://{host}.example.com/v1")
+		assert.Len(t, got, 1)
+		assert.Contains(t, got, "host")
+	})
+
+	t.Run("extracts multiple placeholders and dedupes repeats", func(t *testing.T) {
+		got := urlPlaceholders("https://{host}.example.com:{port}/{base}/{host}")
+		assert.Len(t, got, 3)
+		assert.Contains(t, got, "host")
+		assert.Contains(t, got, "port")
+		assert.Contains(t, got, "base")
+	})
+
+	t.Run("does not span across `/`", func(t *testing.T) {
+		// "{a/b}" must not be treated as a single placeholder named "a/b".
+		assert.Nil(t, urlPlaceholders("https://{a/b}.example.com"))
+	})
+}
+
+func TestUsedAndUndeclaredVariables(t *testing.T) {
+	srv := ServerObjectDefinition{
+		GoName: "ServerUrlExample",
+		OAPISchema: &openapi3.Server{
+			URL: "https://{host}.example.com:{port}/{path}",
+			Variables: map[string]*openapi3.ServerVariable{
+				"host":   {Default: "demo"},
+				"port":   {Default: "443", Enum: []string{"443", "8443"}},
+				"unused": {Default: "x"}, // declared, but not referenced in URL
+				// "path" is referenced in URL but not declared
+			},
+		},
+	}
+
+	used := srv.UsedVariables()
+	assert.Len(t, used, 2)
+	assert.Contains(t, used, "host")
+	assert.Contains(t, used, "port")
+	assert.NotContains(t, used, "unused", "declared-but-unused must be filtered (#2004)")
+
+	undeclared := srv.UndeclaredPlaceholders()
+	assert.Equal(t, []string{"path"}, undeclared, "URL placeholder not in variables must be reported (#2005)")
+}
+
+func TestBuildServerURLTypeDefinitions(t *testing.T) {
+	t.Run("synthesises one TypeDefinition per enum-typed used variable", func(t *testing.T) {
+		spec := &openapi3.T{
+			Servers: openapi3.Servers{
+				{
+					URL: "https://api.example.com:{port}",
+					Variables: map[string]*openapi3.ServerVariable{
+						"port": {Default: "443", Enum: []string{"443", "8443"}},
+					},
+				},
+			},
+		}
+		defs, err := BuildServerURLTypeDefinitions(spec)
+		require.NoError(t, err)
+		require.Len(t, defs, 1)
+		assert.True(t, defs[0].ForceEnumPrefix, "server-URL enum types must keep prefixed identifiers")
+		assert.Equal(t, "string", defs[0].Schema.GoType)
+		assert.Len(t, defs[0].Schema.EnumValues, 2)
+	})
+
+	t.Run("skips non-enum variables", func(t *testing.T) {
+		spec := &openapi3.T{
+			Servers: openapi3.Servers{
+				{
+					URL: "https://{host}.example.com",
+					Variables: map[string]*openapi3.ServerVariable{
+						"host": {Default: "demo"}, // no enum
+					},
+				},
+			},
+		}
+		defs, err := BuildServerURLTypeDefinitions(spec)
+		require.NoError(t, err)
+		assert.Empty(t, defs)
+	})
+
+	t.Run("skips declared-but-unused variables (#2004)", func(t *testing.T) {
+		spec := &openapi3.T{
+			Servers: openapi3.Servers{
+				{
+					URL: "https://api.example.com",
+					Variables: map[string]*openapi3.ServerVariable{
+						"unused": {Default: "443", Enum: []string{"443", "8443"}},
+					},
+				},
+			},
+		}
+		defs, err := BuildServerURLTypeDefinitions(spec)
+		require.NoError(t, err)
+		assert.Empty(t, defs)
+	})
+
+	t.Run("errors when default is not in enum (#2007)", func(t *testing.T) {
+		spec := &openapi3.T{
+			Servers: openapi3.Servers{
+				{
+					URL:         "https://api.example.com:{port}",
+					Description: "Production API server",
+					Variables: map[string]*openapi3.ServerVariable{
+						"port": {Default: "12345", Enum: []string{"443", "8443"}},
+					},
+				},
+			},
+		}
+		_, err := BuildServerURLTypeDefinitions(spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "port")
+		assert.Contains(t, err.Error(), "12345")
+	})
+
+	t.Run("an enum value 'default' does not collide with the default-pointer (#2003)", func(t *testing.T) {
+		// The fix routes enum values through GenerateEnums (ForceEnumPrefix=true)
+		// and renames the default-pointer constant emitted by server-urls.tmpl
+		// to ...VariableDefaultValue, so an enum literal "default" no longer
+		// produces a duplicate const declaration with the default pointer.
+		spec := &openapi3.T{
+			Servers: openapi3.Servers{
+				{
+					URL: "https://api.example.com:{port}",
+					Variables: map[string]*openapi3.ServerVariable{
+						"port": {Default: "default", Enum: []string{"default", "443"}},
+					},
+				},
+			},
+		}
+		defs, err := BuildServerURLTypeDefinitions(spec)
+		require.NoError(t, err)
+		require.Len(t, defs, 1)
+		// Both enum values are present in the synthesized EnumValues
+		// without the "Default" identifier alone shadowing the
+		// default-pointer constant — that lives outside this map and
+		// is named ...VariableDefaultValue in the template.
+		assert.Len(t, defs[0].Schema.EnumValues, 2)
+	})
+}

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -327,24 +328,56 @@ func stripNewLines(s string) string {
 	return r.Replace(s)
 }
 
-// genServerURLWithVariablesFunctionParams is a template helper method to generate the function parameters for the generated function for a Server object that contains `variables` (https://spec.openapis.org/oas/v3.0.3#server-object)
+// genServerURLWithVariablesFunctionParams is a template helper method
+// to generate the function parameters for the generated function for
+// a Server object that contains `variables`
+// (https://spec.openapis.org/oas/v3.0.3#server-object).
 //
-// goTypePrefix is the prefix being used to create underlying types in the template (likely the `ServerObjectDefinition.GoName`)
-// variables are this `ServerObjectDefinition`'s variables for the Server object (likely the `ServerObjectDefinition.OAPISchema`)
-func genServerURLWithVariablesFunctionParams(goTypePrefix string, variables map[string]*openapi3.ServerVariable) string {
-	keys := SortedMapKeys(variables)
-
-	if len(variables) == 0 {
+// goTypePrefix is the prefix being used to create underlying types in
+// the template (likely the `ServerObjectDefinition.GoName`).
+//
+// variables are the declared-and-used variables (typed parameters,
+// each backed by a generated `<prefix><Var>Variable` type).
+//
+// undeclaredPlaceholders are URL `{name}` placeholders that have no
+// corresponding entry in the Server object's `variables` map; they
+// are emitted as plain `string` parameters so the caller can supply
+// values for them. Without this the URL substitution would leave
+// `{name}` in the result, tripping the trailing `{`/`}` runtime check
+// on every call (https://github.com/oapi-codegen/oapi-codegen/issues/2005).
+//
+// The two groups are ordered together alphabetically for stable
+// output regardless of how each set is enumerated.
+func genServerURLWithVariablesFunctionParams(goTypePrefix string, variables map[string]*openapi3.ServerVariable, undeclaredPlaceholders []string) string {
+	if len(variables) == 0 && len(undeclaredPlaceholders) == 0 {
 		return ""
 	}
-	parts := make([]string, len(variables))
 
-	for i := range keys {
-		k := keys[i]
-		variableDefinitionPrefix := goTypePrefix + UppercaseFirstCharacter(k) + "Variable"
-		parts[i] = k + " " + variableDefinitionPrefix
+	type param struct {
+		name string
+		typ  string
 	}
-	return strings.Join(parts, ", ")
+	parts := make([]param, 0, len(variables)+len(undeclaredPlaceholders))
+	for _, k := range SortedMapKeys(variables) {
+		parts = append(parts, param{
+			name: k,
+			typ:  goTypePrefix + UppercaseFirstCharacter(k) + "Variable",
+		})
+	}
+	for _, k := range undeclaredPlaceholders {
+		parts = append(parts, param{name: k, typ: "string"})
+	}
+
+	// Stable, alphabetical ordering across both groups so the
+	// generated function signature is deterministic and reads in a
+	// predictable order regardless of declared/undeclared status.
+	sort.Slice(parts, func(i, j int) bool { return parts[i].name < parts[j].name })
+
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = p.name + " " + p.typ
+	}
+	return strings.Join(out, ", ")
 }
 
 // httpMethodConstant converts an HTTP method string (e.g. "GET") to the

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"sort"
 	"strings"
 	"text/template"
 
@@ -328,56 +327,31 @@ func stripNewLines(s string) string {
 	return r.Replace(s)
 }
 
-// genServerURLWithVariablesFunctionParams is a template helper method
-// to generate the function parameters for the generated function for
-// a Server object that contains `variables`
-// (https://spec.openapis.org/oas/v3.0.3#server-object).
+// genServerURLWithVariablesFunctionParams is a template helper method to generate the function parameters for the generated function for a Server object that contains `variables` (https://spec.openapis.org/oas/v3.0.3#server-object)
 //
-// goTypePrefix is the prefix being used to create underlying types in
-// the template (likely the `ServerObjectDefinition.GoName`).
+// goTypePrefix is the prefix being used to create underlying types in the template (likely the `ServerObjectDefinition.GoName`)
+// variables are this `ServerObjectDefinition`'s variables for the Server object (likely the `ServerObjectDefinition.OAPISchema`)
 //
-// variables are the declared-and-used variables (typed parameters,
-// each backed by a generated `<prefix><Var>Variable` type).
-//
-// undeclaredPlaceholders are URL `{name}` placeholders that have no
-// corresponding entry in the Server object's `variables` map; they
-// are emitted as plain `string` parameters so the caller can supply
-// values for them. Without this the URL substitution would leave
-// `{name}` in the result, tripping the trailing `{`/`}` runtime check
-// on every call (https://github.com/oapi-codegen/oapi-codegen/issues/2005).
-//
-// The two groups are ordered together alphabetically for stable
-// output regardless of how each set is enumerated.
-func genServerURLWithVariablesFunctionParams(goTypePrefix string, variables map[string]*openapi3.ServerVariable, undeclaredPlaceholders []string) string {
-	if len(variables) == 0 && len(undeclaredPlaceholders) == 0 {
+// Undeclared `{name}` placeholders that appear in the URL but have no
+// entry in `variables` are NOT handled here; they're emitted as plain
+// `string` parameters by `ServerObjectDefinition.NewFunctionParams`,
+// which the template calls instead of this helper. Custom
+// `server-urls.tmpl` overrides that still call this helper directly
+// keep their pre-existing two-argument signature.
+func genServerURLWithVariablesFunctionParams(goTypePrefix string, variables map[string]*openapi3.ServerVariable) string {
+	keys := SortedMapKeys(variables)
+
+	if len(variables) == 0 {
 		return ""
 	}
+	parts := make([]string, len(variables))
 
-	type param struct {
-		name string
-		typ  string
+	for i := range keys {
+		k := keys[i]
+		variableDefinitionPrefix := goTypePrefix + UppercaseFirstCharacter(k) + "Variable"
+		parts[i] = k + " " + variableDefinitionPrefix
 	}
-	parts := make([]param, 0, len(variables)+len(undeclaredPlaceholders))
-	for _, k := range SortedMapKeys(variables) {
-		parts = append(parts, param{
-			name: k,
-			typ:  goTypePrefix + UppercaseFirstCharacter(k) + "Variable",
-		})
-	}
-	for _, k := range undeclaredPlaceholders {
-		parts = append(parts, param{name: k, typ: "string"})
-	}
-
-	// Stable, alphabetical ordering across both groups so the
-	// generated function signature is deterministic and reads in a
-	// predictable order regardless of declared/undeclared status.
-	sort.Slice(parts, func(i, j int) bool { return parts[i].name < parts[j].name })
-
-	out := make([]string, len(parts))
-	for i, p := range parts {
-		out[i] = p.name + " " + p.typ
-	}
-	return strings.Join(out, ", ")
+	return strings.Join(parts, ", ")
 }
 
 // httpMethodConstant converts an HTTP method string (e.g. "GET") to the

--- a/pkg/codegen/templates/server-urls.tmpl
+++ b/pkg/codegen/templates/server-urls.tmpl
@@ -1,53 +1,68 @@
 {{ range . }}
-{{ if eq 0 (len .OAPISchema.Variables) }}
-{{/* URLs without variables are straightforward, so we'll create them a constant */}}
+{{ $usedVars := .UsedVariables }}
+{{ $undeclared := .UndeclaredPlaceholders }}
+{{ if and (eq 0 (len $usedVars)) (eq 0 (len $undeclared)) }}
+{{/* URLs without variables (declared or used) are straightforward, so we'll create them a constant */}}
 // {{ .GoName }} defines the Server URL for {{ if len .OAPISchema.Description }}{{ .OAPISchema.Description }}{{ else }}{{ .OAPISchema.URL }}{{ end }}
 const {{ .GoName}} = "{{ .OAPISchema.URL }}"
 {{ else }}
 {{/* URLs with variables are not straightforward, as we may need multiple types, and so will model them as a function */}}
 
-{{/* first, we'll start by generating requisite types */}}
-
 {{ $goName := .GoName }}
-{{ range $k, $v := .OAPISchema.Variables }}
+
+{{/*
+    For each USED variable, emit any inline declarations server-urls.tmpl
+    is still responsible for. Variables declared but not referenced by
+    a `{name}` placeholder in the URL are filtered out earlier
+    (https://github.com/oapi-codegen/oapi-codegen/issues/2004) so we
+    don't generate types/consts/params that the function would never
+    use.
+
+    * Variables with `enum` get their `type` declaration and `const`
+      block (and a `Valid()` method) from typedef.tmpl + constants.tmpl
+      via GenerateEnums; here we only emit the optional default-pointer
+      constant — and we name it `…VariableDefaultValue` so it can never
+      collide with an enum value whose Go identifier is `Default` (e.g.
+      OpenAPI `enum: [default]`).
+
+    * Variables without `enum` need their `type Foo string` and any
+      `const FooDefault = "…"` emitted here, since the generic enum
+      path has nothing to contribute for a non-enum string.
+*/}}
+{{ range $k, $v := $usedVars }}
    {{ $prefix := printf "%s%sVariable" $goName ($k | ucFirst) }}
+   {{ if eq (len $v.Enum) 0 }}
    // {{ $prefix }} is the `{{ $k }}` variable for {{ $goName }}
    type {{ $prefix }} string
-   {{ range $v.Enum }}
-       {{/* TODO this may result in broken generated code if any of the `enum` values are the literal value `default` https://github.com/oapi-codegen/oapi-codegen/issues/2003 */}}
-       // {{ $prefix }}{{ . | ucFirst }} is one of the accepted values for the `{{ $k }}` variable for {{ $goName }}
-       const {{ $prefix }}{{ . | ucFirst }} {{ $prefix }} = "{{ . }}"
-   {{ end }}
-
-   {{/* TODO we should introduce a `Valid() error` method to enums https://github.com/oapi-codegen/oapi-codegen/issues/2006 */}}
-
    {{ if $v.Default }}
-       {{ if gt (len $v.Enum) 0 }}
-           {{/* if we have an enum, we should use the type defined for it for its default value
-               and reference the constant we've already defined for the value */}}
-           {{/* TODO this may result in broken generated code if any of the `enum` values are the literal value `default` https://github.com/oapi-codegen/oapi-codegen/issues/2003 */}}
-           {{/* TODO this may result in broken generated code if the `default` isn't found in `enum` (which is an issue with the spec) https://github.com/oapi-codegen/oapi-codegen/issues/2007 */}}
-           // {{ $prefix }}Default is the default choice, for the accepted values for the `{{ $k }}` variable for {{ $goName }}
-           const {{ $prefix }}Default {{ $prefix }} = {{ $prefix }}{{ $v.Default | ucFirst }}
-       {{ else }}
-           // {{ $prefix }}Default is the default value for the `{{ $k }}` variable for {{ $goName }}
-           const {{ $prefix }}Default = "{{ $v.Default }}"
-       {{ end }}
+   // {{ $prefix }}Default is the default value for the `{{ $k }}` variable for {{ $goName }}
+   const {{ $prefix }}Default = "{{ $v.Default }}"
+   {{ end }}
+   {{ else if $v.Default }}
+   // {{ $prefix }}DefaultValue is the default choice, for the accepted values for the `{{ $k }}` variable for {{ $goName }}
+   const {{ $prefix }}DefaultValue {{ $prefix }} = {{ $prefix }}{{ $v.Default | schemaNameToTypeName | sanitizeGoIdentity }}
    {{ end }}
 {{ end }}
 
 
 // New{{ .GoName }} constructs the Server URL for {{ .OAPISchema.Description }}, with the provided variables.
-func New{{ .GoName }}({{ genServerURLWithVariablesFunctionParams .GoName .OAPISchema.Variables }}) (string, error) {
+func New{{ .GoName }}({{ genServerURLWithVariablesFunctionParams .GoName $usedVars $undeclared }}) (string, error) {
+    {{ range $k, $v := $usedVars }}
+        {{- if gt (len $v.Enum) 0 -}}
+    if !{{ $k }}.Valid() {
+        return "", fmt.Errorf("`%v` is not one of the accepted values for the `{{ $k }}` variable", {{ $k }})
+    }
+        {{ end -}}
+    {{ end }}
     u := "{{ .OAPISchema.URL }}"
 
-    {{ range $k, $v := .OAPISchema.Variables }}
+    {{ range $k, $v := $usedVars }}
         {{- $placeholder := printf "{%s}" $k -}}
-        {{- if gt (len $v.Enum) 0 -}}
-        {{/* TODO https://github.com/oapi-codegen/oapi-codegen/issues/2006 */}}
-        // TODO in the future, this will validate that the value is part of the {{ printf "%s%sVariable" $goName ($k | ucFirst) }} enum
-        {{ end -}}
         u = strings.ReplaceAll(u, "{{ $placeholder }}", string({{ $k }}))
+    {{ end }}
+    {{ range $k := $undeclared }}
+        {{- $placeholder := printf "{%s}" $k -}}
+        u = strings.ReplaceAll(u, "{{ $placeholder }}", {{ $k }})
     {{ end }}
 
     if strings.Contains(u, "{") || strings.Contains(u, "}") {

--- a/pkg/codegen/templates/server-urls.tmpl
+++ b/pkg/codegen/templates/server-urls.tmpl
@@ -38,15 +38,25 @@ const {{ .GoName}} = "{{ .OAPISchema.URL }}"
    // {{ $prefix }}Default is the default value for the `{{ $k }}` variable for {{ $goName }}
    const {{ $prefix }}Default = "{{ $v.Default }}"
    {{ end }}
-   {{ else if $v.Default }}
-   // {{ $prefix }}DefaultValue is the default choice, for the accepted values for the `{{ $k }}` variable for {{ $goName }}
-   const {{ $prefix }}DefaultValue {{ $prefix }} = {{ $prefix }}{{ $v.Default | schemaNameToTypeName | sanitizeGoIdentity }}
    {{ end }}
+{{ end }}
+
+{{/*
+    Enum-typed default-pointer constants. Their identifier names are
+    pre-computed in Go (ServerObjectDefinition.EnumDefaultPointers) so
+    that the pointer's reference to the enum-value constant always
+    matches the post-dedup name actually emitted by constants.tmpl,
+    and the pointer itself is renamed `…DefaultValue` only for specs
+    that would have collided under the old codegen anyway.
+*/}}
+{{ range .EnumDefaultPointers }}
+   // {{ .PointerName }} is the default choice, for the accepted values for the `{{ .VariableName }}` variable
+   const {{ .PointerName }} {{ .TypeName }} = {{ .TargetName }}
 {{ end }}
 
 
 // New{{ .GoName }} constructs the Server URL for {{ .OAPISchema.Description }}, with the provided variables.
-func New{{ .GoName }}({{ genServerURLWithVariablesFunctionParams .GoName $usedVars $undeclared }}) (string, error) {
+func New{{ .GoName }}({{ .NewServerFunctionParams }}) (string, error) {
     {{ range $k, $v := $usedVars }}
         {{- if gt (len $v.Enum) 0 -}}
     if !{{ $k }}.Valid() {


### PR DESCRIPTION
The server-URL codegen feature (`generate.server-urls: true`) re-implemented its own enum emission inside server-urls.tmpl rather than going through the generic GenerateEnums / GenerateTypes pipeline used by every other enum-bearing schema in the codebase. That self-contained path quietly accumulated five distinct bugs:

  * Two `const ...VariableDefault` declarations whenever an enum value's `ucFirst` form was the literal string `Default` (e.g. `enum: [default]`), producing uncompilable Go (#2003).
  * No `Valid()` method on enum-typed variables, with a literal "TODO ... will validate that the value is part of the ... enum" comment emitted in the generated function body (#2006).
  * Variables declared in `variables:` but absent from the URL still produced a type, constant, function parameter, and a no-op `strings.ReplaceAll` call (#2004).
  * `{name}` placeholders in the URL with no entry in `variables:` were left in the URL after substitution and tripped the trailing `{`/`}` runtime check on every call, making the generated function permanently unusable (#2005).
  * When `default` was set to a value not in `enum` (which OpenAPI 3 declares invalid), the template emitted `const FooDefault Foo = FooDevelopment` where `FooDevelopment` was never declared, surfacing the spec error as a confusing Go compile failure (#2007).

All five share one root cause: server-URL variables didn't reach the type and enum codegen passes that already exist for every other schema.

Changes:

- Add `ForceEnumPrefix` to TypeDefinition. GenerateEnums OR's it into PrefixTypeName so synthesized server-URL enum types keep the existing always-prefixed identifier shape (`<Prefix><Value>` rather than the bare `<Value>` the generic path would otherwise emit when no conflict is detected).

- Add BuildServerURLTypeDefinitions in pkg/codegen/server_urls.go. It extracts enum-typed used variables from spec.Servers, synthesizes a TypeDefinition per variable, and validates `default ∈ enum` at codegen time so #2007 spec violations are caught with a clear error rather than emitted as broken Go.

- Wire BuildServerURLTypeDefinitions into the `generate.server-urls` gate so the synthesized types flow through GenerateTypes (typedef.tmpl) and GenerateEnums (constants.tmpl) regardless of `generate.models`. This gives server-URL enum variables the same `type X string`, `const ( ... )` block, and `Valid()` method as any other enum-bearing schema.

- Drop type/const emission for enum-typed variables from server-urls.tmpl; it now emits only the per-server function (which calls `.Valid()` on each enum-typed parameter) and any non-enum variable scaffolding.

- Add ServerObjectDefinition.UsedVariables and UndeclaredPlaceholders helpers + extract serverObjectDefinitions, the name-deconfliction pass shared by both GenerateServerURLs and BuildServerURLTypeDefinitions, so the type pipeline and the function-body pipeline see the same identifiers.

- Extend genServerURLWithVariablesFunctionParams to take undeclared placeholders, emitting them as plain `string` parameters alongside the declared variables (sorted together for stable output).

User-visible naming change: for enum-typed server-URL variables only, the default-pointer constant is renamed from `<Prefix>Default` to `<Prefix>DefaultValue`. This is what makes the #2003 collision impossible permanently — the enum-value namespace and the default-pointer namespace are distinct regardless of what string values appear in the spec. Non-enum variables keep their existing `<Prefix>Default` naming. Enum-value identifiers also pick up an `N` prefix for digit-leading values (e.g. an enum value `8443` becomes `<Prefix>N8443`) since they now flow through SchemaNameToTypeName, matching how every other enum in the codegen names digit-leading values.

The example fixture at examples/generate/serverurls/api.yaml gains two new servers: one with `enum: [default, 443]` to lock in the #2003 fix end-to-end, and one with an undeclared `{tenant}` placeholder for #2005. The existing `noDefault: {}` declared-but-unused variable now demonstrates the #2004 filtering. Three previously-identical localhost URLs are given unique ports (80/81/82) to comply with OpenAPI's URL-uniqueness requirement.

Closes #2003
Closes #2004
Closes #2005
Closes #2006
Closes #2007

Supersedes #2045