### PR TITLE
feat: add json-encoding output option for controlling JSON encoder settings

### DIFF
--- a/configuration-schema.json
+++ b/configuration-schema.json
@@ -295,6 +295,28 @@
               "$ref": "#/$defs/format-mapping"
             }
           }
+        },
+        "json-encoding": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "JSONEncoding controls JSON encoding behavior (HTML escaping, indentation) for MarshalJSON methods and request body serialization in generated code.",
+          "properties": {
+            "escape-html": {
+              "type": "boolean",
+              "description": "Controls whether HTML special characters (<, >, &) are escaped to Unicode escape sequences in JSON output. When set to false, these characters are output as-is. Defaults to true, matching json.Marshal behavior.",
+              "default": true
+            },
+            "indent-prefix": {
+              "type": "string",
+              "description": "String prepended to each line per indentation level. Corresponds to the first argument of json.Encoder.SetIndent.",
+              "default": ""
+            },
+            "indent": {
+              "type": "string",
+              "description": "String appended per nesting level in JSON output. When non-empty, generated code uses an indented encoder instead of json.Marshal. Corresponds to the second argument of json.Encoder.SetIndent.",
+              "default": ""
+            }
+          }
         }
       }
     },

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -218,44 +218,10 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 	// This creates the golang templates text package
 	TemplateFunctions["opts"] = func() Configuration { return globalState.options }
 	TemplateFunctions["jsonNewEncoder"] = func(bufVarName string) string {
-		enc := globalState.options.OutputOptions.JSONEncoding
-		if !enc.NeedsCustomEncoding() {
-			return "json.NewEncoder(&" + bufVarName + ")"
-		}
-		var sb strings.Builder
-		sb.WriteString("func() *json.Encoder {\n")
-		sb.WriteString("__e := json.NewEncoder(&" + bufVarName + ")\n")
-		if !enc.EscapeHTMLValue() {
-			sb.WriteString("__e.SetEscapeHTML(false)\n")
-		}
-		if enc.Indent != "" || enc.IndentPrefix != "" {
-			fmt.Fprintf(&sb, "__e.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
-		}
-		sb.WriteString("return __e\n")
-		sb.WriteString("}()")
-		return sb.String()
+		return jsonNewEncoderExpr(globalState.options.OutputOptions.JSONEncoding, bufVarName)
 	}
 	TemplateFunctions["jsonMarshalExpr"] = func(varName string) string {
-		enc := globalState.options.OutputOptions.JSONEncoding
-		if !enc.NeedsCustomEncoding() {
-			return "json.Marshal(" + varName + ")"
-		}
-		var sb strings.Builder
-		sb.WriteString("func() ([]byte, error) {\n")
-		sb.WriteString("var __buf bytes.Buffer\n")
-		sb.WriteString("__enc := json.NewEncoder(&__buf)\n")
-		if !enc.EscapeHTMLValue() {
-			sb.WriteString("__enc.SetEscapeHTML(false)\n")
-		}
-		if enc.Indent != "" || enc.IndentPrefix != "" {
-			fmt.Fprintf(&sb, "__enc.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
-		}
-		sb.WriteString("if __err := __enc.Encode(" + varName + "); __err != nil {\n")
-		sb.WriteString("return nil, __err\n")
-		sb.WriteString("}\n")
-		sb.WriteString("return bytes.TrimRight(__buf.Bytes(), \"\\n\"), nil\n")
-		sb.WriteString("}()")
-		return sb.String()
+		return jsonMarshalExpr(globalState.options.OutputOptions.JSONEncoding, varName)
 	}
 	t := template.New("oapi-codegen").Funcs(TemplateFunctions)
 	// This parses all of our own template files into the template object

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -223,6 +223,9 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 	TemplateFunctions["jsonMarshalExpr"] = func(varName string) string {
 		return jsonMarshalExpr(globalState.options.OutputOptions.JSONEncoding, varName)
 	}
+	TemplateFunctions["jsonMarshalFieldExpr"] = func(varName string) string {
+		return jsonMarshalFieldExpr(globalState.options.OutputOptions.JSONEncoding, varName)
+	}
 	t := template.New("oapi-codegen").Funcs(TemplateFunctions)
 	// This parses all of our own template files into the template object
 	// above

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -217,6 +217,24 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 
 	// This creates the golang templates text package
 	TemplateFunctions["opts"] = func() Configuration { return globalState.options }
+	TemplateFunctions["jsonNewEncoder"] = func(bufVarName string) string {
+		enc := globalState.options.OutputOptions.JSONEncoding
+		if !enc.NeedsCustomEncoding() {
+			return "json.NewEncoder(&" + bufVarName + ")"
+		}
+		var sb strings.Builder
+		sb.WriteString("func() *json.Encoder {\n")
+		sb.WriteString("__e := json.NewEncoder(&" + bufVarName + ")\n")
+		if !enc.EscapeHTMLValue() {
+			sb.WriteString("__e.SetEscapeHTML(false)\n")
+		}
+		if enc.Indent != "" || enc.IndentPrefix != "" {
+			fmt.Fprintf(&sb, "__e.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
+		}
+		sb.WriteString("return __e\n")
+		sb.WriteString("}()")
+		return sb.String()
+	}
 	TemplateFunctions["jsonMarshalExpr"] = func(varName string) string {
 		enc := globalState.options.OutputOptions.JSONEncoding
 		if !enc.NeedsCustomEncoding() {

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -217,6 +217,28 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 
 	// This creates the golang templates text package
 	TemplateFunctions["opts"] = func() Configuration { return globalState.options }
+	TemplateFunctions["jsonMarshalExpr"] = func(varName string) string {
+		enc := globalState.options.OutputOptions.JSONEncoding
+		if !enc.NeedsCustomEncoding() {
+			return "json.Marshal(" + varName + ")"
+		}
+		var sb strings.Builder
+		sb.WriteString("func() ([]byte, error) {\n")
+		sb.WriteString("var __buf bytes.Buffer\n")
+		sb.WriteString("__enc := json.NewEncoder(&__buf)\n")
+		if !enc.EscapeHTMLValue() {
+			sb.WriteString("__enc.SetEscapeHTML(false)\n")
+		}
+		if enc.Indent != "" || enc.IndentPrefix != "" {
+			fmt.Fprintf(&sb, "__enc.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
+		}
+		sb.WriteString("if __err := __enc.Encode(" + varName + "); __err != nil {\n")
+		sb.WriteString("return nil, __err\n")
+		sb.WriteString("}\n")
+		sb.WriteString("return bytes.TrimRight(__buf.Bytes(), \"\\n\"), nil\n")
+		sb.WriteString("}()")
+		return sb.String()
+	}
 	t := template.New("oapi-codegen").Funcs(TemplateFunctions)
 	// This parses all of our own template files into the template object
 	// above

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -330,8 +330,10 @@ paths:
 }
 
 func TestJSONEncodingOptions(t *testing.T) {
-	// Spec with a oneOf type (triggers union.tmpl MarshalJSON) and a type
-	// with additionalProperties (triggers additional-properties.tmpl MarshalJSON).
+	// Spec with a oneOf type (triggers union.tmpl MarshalJSON), a type with
+	// additionalProperties (triggers additional-properties.tmpl MarshalJSON),
+	// and a path with a JSON request body and response (exercises client.tmpl
+	// and strict-interface.tmpl).
 	const spec = `
 openapi: "3.0.0"
 info:
@@ -360,7 +362,23 @@ components:
           type: string
       additionalProperties:
         type: string
-paths: {}
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: created pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
 `
 	loader := openapi3.NewLoader()
 	swagger, err := loader.LoadFromData([]byte(spec))
@@ -370,39 +388,90 @@ paths: {}
 
 	tests := []struct {
 		name        string
+		generate    GenerateOptions
 		encoding    JSONEncodingOptions
 		wantContain []string
 		wantAbsent  []string
 	}{
+		// --- models (union / additionalProperties MarshalJSON) ---
 		{
-			name:        "default: uses json.Marshal",
+			name:        "models/default: uses json.Marshal",
+			generate:    GenerateOptions{Models: true},
 			encoding:    JSONEncodingOptions{},
 			wantContain: []string{"json.Marshal(v)"},
 			wantAbsent:  []string{"SetEscapeHTML", "SetIndent"},
 		},
 		{
-			name:        "escape-html false: uses encoder with SetEscapeHTML(false)",
+			name:        "models/escape-html false: uses encoder with SetEscapeHTML(false)",
+			generate:    GenerateOptions{Models: true},
 			encoding:    JSONEncodingOptions{EscapeHTML: boolPtr(false)},
 			wantContain: []string{"json.NewEncoder", "SetEscapeHTML(false)"},
 			wantAbsent:  []string{"json.Marshal(v)", "SetIndent"},
 		},
 		{
-			name:        "indent set: uses encoder with SetIndent",
+			name:        "models/indent set: uses encoder with SetIndent",
+			generate:    GenerateOptions{Models: true},
 			encoding:    JSONEncodingOptions{Indent: "\t"},
 			wantContain: []string{"json.NewEncoder", `SetIndent("", "\t")`},
 			wantAbsent:  []string{"json.Marshal(v)", "SetEscapeHTML"},
 		},
 		{
-			name:        "both options: encoder with SetEscapeHTML and SetIndent",
+			name:        "models/both options: encoder with SetEscapeHTML and SetIndent",
+			generate:    GenerateOptions{Models: true},
 			encoding:    JSONEncodingOptions{EscapeHTML: boolPtr(false), Indent: "  "},
 			wantContain: []string{"json.NewEncoder", "SetEscapeHTML(false)", `SetIndent("", "  ")`},
 			wantAbsent:  []string{"json.Marshal(v)"},
 		},
 		{
-			name:        "escape-html true explicit: same as default",
+			name:        "models/escape-html true explicit: same as default",
+			generate:    GenerateOptions{Models: true},
 			encoding:    JSONEncodingOptions{EscapeHTML: boolPtr(true)},
 			wantContain: []string{"json.Marshal(v)"},
 			wantAbsent:  []string{"SetEscapeHTML", "SetIndent"},
+		},
+		// --- client (JSON request body path in client.tmpl) ---
+		{
+			name:        "client/default: uses json.Marshal(body)",
+			generate:    GenerateOptions{Client: true},
+			encoding:    JSONEncodingOptions{},
+			wantContain: []string{"json.Marshal(body)"},
+			wantAbsent:  []string{"func() ([]byte, error) {"},
+		},
+		{
+			name:        "client/escape-html false: uses IIFE encoder for body",
+			generate:    GenerateOptions{Client: true},
+			encoding:    JSONEncodingOptions{EscapeHTML: boolPtr(false)},
+			wantContain: []string{"func() ([]byte, error) {", "SetEscapeHTML(false)"},
+			wantAbsent:  []string{"json.Marshal(body)"},
+		},
+		{
+			name:        "client/indent set: uses IIFE encoder with SetIndent for body",
+			generate:    GenerateOptions{Client: true},
+			encoding:    JSONEncodingOptions{Indent: "\t"},
+			wantContain: []string{"func() ([]byte, error) {", `SetIndent("", "\t")`},
+			wantAbsent:  []string{"json.Marshal(body)", "SetEscapeHTML"},
+		},
+		// --- strict server (JSON response path in strict-interface.tmpl) ---
+		{
+			name:        "strict-server/default: uses json.NewEncoder(&buf) directly",
+			generate:    GenerateOptions{StdHTTPServer: true, Strict: true, Models: true},
+			encoding:    JSONEncodingOptions{},
+			wantContain: []string{"json.NewEncoder(&buf)"},
+			wantAbsent:  []string{"func() *json.Encoder {"},
+		},
+		{
+			name:        "strict-server/escape-html false: uses IIFE encoder",
+			generate:    GenerateOptions{StdHTTPServer: true, Strict: true, Models: true},
+			encoding:    JSONEncodingOptions{EscapeHTML: boolPtr(false)},
+			wantContain: []string{"func() *json.Encoder {", "SetEscapeHTML(false)"},
+			wantAbsent:  []string{},
+		},
+		{
+			name:        "strict-server/indent set: uses IIFE encoder with SetIndent",
+			generate:    GenerateOptions{StdHTTPServer: true, Strict: true, Models: true},
+			encoding:    JSONEncodingOptions{Indent: "  "},
+			wantContain: []string{"func() *json.Encoder {", `SetIndent("", "  ")`},
+			wantAbsent:  []string{"SetEscapeHTML"},
 		},
 	}
 
@@ -410,7 +479,7 @@ paths: {}
 		t.Run(tt.name, func(t *testing.T) {
 			opts := Configuration{
 				PackageName: "testpkg",
-				Generate:    GenerateOptions{Models: true},
+				Generate:    tt.generate,
 				OutputOptions: OutputOptions{
 					SkipPrune:    true,
 					JSONEncoding: tt.encoding,

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -329,5 +329,109 @@ paths:
 	assert.Contains(t, code, "roleName string")
 }
 
+func TestJSONEncodingOptions(t *testing.T) {
+	// Spec with a oneOf type (triggers union.tmpl MarshalJSON) and a type
+	// with additionalProperties (triggers additional-properties.tmpl MarshalJSON).
+	const spec = `
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: JSON encoding test
+components:
+  schemas:
+    Cat:
+      type: object
+      properties:
+        name:
+          type: string
+    Dog:
+      type: object
+      properties:
+        breed:
+          type: string
+    Pet:
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+    Metadata:
+      type: object
+      properties:
+        name:
+          type: string
+      additionalProperties:
+        type: string
+paths: {}
+`
+	loader := openapi3.NewLoader()
+	swagger, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name        string
+		encoding    JSONEncodingOptions
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "default: uses json.Marshal",
+			encoding:    JSONEncodingOptions{},
+			wantContain: []string{"json.Marshal(v)"},
+			wantAbsent:  []string{"SetEscapeHTML", "SetIndent"},
+		},
+		{
+			name:        "escape-html false: uses encoder with SetEscapeHTML(false)",
+			encoding:    JSONEncodingOptions{EscapeHTML: boolPtr(false)},
+			wantContain: []string{"json.NewEncoder", "SetEscapeHTML(false)"},
+			wantAbsent:  []string{"json.Marshal(v)", "SetIndent"},
+		},
+		{
+			name:        "indent set: uses encoder with SetIndent",
+			encoding:    JSONEncodingOptions{Indent: "\t"},
+			wantContain: []string{"json.NewEncoder", `SetIndent("", "\t")`},
+			wantAbsent:  []string{"json.Marshal(v)", "SetEscapeHTML"},
+		},
+		{
+			name:        "both options: encoder with SetEscapeHTML and SetIndent",
+			encoding:    JSONEncodingOptions{EscapeHTML: boolPtr(false), Indent: "  "},
+			wantContain: []string{"json.NewEncoder", "SetEscapeHTML(false)", `SetIndent("", "  ")`},
+			wantAbsent:  []string{"json.Marshal(v)"},
+		},
+		{
+			name:        "escape-html true explicit: same as default",
+			encoding:    JSONEncodingOptions{EscapeHTML: boolPtr(true)},
+			wantContain: []string{"json.Marshal(v)"},
+			wantAbsent:  []string{"SetEscapeHTML", "SetIndent"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := Configuration{
+				PackageName: "testpkg",
+				Generate:    GenerateOptions{Models: true},
+				OutputOptions: OutputOptions{
+					SkipPrune:    true,
+					JSONEncoding: tt.encoding,
+				},
+			}
+			code, err := Generate(swagger, opts)
+			require.NoError(t, err)
+			assert.NotEmpty(t, code)
+
+			_, err = format.Source([]byte(code))
+			require.NoError(t, err, "generated code must be valid Go")
+
+			for _, want := range tt.wantContain {
+				assert.Contains(t, code, want)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.NotContains(t, code, absent)
+			}
+		})
+	}
+}
+
 //go:embed test_spec.yaml
 var testOpenAPIDefinition string

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -392,6 +392,10 @@ type OutputOptions struct {
 	// TypeMapping allows customizing OpenAPI type/format to Go type mappings.
 	// User-specified mappings are merged on top of the defaults.
 	TypeMapping *TypeMapping `yaml:"type-mapping,omitempty"`
+
+	// JSONEncoding controls JSON encoding behavior (e.g. HTML escaping, indentation)
+	// for MarshalJSON methods and request body serialization in generated code.
+	JSONEncoding JSONEncodingOptions `yaml:"json-encoding,omitempty"`
 }
 
 func (oo OutputOptions) Validate() map[string]string {
@@ -434,4 +438,34 @@ type OutputOptionsOverlay struct {
 	// Strict defines whether the Overlay should be applied in a strict way, highlighting any actions that will not take any effect. This can, however, lead to more work when testing new actions in an Overlay, so can be turned off with this setting.
 	// Defaults to true.
 	Strict *bool `yaml:"strict,omitempty"`
+}
+
+// JSONEncodingOptions controls JSON encoding behavior for MarshalJSON methods
+// and request body serialization in generated code.
+type JSONEncodingOptions struct {
+	// EscapeHTML controls whether HTML special characters (<, >, &) are escaped
+	// to Unicode escape sequences in JSON output. When set to false, these
+	// characters are output as-is. Defaults to true, matching json.Marshal behavior.
+	EscapeHTML *bool `yaml:"escape-html,omitempty"`
+	// IndentPrefix is the string prepended to each line for each level of
+	// indentation. Corresponds to the first argument of json.Encoder.SetIndent.
+	IndentPrefix string `yaml:"indent-prefix,omitempty"`
+	// Indent is the string appended per nesting level. When non-empty, generated
+	// code uses an indented encoder instead of json.Marshal.
+	// Corresponds to the second argument of json.Encoder.SetIndent.
+	Indent string `yaml:"indent,omitempty"`
+}
+
+// EscapeHTMLValue returns the effective EscapeHTML setting, defaulting to true.
+func (o JSONEncodingOptions) EscapeHTMLValue() bool {
+	if o.EscapeHTML == nil {
+		return true
+	}
+	return *o.EscapeHTML
+}
+
+// NeedsCustomEncoding reports whether the options differ from standard json.Marshal
+// behavior and therefore require using json.Encoder.
+func (o JSONEncodingOptions) NeedsCustomEncoding() bool {
+	return !o.EscapeHTMLValue() || o.Indent != "" || o.IndentPrefix != ""
 }

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -422,22 +422,21 @@ func jsonMarshalExpr(enc JSONEncodingOptions, varName string) string {
 	if !enc.NeedsCustomEncoding() {
 		return "json.Marshal(" + varName + ")"
 	}
-	var sb strings.Builder
-	sb.WriteString("func() ([]byte, error) {\n")
-	sb.WriteString("var __buf bytes.Buffer\n")
-	sb.WriteString("__enc := json.NewEncoder(&__buf)\n")
+	var opts string
 	if !enc.EscapeHTMLValue() {
-		sb.WriteString("__enc.SetEscapeHTML(false)\n")
+		opts += "__enc.SetEscapeHTML(false)\n"
 	}
 	if enc.Indent != "" || enc.IndentPrefix != "" {
-		fmt.Fprintf(&sb, "__enc.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
+		opts += fmt.Sprintf("__enc.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
 	}
-	sb.WriteString("if __err := __enc.Encode(" + varName + "); __err != nil {\n")
-	sb.WriteString("return nil, __err\n")
-	sb.WriteString("}\n")
-	sb.WriteString("return bytes.TrimRight(__buf.Bytes(), \"\\n\"), nil\n")
-	sb.WriteString("}()")
-	return sb.String()
+	return fmt.Sprintf(`func() ([]byte, error) {
+var __buf bytes.Buffer
+__enc := json.NewEncoder(&__buf)
+%sif __err := __enc.Encode(%s); __err != nil {
+return nil, __err
+}
+return bytes.TrimRight(__buf.Bytes(), "\n"), nil
+}()`, opts, varName)
 }
 
 // jsonMarshalFieldExpr is like jsonMarshalExpr but never applies indentation.
@@ -460,16 +459,15 @@ func jsonNewEncoderExpr(enc JSONEncodingOptions, bufVarName string) string {
 	if !enc.NeedsCustomEncoding() {
 		return "json.NewEncoder(&" + bufVarName + ")"
 	}
-	var sb strings.Builder
-	sb.WriteString("func() *json.Encoder {\n")
-	sb.WriteString("__e := json.NewEncoder(&" + bufVarName + ")\n")
+	var opts string
 	if !enc.EscapeHTMLValue() {
-		sb.WriteString("__e.SetEscapeHTML(false)\n")
+		opts += "__e.SetEscapeHTML(false)\n"
 	}
 	if enc.Indent != "" || enc.IndentPrefix != "" {
-		fmt.Fprintf(&sb, "__e.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
+		opts += fmt.Sprintf("__e.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
 	}
-	sb.WriteString("return __e\n")
-	sb.WriteString("}()")
-	return sb.String()
+	return fmt.Sprintf(`func() *json.Encoder {
+__e := json.NewEncoder(&%s)
+%sreturn __e
+}()`, bufVarName, opts)
 }

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -440,6 +440,17 @@ func jsonMarshalExpr(enc JSONEncodingOptions, varName string) string {
 	return sb.String()
 }
 
+// jsonMarshalFieldExpr is like jsonMarshalExpr but never applies indentation.
+// Use this when marshaling individual field values that will be stored as
+// json.RawMessage in an intermediate map; the outer marshal via jsonMarshalExpr
+// is the right place to apply indentation so that the full structure is
+// indented consistently without double-indenting nested values.
+func jsonMarshalFieldExpr(enc JSONEncodingOptions, varName string) string {
+	enc.Indent = ""
+	enc.IndentPrefix = ""
+	return jsonMarshalExpr(enc, varName)
+}
+
 // jsonNewEncoderExpr returns a Go expression that creates a *json.Encoder
 // writing to &bufVarName, applying any JSONEncoding options. When no custom
 // encoding is required the expression is a plain json.NewEncoder call;

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -413,3 +413,52 @@ var TemplateFunctions = template.FuncMap{
 	"genServerURLWithVariablesFunctionParams": genServerURLWithVariablesFunctionParams,
 	"httpMethodConstant":                      httpMethodConstant,
 }
+
+// jsonMarshalExpr returns a Go expression that marshals varName to JSON,
+// respecting the JSONEncoding options. When no custom encoding is required the
+// expression is a plain json.Marshal call; otherwise it is an immediately-
+// invoked function that configures a json.Encoder appropriately.
+func jsonMarshalExpr(enc JSONEncodingOptions, varName string) string {
+	if !enc.NeedsCustomEncoding() {
+		return "json.Marshal(" + varName + ")"
+	}
+	var sb strings.Builder
+	sb.WriteString("func() ([]byte, error) {\n")
+	sb.WriteString("var __buf bytes.Buffer\n")
+	sb.WriteString("__enc := json.NewEncoder(&__buf)\n")
+	if !enc.EscapeHTMLValue() {
+		sb.WriteString("__enc.SetEscapeHTML(false)\n")
+	}
+	if enc.Indent != "" || enc.IndentPrefix != "" {
+		fmt.Fprintf(&sb, "__enc.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
+	}
+	sb.WriteString("if __err := __enc.Encode(" + varName + "); __err != nil {\n")
+	sb.WriteString("return nil, __err\n")
+	sb.WriteString("}\n")
+	sb.WriteString("return bytes.TrimRight(__buf.Bytes(), \"\\n\"), nil\n")
+	sb.WriteString("}()")
+	return sb.String()
+}
+
+// jsonNewEncoderExpr returns a Go expression that creates a *json.Encoder
+// writing to &bufVarName, applying any JSONEncoding options. When no custom
+// encoding is required the expression is a plain json.NewEncoder call;
+// otherwise it is an immediately-invoked function that sets the options before
+// returning the encoder.
+func jsonNewEncoderExpr(enc JSONEncodingOptions, bufVarName string) string {
+	if !enc.NeedsCustomEncoding() {
+		return "json.NewEncoder(&" + bufVarName + ")"
+	}
+	var sb strings.Builder
+	sb.WriteString("func() *json.Encoder {\n")
+	sb.WriteString("__e := json.NewEncoder(&" + bufVarName + ")\n")
+	if !enc.EscapeHTMLValue() {
+		sb.WriteString("__e.SetEscapeHTML(false)\n")
+	}
+	if enc.Indent != "" || enc.IndentPrefix != "" {
+		fmt.Fprintf(&sb, "__e.SetIndent(%q, %q)\n", enc.IndentPrefix, enc.Indent)
+	}
+	sb.WriteString("return __e\n")
+	sb.WriteString("}()")
+	return sb.String()
+}

--- a/pkg/codegen/templates/additional-properties.tmpl
+++ b/pkg/codegen/templates/additional-properties.tmpl
@@ -54,14 +54,14 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
     object := make(map[string]json.RawMessage)
 {{range .Schema.Properties}}
 {{if .RequiresNilCheck}}if a.{{.GoFieldName}} != nil { {{end}}
-    object["{{.JsonFieldName}}"], err = {{jsonMarshalExpr (printf "a.%s" .GoFieldName)}}
+    object["{{.JsonFieldName}}"], err = {{jsonMarshalFieldExpr (printf "a.%s" .GoFieldName)}}
     if err != nil {
         return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}': %w", err)
     }
 {{if .RequiresNilCheck}} }{{end}}
 {{end}}
     for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = {{jsonMarshalExpr "field"}}
+		object[fieldName], err = {{jsonMarshalFieldExpr "field"}}
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}

--- a/pkg/codegen/templates/additional-properties.tmpl
+++ b/pkg/codegen/templates/additional-properties.tmpl
@@ -54,19 +54,19 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
     object := make(map[string]json.RawMessage)
 {{range .Schema.Properties}}
 {{if .RequiresNilCheck}}if a.{{.GoFieldName}} != nil { {{end}}
-    object["{{.JsonFieldName}}"], err = json.Marshal(a.{{.GoFieldName}})
+    object["{{.JsonFieldName}}"], err = {{jsonMarshalExpr (printf "a.%s" .GoFieldName)}}
     if err != nil {
         return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}': %w", err)
     }
 {{if .RequiresNilCheck}} }{{end}}
 {{end}}
     for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
+		object[fieldName], err = {{jsonMarshalExpr "field"}}
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
-	return json.Marshal(object)
+	return {{jsonMarshalExpr "object"}}
 }
 {{end}}
 {{end}}

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -136,7 +136,7 @@ func (c *{{ $clientTypeName }}) {{$opid}}{{.Suffix}}(ctx context.Context{{genPar
 func New{{$opid}}Request{{.Suffix}}(server string{{genParamArgs $pathParams}}{{if $hasParams}}, params *{{$opid}}Params{{end}}, body {{$opid}}{{.NameTag}}RequestBody) (*http.Request, error) {
     var bodyReader io.Reader
     {{if .IsJSON -}}
-        buf, err := json.Marshal(body)
+        buf, err := {{jsonMarshalExpr "body"}}
         if err != nil {
             return nil, err
         }

--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -86,7 +86,7 @@
                 {{if .IsJSON -}}
                     {{$hasUnionElements := ne 0 (len .Schema.UnionElements) -}}
                     var buf bytes.Buffer
-                    if err := json.NewEncoder(&buf).Encode(response{{if $hasBodyVar}}.Body{{end}}{{if and $hasUnionElements (not .Schema.IsExternalRef)}}.union{{end}}); err != nil {
+                    if err := {{jsonNewEncoder "buf"}}.Encode(response{{if $hasBodyVar}}.Body{{end}}{{if and $hasUnionElements (not .Schema.IsExternalRef)}}.union{{end}}); err != nil {
                         return err
                     }
                     w.Header().Set("Content-Type", {{if .HasFixedContentType }}{{.ContentType | toGoString}}{{else}}response.ContentType{{end}})

--- a/pkg/codegen/templates/union-and-additional-properties.tmpl
+++ b/pkg/codegen/templates/union-and-additional-properties.tmpl
@@ -55,18 +55,18 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
     }
 {{range .Schema.Properties}}
 {{if .RequiresNilCheck}}if a.{{.GoFieldName}} != nil { {{end}}
-    object["{{.JsonFieldName}}"], err = json.Marshal(a.{{.GoFieldName}})
+    object["{{.JsonFieldName}}"], err = {{jsonMarshalExpr (printf "a.%s" .GoFieldName)}}
     if err != nil {
         return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}': %w", err)
     }
 {{if .RequiresNilCheck}} }{{end}}
 {{end}}
     for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
+		object[fieldName], err = {{jsonMarshalExpr "field"}}
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
-	return json.Marshal(object)
+	return {{jsonMarshalExpr "object"}}
 }
 {{end}}

--- a/pkg/codegen/templates/union-and-additional-properties.tmpl
+++ b/pkg/codegen/templates/union-and-additional-properties.tmpl
@@ -55,14 +55,14 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
     }
 {{range .Schema.Properties}}
 {{if .RequiresNilCheck}}if a.{{.GoFieldName}} != nil { {{end}}
-    object["{{.JsonFieldName}}"], err = {{jsonMarshalExpr (printf "a.%s" .GoFieldName)}}
+    object["{{.JsonFieldName}}"], err = {{jsonMarshalFieldExpr (printf "a.%s" .GoFieldName)}}
     if err != nil {
         return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}': %w", err)
     }
 {{if .RequiresNilCheck}} }{{end}}
 {{end}}
     for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = {{jsonMarshalExpr "field"}}
+		object[fieldName], err = {{jsonMarshalFieldExpr "field"}}
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}

--- a/pkg/codegen/templates/union.tmpl
+++ b/pkg/codegen/templates/union.tmpl
@@ -30,7 +30,7 @@
                     {{end -}}
                 {{end -}}
             {{end -}}
-            b, err := json.Marshal(v)
+            b, err := {{jsonMarshalExpr "v"}}
             t.union = b
             return err
         }
@@ -53,7 +53,7 @@
                     {{end -}}
                 {{end -}}
             {{end -}}
-            b, err := json.Marshal(v)
+            b, err := {{jsonMarshalExpr "v"}}
             if err != nil {
               return err
             }
@@ -108,13 +108,13 @@
             }
             {{range .Schema.Properties}}
             {{if .RequiresNilCheck}}if t.{{.GoFieldName}} != nil { {{end}}
-                object["{{.JsonFieldName}}"], err = json.Marshal(t.{{.GoFieldName}})
+                object["{{.JsonFieldName}}"], err = {{jsonMarshalExpr (printf "t.%s" .GoFieldName)}}
                 if err != nil {
                     return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}': %w", err)
                 }
             {{if .RequiresNilCheck}} }{{end}}
             {{end -}}
-            b, err = json.Marshal(object)
+            b, err = {{jsonMarshalExpr "object"}}
         {{end -}}
         return b, err
     }


### PR DESCRIPTION
## Summary

Add `output-options.json-encoding` configuration block to control JSON encoding behavior in generated code.

- **`escape-html`** (bool, default `true`): maps to `json.Encoder.SetEscapeHTML`. When set to `false`, HTML special characters (`<`, `>`, `&`) are output as-is instead of being escaped to Unicode sequences.
- **`indent-prefix`** (string, default `""`): maps to the first argument of `json.Encoder.SetIndent`.
- **`indent`** (string, default `""`): maps to the second argument of `json.Encoder.SetIndent`. When non-empty, indented output is produced.

### Example config

```yaml
output-options:
  json-encoding:
    escape-html: false
    indent: "  "
```

### Affected generated code

| Location | Change |
|---|---|
| `MarshalJSON()` in union types | `json.Marshal(v)` → encoder with configured settings |
| `MarshalJSON()` in types with `additionalProperties` | same |
| `MarshalJSON()` in union + `additionalProperties` types | same |
| JSON request body in client | `json.Marshal(body)` → encoder with configured settings |
| `Visit*Response()` in strict server | `json.NewEncoder(&buf)` → encoder with configured settings |

When no options are set (default), `json.Marshal` / `json.NewEncoder` are emitted as before — **fully backward-compatible**.

Parameter serialization (path, query, header, cookie) is intentionally excluded: applying `SetIndent` there would embed whitespace into URL/header values and break requests.

## Test plan

- [x] `TestJSONEncodingOptions` covers: default, `escape-html: false`, `indent`, both options combined, and explicit `escape-html: true`
- [x] All existing tests pass unchanged
- [x] Generated code passes `go/format` validation in all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)