### PR TITLE
feat: add SetGlobalStateOptions and ResetGlobalState

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -1474,3 +1474,24 @@ func GetParametersImports(params map[string]*openapi3.ParameterRef) (map[string]
 func SetGlobalStateSpec(spec *openapi3.T) {
 	globalState.spec = spec
 }
+
+// SetGlobalStateOptions allows setting globalState.options without calling
+// Generate. This is useful when using oapi-codegen as a library and calling
+// Generate multiple times with different options in a single process.
+func SetGlobalStateOptions(opts Configuration) {
+	globalState.options = opts
+}
+
+// ResetGlobalState resets all global state to its zero value. This is useful
+// when using oapi-codegen as a library and calling Generate multiple times
+// in a single process to ensure no state leaks between calls.
+func ResetGlobalState() {
+	globalState.options = Configuration{}
+	globalState.spec = nil
+	globalState.importMapping = nil
+	globalState.initialismsMap = nil
+	globalState.typeMapping = TypeMapping{}
+	globalState.resolvedNames = nil
+	globalState.resolvedClientWrapperNames = nil
+	globalState.streamingContentTypeRegexes = nil
+}


### PR DESCRIPTION
## Problem

When using oapi-codegen as a library and calling `Generate` multiple times in a single process (e.g., to split client operations by tags into separate files), the `globalState.options` from the first call persists and affects subsequent calls. This makes it impossible to generate separate files with different configurations.

## Solution

This PR adds two new exported functions, following the pattern established by `SetGlobalStateSpec` (PR #1174):

- **`SetGlobalStateOptions(opts Configuration)`** — Allows setting `globalState.options` without calling `Generate`. Useful when you need to override options between successive `Generate` calls.

- **`ResetGlobalState()`** — Resets all global state fields to their zero values. This is a more thorough reset that prevents any state leakage between calls, including options, spec, import mappings, type mappings, initialisms, resolved names, and streaming content type regexes.

## Usage

```go
// Generate with first set of options
result1, err := codegen.Generate(spec, opts1)

// Reset state before next call
codegen.ResetGlobalState()

// Generate with different options
result2, err := codegen.Generate(spec, opts2)
```

Or for just overriding options:

```go
codegen.SetGlobalStateOptions(newOpts)
result, err := codegen.Generate(spec, newOpts)
```

Fixes #1805
