### PR TITLE
lint: migrate to `golangci-lint`'s install script on `main`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo "    lint         lint the project"
 
 $(GOBIN)/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v2.10.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | sh -s -- -b $(GOBIN) v2.10.1
 
 .PHONY: tools
 tools: $(GOBIN)/golangci-lint


### PR DESCRIPTION
Via [0], otherwise downloads fails with:

```
golangci/golangci-lint err hash_sha256_verify checksum for
    '/tmp/.../golangci-lint-2.12.2-linux-amd64.tar.gz' did not verify

```

[0]: https://redirect.github.com/golangci/golangci-lint/issues/6572#issuecomment-4400895705
