### PR TITLE
echo: don't echo Go error messages into HTTP responses

### DIFF
--- a/examples/petstore-expanded/echo-v5/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/echo-v5/api/petstore-server.gen.go
@@ -50,14 +50,14 @@ func (w *ServerInterfaceWrapper) FindPets(ctx *echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "tags", ctx.QueryParams(), &params.Tags, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter tags: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter tags: '%s'", ctx.QueryParams().Get("tags"))).Wrap(err)
 	}
 
 	// ------------- Optional query parameter "limit" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", ctx.QueryParams(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: '%s'", ctx.QueryParams().Get("limit"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -82,7 +82,7 @@ func (w *ServerInterfaceWrapper) DeletePet(ctx *echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -98,7 +98,7 @@ func (w *ServerInterfaceWrapper) FindPetByID(ctx *echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/examples/petstore-expanded/echo/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-server.gen.go
@@ -50,14 +50,14 @@ func (w *ServerInterfaceWrapper) FindPets(ctx echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "tags", ctx.QueryParams(), &params.Tags, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter tags: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter tags: '%s'", ctx.QueryParams().Get("tags"))).SetInternal(err)
 	}
 
 	// ------------- Optional query parameter "limit" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", ctx.QueryParams(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: '%s'", ctx.QueryParams().Get("limit"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -82,7 +82,7 @@ func (w *ServerInterfaceWrapper) DeletePet(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -98,7 +98,7 @@ func (w *ServerInterfaceWrapper) FindPetByID(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/internal/test/issues/issue-1180/issue.gen.go
+++ b/internal/test/issues/issue-1180/issue.gen.go
@@ -264,7 +264,7 @@ func (w *ServerInterfaceWrapper) GetSimplePrimitive(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -458,7 +458,7 @@ func (w *ServerInterfaceWrapper) GetPet(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "petId", ctx.Param("petId"), &petId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter petId: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter petId: '%s'", ctx.Param("petId"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -314,7 +314,7 @@ func (w *ServerInterfaceWrapper) GetFoo(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "Foo", valueList[0], &Foo, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter Foo: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter Foo: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.Foo = &Foo
@@ -329,7 +329,7 @@ func (w *ServerInterfaceWrapper) GetFoo(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "Bar", valueList[0], &Bar, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter Bar: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter Bar: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.Bar = &Bar

--- a/internal/test/parameters/echo/gen/server.gen.go
+++ b/internal/test/parameters/echo/gen/server.gen.go
@@ -137,7 +137,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		var value int32
 		err = runtime.BindStyledParameterWithOptions("simple", "p", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: false, Required: false, Type: "integer", Format: "int32"})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter p: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter p: '%s'", cookie.Value)).SetInternal(err)
 		}
 		params.P = &value
 
@@ -148,7 +148,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		var value int32
 		err = runtime.BindStyledParameterWithOptions("simple", "ep", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false, Type: "integer", Format: "int32"})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ep: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ep: '%s'", cookie.Value)).SetInternal(err)
 		}
 		params.Ep = &value
 
@@ -159,7 +159,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		var value []int32
 		err = runtime.BindStyledParameterWithOptions("simple", "ea", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false, Type: "array", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: '%s'", cookie.Value)).SetInternal(err)
 		}
 		params.Ea = &value
 
@@ -170,7 +170,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		var value []int32
 		err = runtime.BindStyledParameterWithOptions("simple", "a", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: false, Required: false, Type: "array", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: '%s'", cookie.Value)).SetInternal(err)
 		}
 		params.A = &value
 
@@ -181,7 +181,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		var value Object
 		err = runtime.BindStyledParameterWithOptions("simple", "eo", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false, Type: "", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter eo: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter eo: '%s'", cookie.Value)).SetInternal(err)
 		}
 		params.Eo = &value
 
@@ -192,7 +192,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		var value Object
 		err = runtime.BindStyledParameterWithOptions("simple", "o", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: false, Required: false, Type: "", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter o: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter o: '%s'", cookie.Value)).SetInternal(err)
 		}
 		params.O = &value
 
