### PR TITLE
Improve string escaping and add tests

### DIFF
--- a/pkg/codegen/server_urls_test.go
+++ b/pkg/codegen/server_urls_test.go
@@ -1,7 +1,11 @@
 package codegen
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"testing"
+	"text/template"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
@@ -55,6 +59,116 @@ func TestUsedAndUndeclaredVariables(t *testing.T) {
 
 	undeclared := srv.UndeclaredPlaceholders()
 	assert.Equal(t, []string{"path"}, undeclared, "URL placeholder not in variables must be reported (#2005)")
+}
+
+// renderServerURLs parses the embedded templates and renders the
+// server-urls template for spec, mirroring the setup in Generate.
+func renderServerURLs(t *testing.T, spec *openapi3.T) string {
+	t.Helper()
+	// Generate registers `opts` before parsing; mirror that here so the
+	// (unrelated) framework templates parse cleanly.
+	TemplateFunctions["opts"] = func() Configuration { return globalState.options }
+	tmpl := template.New("oapi-codegen").Funcs(TemplateFunctions)
+	require.NoError(t, LoadTemplates(templates, tmpl))
+	out, err := GenerateServerURLs(tmpl, spec)
+	require.NoError(t, err)
+	return out
+}
+
+// injectSentinel is the identifier a malicious spec tries to smuggle in
+// as a real top-level declaration. The two escape techniques covered are:
+//   - a newline that breaks out of a `//` line comment, and
+//   - a `"` that breaks out of a `const … = "…"` string literal,
+//
+// both of which would land `var injectSentinel = …` at package scope.
+const injectSentinel = "OapiCodegenInjectedPwned"
+
+// TestServerURLInjection checks that attacker-controlled spec text (server
+// description, URL, and variable default), which flows into generated Go line
+// comments and string literals, cannot break out into an executable top-level
+// declaration.
+func TestServerURLInjection(t *testing.T) {
+	// commentBreakout escapes a `//` comment, declares the sentinel, then
+	// re-opens a comment so the surrounding template text stays valid.
+	commentBreakout := "benign\nvar " + injectSentinel + " = 1\n//"
+	// literalBreakout escapes a `"…"` string literal, declares the
+	// sentinel, then re-opens a literal to swallow the template's closing
+	// quote.
+	literalBreakout := `https://api.example.com"; var ` + injectSentinel + ` = 1; var _ = "`
+
+	t.Run("newline in description cannot escape the doc comment", func(t *testing.T) {
+		out := renderServerURLs(t, &openapi3.T{Servers: openapi3.Servers{
+			{URL: "https://api.example.com", Description: commentBreakout},
+		}})
+		assertSentinelNotDeclared(t, out)
+	})
+
+	t.Run("description in the function (variable-bearing) form cannot escape", func(t *testing.T) {
+		out := renderServerURLs(t, &openapi3.T{Servers: openapi3.Servers{
+			{URL: "https://api.example.com/{tenant}", Description: commentBreakout},
+		}})
+		assertSentinelNotDeclared(t, out)
+	})
+
+	t.Run("quote in URL cannot escape the const string literal", func(t *testing.T) {
+		out := renderServerURLs(t, &openapi3.T{Servers: openapi3.Servers{
+			{URL: literalBreakout},
+		}})
+		assertSentinelNotDeclared(t, out)
+	})
+
+	t.Run("quote in a variable default cannot escape the const string literal", func(t *testing.T) {
+		out := renderServerURLs(t, &openapi3.T{Servers: openapi3.Servers{
+			{
+				URL: "https://api.example.com/{base}",
+				Variables: map[string]*openapi3.ServerVariable{
+					// non-enum, used → emits `const …BaseVariableDefault = "<default>"`
+					"base": {Default: `v2"; var ` + injectSentinel + ` = 1; var _ = "`},
+				},
+			},
+		}})
+		assertSentinelNotDeclared(t, out)
+	})
+}
+
+// assertSentinelNotDeclared parses the generated output as a package body
+// and fails if it is not valid Go or if injectSentinel appears as a
+// top-level declared identifier (i.e. the payload escaped its comment or
+// string literal and became real source).
+func assertSentinelNotDeclared(t *testing.T, out string) {
+	t.Helper()
+	src := "package p\n" + out
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "gen.go", src, parser.ParseComments)
+	require.NoError(t, err, "generated output must parse as valid Go:\n%s", src)
+
+	for _, name := range topLevelDeclNames(file) {
+		assert.NotEqual(t, injectSentinel, name,
+			"injected identifier became a real top-level declaration:\n%s", src)
+	}
+}
+
+// topLevelDeclNames returns every identifier declared at file scope.
+func topLevelDeclNames(file *ast.File) []string {
+	var names []string
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			names = append(names, d.Name.Name)
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.ValueSpec:
+					for _, n := range s.Names {
+						names = append(names, n.Name)
+					}
+				case *ast.TypeSpec:
+					names = append(names, s.Name.Name)
+				}
+			}
+		}
+	}
+	return names
 }
 
 func TestBuildServerURLTypeDefinitions(t *testing.T) {

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -322,8 +322,10 @@ func toStringArray(sarr []string) string {
 	return `[]string{` + s + `}`
 }
 
+// stripNewLines removes newlines so untrusted spec text stays inside a single
+// generated `//` line comment instead of breaking out into real Go source.
 func stripNewLines(s string) string {
-	r := strings.NewReplacer("\n", "")
+	r := strings.NewReplacer("\n", "", "\r", "")
 	return r.Replace(s)
 }
 

--- a/pkg/codegen/templates/server-urls.tmpl
+++ b/pkg/codegen/templates/server-urls.tmpl
@@ -3,8 +3,8 @@
 {{ $undeclared := .UndeclaredPlaceholders }}
 {{ if and (eq 0 (len $usedVars)) (eq 0 (len $undeclared)) }}
 {{/* URLs without variables (declared or used) are straightforward, so we'll create them a constant */}}
-// {{ .GoName }} defines the Server URL for {{ if len .OAPISchema.Description }}{{ .OAPISchema.Description }}{{ else }}{{ .OAPISchema.URL }}{{ end }}
-const {{ .GoName}} = "{{ .OAPISchema.URL }}"
+// {{ .GoName }} defines the Server URL for {{ if len .OAPISchema.Description }}{{ stripNewLines .OAPISchema.Description }}{{ else }}{{ stripNewLines .OAPISchema.URL }}{{ end }}
+const {{ .GoName}} = {{ .OAPISchema.URL | toGoString }}
 {{ else }}
 {{/* URLs with variables are not straightforward, as we may need multiple types, and so will model them as a function */}}
 
@@ -36,7 +36,7 @@ const {{ .GoName}} = "{{ .OAPISchema.URL }}"
    type {{ $prefix }} string
    {{ if $v.Default }}
    // {{ $prefix }}Default is the default value for the `{{ $k }}` variable for {{ $goName }}
-   const {{ $prefix }}Default = "{{ $v.Default }}"
+   const {{ $prefix }}Default = {{ $v.Default | toGoString }}
    {{ end }}
    {{ end }}
 {{ end }}
@@ -55,7 +55,7 @@ const {{ .GoName}} = "{{ .OAPISchema.URL }}"
 {{ end }}
 
 
-// New{{ .GoName }} constructs the Server URL for {{ .OAPISchema.Description }}, with the provided variables.
+// New{{ .GoName }} constructs the Server URL for {{ stripNewLines .OAPISchema.Description }}, with the provided variables.
 func New{{ .GoName }}({{ .NewServerFunctionParams }}) (string, error) {
     {{ range $k, $v := $usedVars }}
         {{- if gt (len $v.Enum) 0 -}}
@@ -64,7 +64,7 @@ func New{{ .GoName }}({{ .NewServerFunctionParams }}) (string, error) {
     }
         {{ end -}}
     {{ end }}
-    u := "{{ .OAPISchema.URL }}"
+    u := {{ .OAPISchema.URL | toGoString }}
 
     {{ range $k, $v := $usedVars }}
         {{- $placeholder := printf "{%s}" $k -}}

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -905,10 +905,12 @@ func PathToTypeName(path []string) string {
 }
 
 // StringToGoString takes an arbitrary string and converts it to a valid Go string literal,
-// including the quotes. For instance, `foo "bar"` would be converted to `"foo \"bar\""`
+// including the quotes. For instance, `foo "bar"` would be converted to `"foo \"bar\""`.
+//
+// strconv.Quote escapes backslashes, newlines and other control characters too,
+// so untrusted spec text cannot break out of the generated string literal.
 func StringToGoString(in string) string {
-	esc := strings.ReplaceAll(in, "\"", "\\\"")
-	return fmt.Sprintf("\"%s\"", esc)
+	return strconv.Quote(in)
 }
 
 // StringToGoComment renders a possible multi-line string as a valid Go-Comment.

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -544,6 +544,19 @@ func TestStringToGoStringValue(t *testing.T) {
 			expected: `"application/json; foo=\"bar\""`,
 			message:  "string with quotes should include escape characters",
 		},
+		{
+			// The previous implementation only escaped `"`, so a backslash
+			// before a quote (`\"`) escaped the escaping and let untrusted
+			// spec text break out of the generated string literal.
+			input:    `a\"; var Evil = 1; var _ = "`,
+			expected: `"a\\\"; var Evil = 1; var _ = \""`,
+			message:  "backslashes must be escaped so a quote cannot break out of the literal",
+		},
+		{
+			input:    "line1\nline2",
+			expected: `"line1\nline2"`,
+			message:  "newlines must be escaped so they cannot terminate the literal",
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.message, func(t *testing.T) {


### PR DESCRIPTION
Tighten how server URL values are emitted in the server-urls template so that spec-supplied text is always serialized into a proper Go context:

- Route server descriptions and URLs through stripNewLines when they are written into generated // comments, so a multi-line value stays on the comment line instead of spilling into following lines.
- Emit server URL and variable-default values via toGoString (now backed by strconv.Quote) instead of hand-wrapping them in quotes, so quotes, backslashes, and newlines are escaped correctly.
- Harden StringToGoString to use strconv.Quote; the previous version only escaped double quotes and mishandled backslashes. This also tidies up the content-type literals that already used it.
- Extend stripNewLines to drop carriage returns as well as newlines.

Add regression tests covering the server-urls rendering and the StringToGoString escaping, and confirm `make generate` produces no changes to committed output.