### PR TITLE
Update Greptile directives

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -59,7 +59,12 @@ When a PR modifies a template, ask:
 
 Be pragmatic: do not demand identical changes in seven places. Do your best to assess whether a change is conceptually backend-agnostic (most template changes are) or genuinely backend-specific (some are), and flag missing parity only when the change looks generally applicable.
 
-## 5. General
+## 5. Dependencies
+
+- Watch out for users making `go.mod` changes which advance the Go version to a new minor release. We want these to be explicitly justified in the commit message. Maintenance version bumps are ok. Mention that the maintainers would prefer to do a minor version bump themselves.
+- Watch out for unnecessary dependency changes that creep into code reviews, just because people tend to do it out of habit. Every dependency update should have a reason if it's bundled with codegen changes.
+
+## 6. General
 
 - The repo is a multi-module monorepo. Cross-module changes (e.g., to `runtime/` consumers) deserve extra scrutiny.
 - `internal/test/` contains regression tests keyed to GitHub issues. New bug fixes should generally include a regression test there.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,11 @@ These are also run in GitHub Actions, across a number of Go releases.
 
 It's recommended to raise a draft PR first, so you can get feedback on the PR from GitHub, and review your own changes, before getting the attention of a maintainer.
 
+Once your draft PR passes basic CI, remove the draft status, and at that point, the [Greptile](https://www.greptile.com/) code review system, in addition to the maintainers, will go over your code.
+It doesn't re-review updates, to save on costs, so if you would like a second review, tag `@greptileai` in one of your responses to the comments, and ask it
+to redo the review, or push back if you think it's wrong. We've got it set very conservatively, but we've configured it with guidance on what to
+watch for in PR's, since over the years, we've learned the pain points.
+
 ### "Should I @-mention the maintainers on an issue"
 
 Please try to avoid pinging the maintainers in an issue, Pull Request, or discussion.


### PR DESCRIPTION
Tell Greptile to watch out for unintended dependency changes, and explain in CONTRIBUTING.md about using Greptile.