@@ -219,7 +219,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		var value string
 		err = runtime.BindStyledParameterWithOptions("simple", "1s", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false, Type: "string", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: '%s'", cookie.Value)).SetInternal(err)
 		}
 		params.N1s = &value
 
@@ -240,7 +240,7 @@ func (w *ServerInterfaceWrapper) EnumParams(ctx echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "enumPathParam", ctx.QueryParams(), &params.EnumPathParam, runtime.BindQueryParameterOptions{Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter enumPathParam: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter enumPathParam: '%s'", ctx.QueryParams().Get("enumPathParam"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -266,7 +266,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Primitive", valueList[0], &XPrimitive, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "integer", Format: "int32"})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Primitive: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Primitive: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.XPrimitive = &XPrimitive
@@ -281,7 +281,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Primitive-Exploded", valueList[0], &XPrimitiveExploded, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: true, Required: false, Type: "integer", Format: "int32"})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Primitive-Exploded: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Primitive-Exploded: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.XPrimitiveExploded = &XPrimitiveExploded
@@ -296,7 +296,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Array-Exploded", valueList[0], &XArrayExploded, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: true, Required: false, Type: "array", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array-Exploded: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array-Exploded: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.XArrayExploded = &XArrayExploded
@@ -311,7 +311,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Array", valueList[0], &XArray, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "array", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.XArray = &XArray
@@ -326,7 +326,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Object-Exploded", valueList[0], &XObjectExploded, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: true, Required: false, Type: "", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Object-Exploded: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Object-Exploded: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.XObjectExploded = &XObjectExploded
@@ -341,7 +341,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Object", valueList[0], &XObject, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Object: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Object: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.XObject = &XObject
@@ -371,7 +371,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "1-Starting-With-Number", valueList[0], &N1StartingWithNumber, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1-Starting-With-Number: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1-Starting-With-Number: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.N1StartingWithNumber = &N1StartingWithNumber
@@ -390,7 +390,7 @@ func (w *ServerInterfaceWrapper) GetLabelExplodeArray(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -406,7 +406,7 @@ func (w *ServerInterfaceWrapper) GetLabelExplodeObject(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -422,7 +422,7 @@ func (w *ServerInterfaceWrapper) GetLabelExplodePrimitive(ctx echo.Context) erro
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -438,7 +438,7 @@ func (w *ServerInterfaceWrapper) GetLabelNoExplodeArray(ctx echo.Context) error 
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -454,7 +454,7 @@ func (w *ServerInterfaceWrapper) GetLabelNoExplodeObject(ctx echo.Context) error
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -470,7 +470,7 @@ func (w *ServerInterfaceWrapper) GetLabelPrimitive(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -486,7 +486,7 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodeArray(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -502,7 +502,7 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodeObject(ctx echo.Context) error 
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -518,7 +518,7 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodePrimitive(ctx echo.Context) err
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -534,7 +534,7 @@ func (w *ServerInterfaceWrapper) GetMatrixNoExplodeArray(ctx echo.Context) error
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -550,7 +550,7 @@ func (w *ServerInterfaceWrapper) GetMatrixNoExplodeObject(ctx echo.Context) erro
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -566,7 +566,7 @@ func (w *ServerInterfaceWrapper) GetMatrixPrimitive(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -597,7 +597,7 @@ func (w *ServerInterfaceWrapper) GetDeepObject(ctx echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("deepObject", true, true, "deepObj", ctx.QueryParams(), &params.DeepObj, runtime.BindQueryParameterOptions{Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter deepObj: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter deepObj: '%s'", ctx.QueryParams().Get("deepObj"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -615,14 +615,14 @@ func (w *ServerInterfaceWrapper) GetQueryDelimited(ctx echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("spaceDelimited", false, false, "sa", ctx.QueryParams(), &params.Sa, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter sa: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter sa: '%s'", ctx.QueryParams().Get("sa"))).SetInternal(err)
 	}
 
 	// ------------- Optional query parameter "pa" -------------
 
 	err = runtime.BindQueryParameterWithOptions("pipeDelimited", false, false, "pa", ctx.QueryParams(), &params.Pa, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter pa: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter pa: '%s'", ctx.QueryParams().Get("pa"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -640,49 +640,49 @@ func (w *ServerInterfaceWrapper) GetQueryForm(ctx echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "ea", ctx.QueryParams(), &params.Ea, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: '%s'", ctx.QueryParams().Get("ea"))).SetInternal(err)
 	}
 
 	// ------------- Optional query parameter "a" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", false, false, "a", ctx.QueryParams(), &params.A, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: '%s'", ctx.QueryParams().Get("a"))).SetInternal(err)
 	}
 
 	// ------------- Optional query parameter "eo" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "eo", ctx.QueryParams(), &params.Eo, runtime.BindQueryParameterOptions{Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter eo: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter eo: '%s'", ctx.QueryParams().Get("eo"))).SetInternal(err)
 	}
 
 	// ------------- Optional query parameter "o" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", false, false, "o", ctx.QueryParams(), &params.O, runtime.BindQueryParameterOptions{Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter o: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter o: '%s'", ctx.QueryParams().Get("o"))).SetInternal(err)
 	}
 
 	// ------------- Optional query parameter "ep" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "ep", ctx.QueryParams(), &params.Ep, runtime.BindQueryParameterOptions{Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ep: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ep: '%s'", ctx.QueryParams().Get("ep"))).SetInternal(err)
 	}
 
 	// ------------- Optional query parameter "p" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", false, false, "p", ctx.QueryParams(), &params.P, runtime.BindQueryParameterOptions{Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter p: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter p: '%s'", ctx.QueryParams().Get("p"))).SetInternal(err)
 	}
 
 	// ------------- Optional query parameter "ps" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "ps", ctx.QueryParams(), &params.Ps, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ps: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ps: '%s'", ctx.QueryParams().Get("ps"))).SetInternal(err)
 	}
 
 	// ------------- Optional query parameter "co" -------------
@@ -702,7 +702,7 @@ func (w *ServerInterfaceWrapper) GetQueryForm(ctx echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "1s", ctx.QueryParams(), &params.N1s, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: '%s'", ctx.QueryParams().Get("1s"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -718,7 +718,7 @@ func (w *ServerInterfaceWrapper) GetSimpleExplodeArray(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -734,7 +734,7 @@ func (w *ServerInterfaceWrapper) GetSimpleExplodeObject(ctx echo.Context) error 
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -750,7 +750,7 @@ func (w *ServerInterfaceWrapper) GetSimpleExplodePrimitive(ctx echo.Context) err
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -766,7 +766,7 @@ func (w *ServerInterfaceWrapper) GetSimpleNoExplodeArray(ctx echo.Context) error
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -782,7 +782,7 @@ func (w *ServerInterfaceWrapper) GetSimpleNoExplodeObject(ctx echo.Context) erro
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -798,7 +798,7 @@ func (w *ServerInterfaceWrapper) GetSimplePrimitive(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/internal/test/parameters/echov5/server.gen.go
+++ b/internal/test/parameters/echov5/server.gen.go
@@ -137,7 +137,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx *echo.Context) error {
 		var value int32
 		err = runtime.BindStyledParameterWithOptions("simple", "p", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: false, Required: false, Type: "integer", Format: "int32"})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter p: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter p: '%s'", cookie.Value)).Wrap(err)
 		}
 		params.P = &value
 
@@ -148,7 +148,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx *echo.Context) error {
 		var value int32
 		err = runtime.BindStyledParameterWithOptions("simple", "ep", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false, Type: "integer", Format: "int32"})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ep: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ep: '%s'", cookie.Value)).Wrap(err)
 		}
 		params.Ep = &value
 
@@ -159,7 +159,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx *echo.Context) error {
 		var value []int32
 		err = runtime.BindStyledParameterWithOptions("simple", "ea", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false, Type: "array", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: '%s'", cookie.Value)).Wrap(err)
 		}
 		params.Ea = &value
 
@@ -170,7 +170,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx *echo.Context) error {
 		var value []int32
 		err = runtime.BindStyledParameterWithOptions("simple", "a", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: false, Required: false, Type: "array", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: '%s'", cookie.Value)).Wrap(err)
 		}
 		params.A = &value
 
@@ -181,7 +181,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx *echo.Context) error {
 		var value Object
 		err = runtime.BindStyledParameterWithOptions("simple", "eo", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false, Type: "", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter eo: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter eo: '%s'", cookie.Value)).Wrap(err)
 		}
 		params.Eo = &value
 
@@ -192,7 +192,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx *echo.Context) error {
 		var value Object
 		err = runtime.BindStyledParameterWithOptions("simple", "o", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: false, Required: false, Type: "", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter o: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter o: '%s'", cookie.Value)).Wrap(err)
 		}
 		params.O = &value
 
@@ -219,7 +219,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx *echo.Context) error {
 		var value string
 		err = runtime.BindStyledParameterWithOptions("simple", "1s", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false, Type: "string", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: '%s'", cookie.Value)).Wrap(err)
 		}
 		params.N1s = &value
 
@@ -240,7 +240,7 @@ func (w *ServerInterfaceWrapper) EnumParams(ctx *echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "enumPathParam", ctx.QueryParams(), &params.EnumPathParam, runtime.BindQueryParameterOptions{Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter enumPathParam: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter enumPathParam: '%s'", ctx.QueryParams().Get("enumPathParam"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -266,7 +266,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx *echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Primitive", valueList[0], &XPrimitive, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "integer", Format: "int32"})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Primitive: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Primitive: '%s'", valueList[0])).Wrap(err)
 		}
 
 		params.XPrimitive = &XPrimitive
@@ -281,7 +281,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx *echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Primitive-Exploded", valueList[0], &XPrimitiveExploded, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: true, Required: false, Type: "integer", Format: "int32"})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Primitive-Exploded: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Primitive-Exploded: '%s'", valueList[0])).Wrap(err)
 		}
 
 		params.XPrimitiveExploded = &XPrimitiveExploded
@@ -296,7 +296,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx *echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Array-Exploded", valueList[0], &XArrayExploded, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: true, Required: false, Type: "array", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array-Exploded: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array-Exploded: '%s'", valueList[0])).Wrap(err)
 		}
 
 		params.XArrayExploded = &XArrayExploded
@@ -311,7 +311,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx *echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Array", valueList[0], &XArray, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "array", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array: '%s'", valueList[0])).Wrap(err)
 		}
 
 		params.XArray = &XArray
@@ -326,7 +326,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx *echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Object-Exploded", valueList[0], &XObjectExploded, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: true, Required: false, Type: "", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Object-Exploded: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Object-Exploded: '%s'", valueList[0])).Wrap(err)
 		}
 
 		params.XObjectExploded = &XObjectExploded
@@ -341,7 +341,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx *echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "X-Object", valueList[0], &XObject, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Object: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Object: '%s'", valueList[0])).Wrap(err)
 		}
 
 		params.XObject = &XObject
@@ -371,7 +371,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx *echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "1-Starting-With-Number", valueList[0], &N1StartingWithNumber, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1-Starting-With-Number: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1-Starting-With-Number: '%s'", valueList[0])).Wrap(err)
 		}
 
 		params.N1StartingWithNumber = &N1StartingWithNumber
@@ -390,7 +390,7 @@ func (w *ServerInterfaceWrapper) GetLabelExplodeArray(ctx *echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -406,7 +406,7 @@ func (w *ServerInterfaceWrapper) GetLabelExplodeObject(ctx *echo.Context) error 
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -422,7 +422,7 @@ func (w *ServerInterfaceWrapper) GetLabelExplodePrimitive(ctx *echo.Context) err
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -438,7 +438,7 @@ func (w *ServerInterfaceWrapper) GetLabelNoExplodeArray(ctx *echo.Context) error
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -454,7 +454,7 @@ func (w *ServerInterfaceWrapper) GetLabelNoExplodeObject(ctx *echo.Context) erro
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -470,7 +470,7 @@ func (w *ServerInterfaceWrapper) GetLabelPrimitive(ctx *echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -486,7 +486,7 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodeArray(ctx *echo.Context) error 
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -502,7 +502,7 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodeObject(ctx *echo.Context) error
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -518,7 +518,7 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodePrimitive(ctx *echo.Context) er
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -534,7 +534,7 @@ func (w *ServerInterfaceWrapper) GetMatrixNoExplodeArray(ctx *echo.Context) erro
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -550,7 +550,7 @@ func (w *ServerInterfaceWrapper) GetMatrixNoExplodeObject(ctx *echo.Context) err
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -566,7 +566,7 @@ func (w *ServerInterfaceWrapper) GetMatrixPrimitive(ctx *echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: '%s'", ctx.Param("id"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -597,7 +597,7 @@ func (w *ServerInterfaceWrapper) GetDeepObject(ctx *echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("deepObject", true, true, "deepObj", ctx.QueryParams(), &params.DeepObj, runtime.BindQueryParameterOptions{Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter deepObj: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter deepObj: '%s'", ctx.QueryParams().Get("deepObj"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -615,14 +615,14 @@ func (w *ServerInterfaceWrapper) GetQueryDelimited(ctx *echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("spaceDelimited", false, false, "sa", ctx.QueryParams(), &params.Sa, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter sa: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter sa: '%s'", ctx.QueryParams().Get("sa"))).Wrap(err)
 	}
 
 	// ------------- Optional query parameter "pa" -------------
 
 	err = runtime.BindQueryParameterWithOptions("pipeDelimited", false, false, "pa", ctx.QueryParams(), &params.Pa, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter pa: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter pa: '%s'", ctx.QueryParams().Get("pa"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -640,49 +640,49 @@ func (w *ServerInterfaceWrapper) GetQueryForm(ctx *echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "ea", ctx.QueryParams(), &params.Ea, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: '%s'", ctx.QueryParams().Get("ea"))).Wrap(err)
 	}
 
 	// ------------- Optional query parameter "a" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", false, false, "a", ctx.QueryParams(), &params.A, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: '%s'", ctx.QueryParams().Get("a"))).Wrap(err)
 	}
 
 	// ------------- Optional query parameter "eo" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "eo", ctx.QueryParams(), &params.Eo, runtime.BindQueryParameterOptions{Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter eo: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter eo: '%s'", ctx.QueryParams().Get("eo"))).Wrap(err)
 	}
 
 	// ------------- Optional query parameter "o" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", false, false, "o", ctx.QueryParams(), &params.O, runtime.BindQueryParameterOptions{Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter o: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter o: '%s'", ctx.QueryParams().Get("o"))).Wrap(err)
 	}
 
 	// ------------- Optional query parameter "ep" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "ep", ctx.QueryParams(), &params.Ep, runtime.BindQueryParameterOptions{Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ep: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ep: '%s'", ctx.QueryParams().Get("ep"))).Wrap(err)
 	}
 
 	// ------------- Optional query parameter "p" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", false, false, "p", ctx.QueryParams(), &params.P, runtime.BindQueryParameterOptions{Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter p: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter p: '%s'", ctx.QueryParams().Get("p"))).Wrap(err)
 	}
 
 	// ------------- Optional query parameter "ps" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "ps", ctx.QueryParams(), &params.Ps, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ps: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ps: '%s'", ctx.QueryParams().Get("ps"))).Wrap(err)
 	}
 
 	// ------------- Optional query parameter "co" -------------
@@ -702,7 +702,7 @@ func (w *ServerInterfaceWrapper) GetQueryForm(ctx *echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "1s", ctx.QueryParams(), &params.N1s, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: '%s'", ctx.QueryParams().Get("1s"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -718,7 +718,7 @@ func (w *ServerInterfaceWrapper) GetSimpleExplodeArray(ctx *echo.Context) error 
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -734,7 +734,7 @@ func (w *ServerInterfaceWrapper) GetSimpleExplodeObject(ctx *echo.Context) error
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -750,7 +750,7 @@ func (w *ServerInterfaceWrapper) GetSimpleExplodePrimitive(ctx *echo.Context) er
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -766,7 +766,7 @@ func (w *ServerInterfaceWrapper) GetSimpleNoExplodeArray(ctx *echo.Context) erro
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "array", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -782,7 +782,7 @@ func (w *ServerInterfaceWrapper) GetSimpleNoExplodeObject(ctx *echo.Context) err
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -798,7 +798,7 @@ func (w *ServerInterfaceWrapper) GetSimplePrimitive(ctx *echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int32"})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: '%s'", ctx.Param("param"))).Wrap(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -1554,7 +1554,7 @@ func (w *ServerInterfaceWrapper) Issue209(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "str", ctx.Param("str"), &str, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter str: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter str: '%s'", ctx.Param("str"))).SetInternal(err)
 	}
 
 	ctx.Set(string(Access_tokenScopes), []string{})
@@ -1572,7 +1572,7 @@ func (w *ServerInterfaceWrapper) Issue30(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "fallthrough", ctx.Param("fallthrough"), &pFallthrough, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter fallthrough: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter fallthrough: '%s'", ctx.Param("fallthrough"))).SetInternal(err)
 	}
 
 	ctx.Set(string(Access_tokenScopes), []string{})
@@ -1601,7 +1601,7 @@ func (w *ServerInterfaceWrapper) Issue41(ctx echo.Context) error {
 
 	err = runtime.BindStyledParameterWithOptions("simple", "1param", ctx.Param("1param"), &n1param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "object", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1param: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1param: '%s'", ctx.Param("1param"))).SetInternal(err)
 	}
 
 	ctx.Set(string(Access_tokenScopes), []string{})
@@ -1623,7 +1623,7 @@ func (w *ServerInterfaceWrapper) Issue9(ctx echo.Context) error {
 
 	err = runtime.BindQueryParameterWithOptions("form", true, true, "foo", ctx.QueryParams(), &params.Foo, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter foo: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter foo: '%s'", ctx.QueryParams().Get("foo"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -149,7 +149,7 @@ func (w *ServerInterfaceWrapper) ReservedGoKeywordParameters(ctx echo.Context) e
 
 	err = runtime.BindStyledParameterWithOptions("simple", "type", ctx.Param("type"), &pType, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter type: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter type: '%s'", ctx.Param("type"))).SetInternal(err)
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -220,7 +220,7 @@ func (w *ServerInterfaceWrapper) HeadersExample(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "header1", valueList[0], &Header1, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true, Type: "string", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter header1: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter header1: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.Header1 = Header1
@@ -237,7 +237,7 @@ func (w *ServerInterfaceWrapper) HeadersExample(ctx echo.Context) error {
 
 		err = runtime.BindStyledParameterWithOptions("simple", "header2", valueList[0], &Header2, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "integer", Format: ""})
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter header2: %s", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter header2: '%s'", valueList[0])).SetInternal(err)
 		}
 
 		params.Header2 = &Header2

--- a/pkg/codegen/templates/echo/echo-wrappers.tmpl
+++ b/pkg/codegen/templates/echo/echo-wrappers.tmpl
@@ -20,7 +20,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{if .IsStyled}}
     err = runtime.BindStyledParameterWithOptions("{{.Style}}", "{{.ParamName}}", ctx.Param("{{.ParamName}}"), &{{$varName}}, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: {{.Explode}}, Required: {{.Required}}, Type: "{{.SchemaType}}", Format: "{{.SchemaFormat}}"})
     if err != nil {
-        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
+        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: '%s'", ctx.Param("{{.ParamName}}"))).SetInternal(err)
     }
 {{end}}
 {{end}}
@@ -39,7 +39,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     {{if .IsStyled}}
     err = runtime.BindQueryParameterWithOptions("{{.Style}}", {{.Explode}}, {{.Required}}, "{{.ParamName}}", ctx.QueryParams(), &params.{{.GoName}}, runtime.BindQueryParameterOptions{Type: "{{.SchemaType}}", Format: "{{.SchemaFormat}}"})
     if err != nil {
-        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
+        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: '%s'", ctx.QueryParams().Get("{{.ParamName}}"))).SetInternal(err)
     }
     {{else}}
     if paramValue := ctx.QueryParam("{{.ParamName}}"); paramValue != "" {
@@ -81,7 +81,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{if .IsStyled}}
         err = runtime.BindStyledParameterWithOptions("{{.Style}}", "{{.ParamName}}", valueList[0], &{{.GoName}}, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: {{.Explode}}, Required: {{.Required}}, Type: "{{.SchemaType}}", Format: "{{.SchemaFormat}}"})
         if err != nil {
-            return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
+            return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: '%s'", valueList[0])).SetInternal(err)
         }
 {{end}}
         params.{{.GoName}} = {{if .HasOptionalPointer}}&{{end}}{{.GoName}}
@@ -113,7 +113,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     var value {{.TypeDef}}
     err = runtime.BindStyledParameterWithOptions("simple", "{{.ParamName}}", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: {{.Explode}}, Required: {{.Required}}, Type: "{{.SchemaType}}", Format: "{{.SchemaFormat}}"})
     if err != nil {
-        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
+        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: '%s'", cookie.Value)).SetInternal(err)
     }
     params.{{.GoName}} = {{if .HasOptionalPointer}}&{{end}}value
     {{end}}

--- a/pkg/codegen/templates/echo/v5/echo-wrappers.tmpl
+++ b/pkg/codegen/templates/echo/v5/echo-wrappers.tmpl
@@ -20,7 +20,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx *echo.Context) error {
 {{if .IsStyled}}
     err = runtime.BindStyledParameterWithOptions("{{.Style}}", "{{.ParamName}}", ctx.Param("{{.ParamName}}"), &{{$varName}}, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: {{.Explode}}, Required: {{.Required}}, Type: "{{.SchemaType}}", Format: "{{.SchemaFormat}}"})
     if err != nil {
-        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
+        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: '%s'", ctx.Param("{{.ParamName}}"))).Wrap(err)
     }
 {{end}}
 {{end}}
@@ -39,7 +39,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx *echo.Context) error {
     {{if .IsStyled}}
     err = runtime.BindQueryParameterWithOptions("{{.Style}}", {{.Explode}}, {{.Required}}, "{{.ParamName}}", ctx.QueryParams(), &params.{{.GoName}}, runtime.BindQueryParameterOptions{Type: "{{.SchemaType}}", Format: "{{.SchemaFormat}}"})
     if err != nil {
-        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
+        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: '%s'", ctx.QueryParams().Get("{{.ParamName}}"))).Wrap(err)
     }
     {{else}}
     if paramValue := ctx.QueryParam("{{.ParamName}}"); paramValue != "" {
@@ -81,7 +81,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx *echo.Context) error {
 {{if .IsStyled}}
         err = runtime.BindStyledParameterWithOptions("{{.Style}}", "{{.ParamName}}", valueList[0], &{{.GoName}}, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: {{.Explode}}, Required: {{.Required}}, Type: "{{.SchemaType}}", Format: "{{.SchemaFormat}}"})
         if err != nil {
-            return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
+            return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: '%s'", valueList[0])).Wrap(err)
         }
 {{end}}
         params.{{.GoName}} = {{if .HasOptionalPointer}}&{{end}}{{.GoName}}
@@ -113,7 +113,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx *echo.Context) error {
     var value {{.TypeDef}}
     err = runtime.BindStyledParameterWithOptions("simple", "{{.ParamName}}", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: {{.Explode}}, Required: {{.Required}}, Type: "{{.SchemaType}}", Format: "{{.SchemaFormat}}"})
     if err != nil {
-        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
+        return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: '%s'", cookie.Value)).Wrap(err)
     }
     params.{{.GoName}} = {{if .HasOptionalPointer}}&{{end}}value
     {{end}}


### PR DESCRIPTION
## What this is

A small change to the echo and echo-v5 server templates so that the error responses generated servers send back to clients don't include the underlying Go error text.

## What's changing today

When a request to a generated echo server has a parameter that doesn't parse (e.g. a path parameter expecting an int but the client sent `"foo"`), the response currently looks like this:

```
HTTP/1.1 400 Bad Request

Invalid format for parameter id: parsing "foo" as int: strconv.ParseInt: parsing "foo": invalid syntax
```

Everything after the colon is whatever `err.Error()` happened to return — it comes from `runtime.BindStyledParameterWithOptions` / `BindQueryParameterWithOptions` and the underlying `strconv` / `time` parser. That text isn't part of any contract — it's whatever Go's standard library or oapi-codegen-runtime felt like saying at the time. Sending it on the wire means:

- API consumers can come to depend on its exact wording (and it can change between Go releases).
- It can leak internal-looking detail (struct field names from the runtime, package-private wording, etc.).
- Operators of pentest-conscious deployments end up writing custom middleware to strip it.

## Why

Two reasons:

**Security / info disclosure.** Pentest reports routinely flag echoing raw `err.Error()` back to API callers as low-but-real info leakage. The current message can include Go stdlib parser internals (`strconv.ParseInt: …`), runtime/types implementation detail, or library-version-dependent wording. Each message in isolation looks innocuous, but the cumulative shape exposes how parameters get parsed server-side. Production-conscious teams currently have to fork or post-process this template to satisfy that finding — that's the whole reason we've maintained a local override for over a year.

**More useful for the actual caller.** When somebody sends `id=foo`, the helpful thing to tell them is "the value `'foo'` didn't fit parameter `id`". The current message tells them which Go function failed and how, which is information for whoever wrote the server, not whoever is calling it. Quoting the offending value puts the response back in the API consumer's frame.

The original error isn't lost — it stays attached to the HTTPError (via `SetInternal` in v4 / `Wrap` in v5), so server-side error handlers still log it.

## What it changes to

The same response becomes:

```
HTTP/1.1 400 Bad Request

Invalid format for parameter id: 'foo'
```

i.e. the value the caller actually sent. The original error is still attached to the echo HTTPError (via `SetInternal(err)` in v4 and `Wrap(err)` in v5), so server-side error handlers — including echo's default — still log the diagnostic. Just nothing leaks to the wire.

## Concretely, the diff

In `pkg/codegen/templates/echo/echo-wrappers.tmpl` and `pkg/codegen/templates/echo/v5/echo-wrappers.tmpl`, four spots (path / query / header / cookie parameter binds) change from:

```diff
-return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X: %s", err))
+return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X: '%s'", <user-value>)).SetInternal(err)
```

`<user-value>` is the right input source for that location:

| location | value |
|---|---|
| path | `ctx.Param("X")` |
| query | `ctx.QueryParams().Get("X")` |
| header | `valueList[0]` |
| cookie | `cookie.Value` |

For `pkg/codegen/templates/echo/v5/echo-wrappers.tmpl`, `.SetInternal(err)` becomes `.Wrap(err)` (v5's equivalent — `*echo.HTTPError` doesn't have `SetInternal`, but it does have a `Wrap(err)` method that attaches an inner error).

## What about the other framework templates?

Out of scope for this PR. The chi / gorilla / fiber / gin / iris / stdhttp templates have the same shape (`http.Error(w, err.Error(), …)`), and the same argument applies, but I want this PR to be small and easy to review. Happy to do those in follow-ups if this lands.

## Why this is safe

- The HTTP status code is unchanged.
- The HTTP body shape is the same string template — only the substituted token changes.
- Server-side error handlers receive the same error (now via `Internal` / wrapped) so logging is unaffected.
- Valid traffic is byte-identical on the wire.

## Tests

Regenerated all the affected test fixtures (`internal/test/parameters/echo`, `internal/test/parameters/echov5`, `internal/test/strict-server/echo`, the petstore-expanded examples). `go test ./...` is clean across the root, examples, and internal/test modules.

## Background

We've shipped this as a local template override for over a year and it's surfaced no issues — the change is small, the contract is preserved, and the request/response shape is unchanged for valid traffic. Upstreaming so we don't have to maintain the override.