### PR TITLE
Use net/http constants in boilerplate

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -407,7 +407,7 @@ func ParseListThingsResponse(rsp *http.Response) (*ListThingsResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest []ThingWithID
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -433,7 +433,7 @@ func ParseAddThingResponse(rsp *http.Response) (*AddThingResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusCreated:
 		var dest []ThingWithID
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/examples/authenticated-api/stdhttp/api/api.gen.go
+++ b/examples/authenticated-api/stdhttp/api/api.gen.go
@@ -408,7 +408,7 @@ func ParseListThingsResponse(rsp *http.Response) (*ListThingsResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest []ThingWithID
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -434,7 +434,7 @@ func ParseAddThingResponse(rsp *http.Response) (*AddThingResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusCreated:
 		var dest []ThingWithID
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/examples/client/client.gen.go
+++ b/examples/client/client.gen.go
@@ -342,7 +342,7 @@ func ParseGetClientResponse(rsp *http.Response) (*GetClientResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest ClientType
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -368,7 +368,7 @@ func ParseUpdateClientResponse(rsp *http.Response) (*UpdateClientResponse, error
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusBadRequest:
 		var dest struct {
 			Code string `json:"code"`
 		}

--- a/examples/clienttypenameclash/client.gen.go
+++ b/examples/clienttypenameclash/client.gen.go
@@ -244,7 +244,7 @@ func ParseUpdateClientResp(rsp *http.Response) (*UpdateClientResp, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusBadRequest:
 		var dest UpdateClientResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/examples/custom-client-type/custom-client-type.gen.go
+++ b/examples/custom-client-type/custom-client-type.gen.go
@@ -244,7 +244,7 @@ func ParseGetClientResponse(rsp *http.Response) (*GetClientResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Client
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/examples/import-mapping/samepackage/server.gen.go
+++ b/examples/import-mapping/samepackage/server.gen.go
@@ -204,7 +204,7 @@ func (response GetUserById200JSONResponse) VisitGetUserByIdResponse(w http.Respo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -674,7 +674,7 @@ func ParseFindPetsResponse(rsp *http.Response) (*FindPetsResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest []Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -707,7 +707,7 @@ func ParseAddPetResponse(rsp *http.Response) (*AddPetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -766,7 +766,7 @@ func ParseFindPetByIDResponse(rsp *http.Response) (*FindPetByIDResponse, error) 
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/examples/petstore-expanded/strict/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-server.gen.go
@@ -332,7 +332,7 @@ func (response FindPets200JSONResponse) VisitFindPetsResponse(w http.ResponseWri
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -371,7 +371,7 @@ func (response AddPet200JSONResponse) VisitAddPetResponse(w http.ResponseWriter)
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -405,7 +405,7 @@ type DeletePet204Response struct {
 }
 
 func (response DeletePet204Response) VisitDeletePetResponse(w http.ResponseWriter) error {
-	w.WriteHeader(204)
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 
@@ -443,7 +443,7 @@ func (response FindPetByID200JSONResponse) VisitFindPetByIDResponse(w http.Respo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/examples/streaming/stdhttp/sse/streaming.gen.go
+++ b/examples/streaming/stdhttp/sse/streaming.gen.go
@@ -193,7 +193,7 @@ func (response GetStream200ApplicationjsonlResponse) VisitGetStreamResponse(w ht
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()

--- a/internal/test/anonymous_inner_hoisting/client.gen.go
+++ b/internal/test/anonymous_inner_hoisting/client.gen.go
@@ -1279,7 +1279,7 @@ func ParseGetResponseDeepNestedResponse(rsp *http.Response) (*GetResponseDeepNes
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest struct {
 			Wrapper *struct {
 				Inner *GetResponseDeepNested200JSONResponseBody_Wrapper_Inner `json:"inner,omitempty"`
@@ -1309,7 +1309,7 @@ func ParseGetResponseItemsOneOfResponse(rsp *http.Response) (*GetResponseItemsOn
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest struct {
 			Items []GetResponseItemsOneOf200JSONResponseBody_Items_Item `json:"items"`
 		}
@@ -1337,7 +1337,7 @@ func ParseGetResponseRootAnyOfResponse(rsp *http.Response) (*GetResponseRootAnyO
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest GetResponseRootAnyOf200JSONResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -1363,7 +1363,7 @@ func ParseGetResponseRootOneOfResponse(rsp *http.Response) (*GetResponseRootOneO
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest GetResponseRootOneOf200JSONResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/any_of/codegen/inline/openapi.gen.go
+++ b/internal/test/any_of/codegen/inline/openapi.gen.go
@@ -372,7 +372,7 @@ func ParseGetPetsResponse(rsp *http.Response) (*GetPetsResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest struct {
 			Data *[]GetPets200JSONResponseBody_Data_Item `json:"data,omitempty"`
 		}

--- a/internal/test/any_of/codegen/ref_schema/openapi.gen.go
+++ b/internal/test/any_of/codegen/ref_schema/openapi.gen.go
@@ -373,7 +373,7 @@ func ParseGetPetsResponse(rsp *http.Response) (*GetPetsResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest GetPetsDto
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/issues/issue-1087/api.gen.go
+++ b/internal/test/issues/issue-1087/api.gen.go
@@ -286,45 +286,45 @@ func ParseGetThingsResponse(rsp *http.Response) (*GetThingsResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest ThingResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusUnauthorized:
 		var dest externalRef0.N401
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON401 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusForbidden:
 		var dest externalRef0.N403
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON403 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusNotFound:
 		var dest N404
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON404 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusInternalServerError:
 		var dest externalRef0.DefaultError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON500 = &dest
 
-	case rsp.StatusCode == 401:
+	case rsp.StatusCode == http.StatusUnauthorized:
 	// Content-type (text/plain) unsupported
 
-	case rsp.StatusCode == 403:
+	case rsp.StatusCode == http.StatusForbidden:
 		// Content-type (text/plain) unsupported
 
 	}

--- a/internal/test/issues/issue-1093/api/child/child.gen.go
+++ b/internal/test/issues/issue-1093/api/child/child.gen.go
@@ -95,7 +95,7 @@ func (response GetPets200JSONResponse) VisitGetPetsResponse(w http.ResponseWrite
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-1093/api/parent/parent.gen.go
+++ b/internal/test/issues/issue-1093/api/parent/parent.gen.go
@@ -100,7 +100,7 @@ func (response GetPets200JSONResponse) VisitGetPetsResponse(w http.ResponseWrite
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-1182/pkg1/pkg1.gen.go
+++ b/internal/test/issues/issue-1182/pkg1/pkg1.gen.go
@@ -324,7 +324,7 @@ type TestGetResponseObject interface {
 type TestGet200Response externalRef0.ResponseWithReferenceResponse
 
 func (response TestGet200Response) VisitTestGetResponse(w http.ResponseWriter) error {
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	return nil
 }
 

--- a/internal/test/issues/issue-1189/issue1189.gen.go
+++ b/internal/test/issues/issue-1189/issue1189.gen.go
@@ -457,7 +457,7 @@ func ParseTestResponse(rsp *http.Response) (*TestResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/issues/issue-1208-1209/issue-multi-json.gen.go
+++ b/internal/test/issues/issue-1208-1209/issue-multi-json.gen.go
@@ -280,28 +280,28 @@ func ParseTestResponse(rsp *http.Response) (*TestResponse, error) {
 	}
 
 	switch {
-	case rsp.Header.Get("Content-Type") == "application/bar+json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/bar+json" && rsp.StatusCode == http.StatusOK:
 		var dest Bar
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationbarJSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/bar+json" && rsp.StatusCode == 201:
+	case rsp.Header.Get("Content-Type") == "application/bar+json" && rsp.StatusCode == http.StatusCreated:
 		var dest BazApplicationBarPlusJSON
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationbarJSON201 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/foo+json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/foo+json" && rsp.StatusCode == http.StatusOK:
 		var dest Foo
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationfooJSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/foo+json" && rsp.StatusCode == 201:
+	case rsp.Header.Get("Content-Type") == "application/foo+json" && rsp.StatusCode == http.StatusCreated:
 		var dest BazApplicationFooPlusJSON
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -391,7 +391,7 @@ func (response Test200ApplicationBarPlusJSONResponse) VisitTestResponse(w http.R
 		return err
 	}
 	w.Header().Set("Content-Type", "application/bar+json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -405,7 +405,7 @@ func (response Test200ApplicationFooPlusJSONResponse) VisitTestResponse(w http.R
 		return err
 	}
 	w.Header().Set("Content-Type", "application/foo+json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -421,7 +421,7 @@ func (response Test201ApplicationBarPlusJSONResponse) VisitTestResponse(w http.R
 		return err
 	}
 	w.Header().Set("Content-Type", "application/bar+json")
-	w.WriteHeader(201)
+	w.WriteHeader(http.StatusCreated)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -437,7 +437,7 @@ func (response Test201ApplicationFooPlusJSONResponse) VisitTestResponse(w http.R
 		return err
 	}
 	w.Header().Set("Content-Type", "application/foo+json")
-	w.WriteHeader(201)
+	w.WriteHeader(http.StatusCreated)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-1212/pkg1/pkg1.gen.go
+++ b/internal/test/issues/issue-1212/pkg1/pkg1.gen.go
@@ -316,7 +316,7 @@ func (response Test200MultipartResponse) VisitTestResponse(w http.ResponseWriter
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", mime.FormatMediaType("multipart/related", map[string]string{"boundary": writer.Boundary()}))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)

--- a/internal/test/issues/issue-1277/content-array.gen.go
+++ b/internal/test/issues/issue-1277/content-array.gen.go
@@ -332,7 +332,7 @@ func ParseTestResponse(rsp *http.Response) (*TestResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest []Test200JSONResponseBody_Item
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -519,7 +519,7 @@ func (response Test200JSONResponse) VisitTestResponse(w http.ResponseWriter) err
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-1298/issue1298.gen.go
+++ b/internal/test/issues/issue-1298/issue1298.gen.go
@@ -356,7 +356,7 @@ type Test204Response struct {
 }
 
 func (response Test204Response) VisitTestResponse(w http.ResponseWriter) error {
-	w.WriteHeader(204)
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 

--- a/internal/test/issues/issue-1378/bionicle/bionicle.gen.go
+++ b/internal/test/issues/issue-1378/bionicle/bionicle.gen.go
@@ -247,7 +247,7 @@ func (response GetBionicleName200JSONResponse) VisitGetBionicleNameResponse(w ht
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -261,7 +261,7 @@ func (response GetBionicleName400JSONResponse) VisitGetBionicleNameResponse(w ht
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-1378/fooservice/fooservice.gen.go
+++ b/internal/test/issues/issue-1378/fooservice/fooservice.gen.go
@@ -199,7 +199,7 @@ func (response GetBionicleName200JSONResponse) VisitGetBionicleNameResponse(w ht
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -221,7 +221,7 @@ func (response GetBionicleName400JSONResponse) VisitGetBionicleNameResponse(w ht
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-1529/strict-echo/issue1529.gen.go
+++ b/internal/test/issues/issue-1529/strict-echo/issue1529.gen.go
@@ -261,21 +261,21 @@ func ParseTestResponse(rsp *http.Response) (*TestResponse, error) {
 	}
 
 	switch {
-	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Bar\"" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Bar\"" && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationjsonProfileBar200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Foo\"" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Foo\"" && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -375,7 +375,7 @@ func (response Test200JSONResponse) VisitTestResponse(w http.ResponseWriter) err
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -389,7 +389,7 @@ func (response Test200ApplicationJSONProfileBarResponse) VisitTestResponse(w htt
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json; profile=\"Bar\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -403,7 +403,7 @@ func (response Test200ApplicationJSONProfileFooResponse) VisitTestResponse(w htt
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json; profile=\"Foo\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-1529/strict-fiber/issue1529.gen.go
+++ b/internal/test/issues/issue-1529/strict-fiber/issue1529.gen.go
@@ -261,21 +261,21 @@ func ParseTestResponse(rsp *http.Response) (*TestResponse, error) {
 	}
 
 	switch {
-	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Bar\"" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Bar\"" && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationjsonProfileBar200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Foo\"" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Foo\"" && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -359,7 +359,7 @@ type Test200JSONResponse Test
 
 func (response Test200JSONResponse) VisitTestResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/json")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -368,7 +368,7 @@ type Test200ApplicationJSONProfileBarResponse Test
 
 func (response Test200ApplicationJSONProfileBarResponse) VisitTestResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/json; profile=\"Bar\"")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -377,7 +377,7 @@ type Test200ApplicationJSONProfileFooResponse Test
 
 func (response Test200ApplicationJSONProfileFooResponse) VisitTestResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/json; profile=\"Foo\"")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response)
 }

--- a/internal/test/issues/issue-1529/strict-iris/issue1529.gen.go
+++ b/internal/test/issues/issue-1529/strict-iris/issue1529.gen.go
@@ -261,21 +261,21 @@ func ParseTestResponse(rsp *http.Response) (*TestResponse, error) {
 	}
 
 	switch {
-	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Bar\"" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Bar\"" && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationjsonProfileBar200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Foo\"" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json; profile=\"Foo\"" && rsp.StatusCode == http.StatusOK:
 		var dest Test
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -342,7 +342,7 @@ type Test200JSONResponse Test
 
 func (response Test200JSONResponse) VisitTestResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -351,7 +351,7 @@ type Test200ApplicationJSONProfileBarResponse Test
 
 func (response Test200ApplicationJSONProfileBarResponse) VisitTestResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json; profile=\"Bar\"")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -360,7 +360,7 @@ type Test200ApplicationJSONProfileFooResponse Test
 
 func (response Test200ApplicationJSONProfileFooResponse) VisitTestResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json; profile=\"Foo\"")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response)
 }

--- a/internal/test/issues/issue-1676/ping.gen.go
+++ b/internal/test/issues/issue-1676/ping.gen.go
@@ -181,7 +181,7 @@ func (response GetPing200TextResponse) VisitGetPingResponse(w http.ResponseWrite
 	if response.Headers.MyHeader != nil {
 		w.Header().Set("MyHeader", fmt.Sprint(*response.Headers.MyHeader))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response.Body))
 	return err

--- a/internal/test/issues/issue-1963/issue1963.gen.go
+++ b/internal/test/issues/issue-1963/issue1963.gen.go
@@ -293,7 +293,7 @@ func (response BinaryEndpoint200ApplicationoctetStreamResponse) VisitBinaryEndpo
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -319,7 +319,7 @@ func (response FormdataEndpoint200FormdataResponse) VisitFormdataEndpointRespons
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -341,7 +341,7 @@ func (response JsonEndpoint200JSONResponse) VisitJsonEndpointResponse(w http.Res
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -360,7 +360,7 @@ func (response MultipartEndpoint200MultipartResponse) VisitMultipartEndpointResp
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -379,7 +379,7 @@ type TextEndpoint200TextResponse string
 func (response TextEndpoint200TextResponse) VisitTextEndpointResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err

--- a/internal/test/issues/issue-2010/gen/spec_base/issue.gen.go
+++ b/internal/test/issues/issue-2010/gen/spec_base/issue.gen.go
@@ -192,7 +192,7 @@ type GetExample200Response struct {
 }
 
 func (response GetExample200Response) VisitGetExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	return nil
 }
 
@@ -205,7 +205,7 @@ func (response GetExample400JSONResponse) VisitGetExampleResponse(w http.Respons
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-2010/gen/spec_other/issue.gen.go
+++ b/internal/test/issues/issue-2010/gen/spec_other/issue.gen.go
@@ -184,7 +184,7 @@ type GetOtherExample200Response struct {
 }
 
 func (response GetOtherExample200Response) VisitGetOtherExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	return nil
 }
 
@@ -197,7 +197,7 @@ func (response GetOtherExample400JSONResponse) VisitGetOtherExampleResponse(w ht
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-2113/gen/api/api.gen.go
+++ b/internal/test/issues/issue-2113/gen/api/api.gen.go
@@ -189,7 +189,7 @@ func (response ListThings200JSONResponse) VisitListThingsResponse(w http.Respons
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -205,7 +205,7 @@ func (response ListThings400JSONResponse) VisitListThingsResponse(w http.Respons
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-2190/issue2190.gen.go
+++ b/internal/test/issues/issue-2190/issue2190.gen.go
@@ -245,7 +245,7 @@ func ParseGetTestResponse(rsp *http.Response) (*GetTestResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Success
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -432,7 +432,7 @@ func (response GetTest200JSONResponse) VisitGetTestResponse(w http.ResponseWrite
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -442,7 +442,7 @@ type GetTest401TextResponse UnauthorizedTextResponse
 func (response GetTest401TextResponse) VisitGetTestResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(401)
+	w.WriteHeader(http.StatusUnauthorized)
 
 	_, err := w.Write([]byte(response))
 	return err

--- a/internal/test/issues/issue-2367/api.gen.go
+++ b/internal/test/issues/issue-2367/api.gen.go
@@ -81,7 +81,7 @@ type GetHello200Response struct {
 }
 
 func (response GetHello200Response) VisitGetHelloResponse(w http.ResponseWriter) error {
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	return nil
 }
 

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -415,7 +415,7 @@ func ParseGetPetResponse(rsp *http.Response) (*GetPetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -441,7 +441,7 @@ func ParseValidatePetsResponse(rsp *http.Response) (*ValidatePetsResponse, error
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest []Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -260,7 +260,7 @@ func ParseExampleGetResponse(rsp *http.Response) (*ExampleGetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Document
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/issues/issue-970/issue970.gen.go
+++ b/internal/test/issues/issue-970/issue970.gen.go
@@ -309,7 +309,7 @@ func (response GetEvent200JSONResponse) VisitGetEventResponse(w http.ResponseWri
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -282,7 +282,7 @@ func ParseGetFooResponse(rsp *http.Response) (*GetFooResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest string
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -291,7 +291,7 @@ func ParseGetFooResponse(rsp *http.Response) (*GetFooResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest []Bar
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
+++ b/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
@@ -226,7 +226,7 @@ func (response PostInvalidExtRefTrouble300JSONResponse) VisitPostInvalidExtRefTr
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(300)
+	w.WriteHeader(http.StatusMultipleChoices)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -252,7 +252,7 @@ func (response PostNoTrouble200JSONResponse) VisitPostNoTroubleResponse(w http.R
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue1799/chi/out.gen.go
+++ b/internal/test/issues/issue1799/chi/out.gen.go
@@ -284,7 +284,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -298,7 +298,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams2\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -319,7 +319,7 @@ func (response GetObject200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivityst
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue1799/client/out.gen.go
+++ b/internal/test/issues/issue1799/client/out.gen.go
@@ -643,14 +643,14 @@ func ParseGetGetMultibodyResponse(rsp *http.Response) (*GetGetMultibodyResponse,
 	}
 
 	switch {
-	case rsp.Header.Get("Content-Type") == "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"" && rsp.StatusCode == http.StatusOK:
 		var dest string
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationldJSONProfilehttpswwwW3Orgnsactivitystreams200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams2\"" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams2\"" && rsp.StatusCode == http.StatusOK:
 		var dest string
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -676,7 +676,7 @@ func ParseGetObjectResponse(rsp *http.Response) (*GetObjectResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest string
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/issues/issue1799/echo/out.gen.go
+++ b/internal/test/issues/issue1799/echo/out.gen.go
@@ -161,7 +161,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -175,7 +175,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams2\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -196,7 +196,7 @@ func (response GetObject200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivityst
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue1799/fiber/out.gen.go
+++ b/internal/test/issues/issue1799/fiber/out.gen.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -172,7 +173,7 @@ type GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivitystream
 
 func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3OrgnsactivitystreamsResponse) VisitGetGetMultibodyResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -181,7 +182,7 @@ type GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivitystream
 
 func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivitystreams2Response) VisitGetGetMultibodyResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams2\"")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -197,7 +198,7 @@ type GetObject200ApplicationLdPlusJSONProfilehttpswwwW3OrgnsactivitystreamsRespo
 
 func (response GetObject200ApplicationLdPlusJSONProfilehttpswwwW3OrgnsactivitystreamsResponse) VisitGetObjectResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response)
 }

--- a/internal/test/issues/issue1799/gin/out.gen.go
+++ b/internal/test/issues/issue1799/gin/out.gen.go
@@ -160,7 +160,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -174,7 +174,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams2\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -195,7 +195,7 @@ func (response GetObject200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivityst
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue1799/gorilla/out.gen.go
+++ b/internal/test/issues/issue1799/gorilla/out.gen.go
@@ -255,7 +255,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -269,7 +269,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams2\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -290,7 +290,7 @@ func (response GetObject200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivityst
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue1799/iris/out.gen.go
+++ b/internal/test/issues/issue1799/iris/out.gen.go
@@ -119,7 +119,7 @@ type GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivitystream
 
 func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3OrgnsactivitystreamsResponse) VisitGetGetMultibodyResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -128,7 +128,7 @@ type GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivitystream
 
 func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivitystreams2Response) VisitGetGetMultibodyResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams2\"")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -144,7 +144,7 @@ type GetObject200ApplicationLdPlusJSONProfilehttpswwwW3OrgnsactivitystreamsRespo
 
 func (response GetObject200ApplicationLdPlusJSONProfilehttpswwwW3OrgnsactivitystreamsResponse) VisitGetObjectResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response)
 }

--- a/internal/test/issues/issue1799/std-http/out.gen.go
+++ b/internal/test/issues/issue1799/std-http/out.gen.go
@@ -259,7 +259,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -273,7 +273,7 @@ func (response GetGetMultibody200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsacti
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams2\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -294,7 +294,7 @@ func (response GetObject200ApplicationLdPlusJSONProfilehttpswwwW3Orgnsactivityst
 		return err
 	}
 	w.Header().Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/internal/test/issues/issue240/client.gen.go
+++ b/internal/test/issues/issue240/client.gen.go
@@ -352,7 +352,7 @@ func ParseGetClientResponse(rsp *http.Response) (*GetClientResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest ClientType
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -378,7 +378,7 @@ func ParseUpdateClientResponse(rsp *http.Response) (*UpdateClientResponse, error
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusBadRequest:
 		var dest struct {
 			Code string `json:"code"`
 		}

--- a/internal/test/name_conflict_resolution/name_conflict_resolution.gen.go
+++ b/internal/test/name_conflict_resolution/name_conflict_resolution.gen.go
@@ -2896,7 +2896,7 @@ func ParseListEntitiesResponse(rsp *http.Response) (*ListEntitiesResponse, error
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest struct {
 			Data     *[]Widget `json:"data,omitempty"`
 			Metadata *Metadata `json:"metadata,omitempty"`
@@ -2925,7 +2925,7 @@ func ParsePostFooResponse(rsp *http.Response) (*PostFooResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest BarResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -2951,7 +2951,7 @@ func ParseListItemsResponse2(rsp *http.Response) (*ListItemsResponse2, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest ListItemsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -2977,7 +2977,7 @@ func ParseCreateItemResponse2(rsp *http.Response) (*CreateItemResponse2, error) 
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest CreateItemResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3003,7 +3003,7 @@ func ParseCreateOrderResponse(rsp *http.Response) (*CreateOrderResponse, error) 
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Order
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3029,7 +3029,7 @@ func ParseGetOutcomeResponse(rsp *http.Response) (*GetOutcomeResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest OutcomeResult
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3071,7 +3071,7 @@ func ParseSendPayloadResponse(rsp *http.Response) (*SendPayloadResponse, error) 
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Payload
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3097,7 +3097,7 @@ func ParseCreatePetResponse(rsp *http.Response) (*CreatePetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3123,7 +3123,7 @@ func ParseQueryResponse2(rsp *http.Response) (*QueryResponse2, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest QueryResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3149,7 +3149,7 @@ func ParseGetQuxResponse(rsp *http.Response) (*GetQuxResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest QuxResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3191,7 +3191,7 @@ func ParseGetRenamedSchemaResponse(rsp *http.Response) (*GetRenamedSchemaRespons
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Renamer
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3233,28 +3233,28 @@ func ParsePatchResourceResponse(rsp *http.Response) (*PatchResourceResponse, err
 	}
 
 	switch {
-	case rsp.Header.Get("Content-Type") == "application/json-patch+json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json-patch+json" && rsp.StatusCode == http.StatusOK:
 		var dest N200ResourcePatchResponseJSON2ApplicationJSONPatchPlusJSON
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationjsonPatchJSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/json-patch-query+json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json-patch-query+json" && rsp.StatusCode == http.StatusOK:
 		var dest N200ResourcePatchResponseJSON3ApplicationJSONPatchQueryPlusJSON
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationjsonPatchQueryJSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == http.StatusOK:
 		var dest N200ResourcePatchResponseJSONApplicationJSON
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/merge-patch+json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/merge-patch+json" && rsp.StatusCode == http.StatusOK:
 		var dest N200ResourcePatchResponseJSON4ApplicationMergePatchPlusJSON
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3280,7 +3280,7 @@ func ParseGetStatusResponse2(rsp *http.Response) (*GetStatusResponse2, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest GetStatusResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -3306,7 +3306,7 @@ func ParseGetZapResponse(rsp *http.Response) (*GetZapResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest ZapResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/outputoptions/name-normalizer/to-camel-case-with-additional-initialisms/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/to-camel-case-with-additional-initialisms/name_normalizer.gen.go
@@ -350,7 +350,7 @@ func ParseGetHTTPPetResponse(rsp *http.Response) (*GetHTTPPetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/outputoptions/name-normalizer/to-camel-case-with-digits/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/to-camel-case-with-digits/name_normalizer.gen.go
@@ -350,7 +350,7 @@ func ParseGetHttpPetResponse(rsp *http.Response) (*GetHttpPetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/outputoptions/name-normalizer/to-camel-case-with-initialisms/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/to-camel-case-with-initialisms/name_normalizer.gen.go
@@ -350,7 +350,7 @@ func ParseGetHTTPPetResponse(rsp *http.Response) (*GetHTTPPetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/outputoptions/name-normalizer/to-camel-case/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/to-camel-case/name_normalizer.gen.go
@@ -350,7 +350,7 @@ func ParseGetHttpPetResponse(rsp *http.Response) (*GetHttpPetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/outputoptions/name-normalizer/unset/name_normalizer.gen.go
+++ b/internal/test/outputoptions/name-normalizer/unset/name_normalizer.gen.go
@@ -350,7 +350,7 @@ func ParseGetHttpPetResponse(rsp *http.Response) (*GetHttpPetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Pet
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/outputoptions/response-body-getters/enabled/response_body_getters.gen.go
+++ b/internal/test/outputoptions/response-body-getters/enabled/response_body_getters.gen.go
@@ -266,7 +266,7 @@ func ParseGetThingResponse(rsp *http.Response) (*GetThingResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Thing
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/outputoptions/response-body-getters/skipped/response_body_getters.gen.go
+++ b/internal/test/outputoptions/response-body-getters/skipped/response_body_getters.gen.go
@@ -251,7 +251,7 @@ func ParseGetThingResponse(rsp *http.Response) (*GetThingResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Thing
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/pathalias/client.gen.go
+++ b/internal/test/pathalias/client.gen.go
@@ -333,7 +333,7 @@ func ParseGetTestResponse(rsp *http.Response) (*GetTestResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest B
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -359,7 +359,7 @@ func ParseGetTestAlias0Response(rsp *http.Response) (*GetTestAlias0Response, err
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest B
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -1328,7 +1328,7 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest struct {
 			AnyType1 *AnyType1 `json:"anyType1,omitempty"`
 
@@ -1362,14 +1362,14 @@ func ParseIssue1051Response(rsp *http.Response) (*Issue1051Response, error) {
 	}
 
 	switch {
-	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == http.StatusOK:
 		var dest map[string]interface{}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/vnd.something.v1+json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/vnd.something.v1+json" && rsp.StatusCode == http.StatusOK:
 		var dest map[string]interface{}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -1395,7 +1395,7 @@ func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest GenericObject
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -1409,21 +1409,21 @@ func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
 		}
 		response.JSONDefault = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "xml") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "xml") && rsp.StatusCode == http.StatusOK:
 		var dest GenericObject
 		if err := xml.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.XML200 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "yaml") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "yaml") && rsp.StatusCode == http.StatusOK:
 		var dest GenericObject
 		if err := yaml.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.YAML200 = &dest
 
-	case rsp.StatusCode == 200:
+	case rsp.StatusCode == http.StatusOK:
 	// Content-type (text/markdown) unsupported
 
 	case true:
@@ -1496,7 +1496,7 @@ func ParseGetIssues375Response(rsp *http.Response) (*GetIssues375Response, error
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest EnumInObjInArray
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -1554,7 +1554,7 @@ func ParseIssue975Response(rsp *http.Response) (*Issue975Response, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest DeprecatedProperty
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -625,7 +625,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -633,7 +633,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 type JSONExample400Response = BadrequestResponse
 
 func (response JSONExample400Response) VisitJSONExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -660,7 +660,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -669,7 +669,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 type MultipartExample400Response = BadrequestResponse
 
 func (response MultipartExample400Response) VisitMultipartExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -696,7 +696,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", mime.FormatMediaType("multipart/related", map[string]string{"boundary": writer.Boundary()}))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -705,7 +705,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 type MultipartRelatedExample400Response = BadrequestResponse
 
 func (response MultipartRelatedExample400Response) VisitMultipartRelatedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -739,7 +739,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -753,7 +753,7 @@ func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultiple
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -769,7 +769,7 @@ func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultiple
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -784,7 +784,7 @@ func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipl
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -795,7 +795,7 @@ type MultipleRequestAndResponseTypes200TextResponse string
 func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -804,7 +804,7 @@ func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequ
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -831,7 +831,7 @@ func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(204)
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 
@@ -852,7 +852,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -860,7 +860,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 type RequiredJSONBody400Response = BadrequestResponse
 
 func (response RequiredJSONBody400Response) VisitRequiredJSONBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -886,7 +886,7 @@ type RequiredTextBody200TextResponse string
 func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -895,7 +895,7 @@ func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w 
 type RequiredTextBody400Response = BadrequestResponse
 
 func (response RequiredTextBody400Response) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -921,7 +921,7 @@ type ReservedGoKeywordParameters200TextResponse string
 func (response ReservedGoKeywordParameters200TextResponse) VisitReservedGoKeywordParametersResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -946,7 +946,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -954,7 +954,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 type ReusableResponses400Response = BadrequestResponse
 
 func (response ReusableResponses400Response) VisitReusableResponsesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -980,7 +980,7 @@ type TextExample200TextResponse string
 func (response TextExample200TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -989,7 +989,7 @@ func (response TextExample200TextResponse) VisitTextExampleResponse(w http.Respo
 type TextExample400Response = BadrequestResponse
 
 func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1021,7 +1021,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -1033,7 +1033,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 type UnknownExample400Response = BadrequestResponse
 
 func (response UnknownExample400Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1067,7 +1067,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -1079,7 +1079,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 type UnspecifiedContentType400Response = BadrequestResponse
 
 func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1087,7 +1087,7 @@ type UnspecifiedContentType401Response struct {
 }
 
 func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(401)
+	w.WriteHeader(http.StatusUnauthorized)
 	return nil
 }
 
@@ -1095,7 +1095,7 @@ type UnspecifiedContentType403Response struct {
 }
 
 func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(403)
+	w.WriteHeader(http.StatusForbidden)
 	return nil
 }
 
@@ -1125,7 +1125,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -1133,7 +1133,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 type URLEncodedExample400Response = BadrequestResponse
 
 func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1182,7 +1182,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1190,7 +1190,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 type HeadersExample400Response = BadrequestResponse
 
 func (response HeadersExample400Response) VisitHeadersExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1230,7 +1230,7 @@ func (response UnionExample200ApplicationAlternativePlusJSONResponse) VisitUnion
 	w.Header().Set("Content-Type", "application/alternative+json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1249,7 +1249,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1257,7 +1257,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 type UnionExample400Response = BadrequestResponse
 
 func (response UnionExample400Response) VisitUnionExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 

--- a/internal/test/strict-server/client/client.gen.go
+++ b/internal/test/strict-server/client/client.gen.go
@@ -2087,7 +2087,7 @@ func ParseJSONExampleResponse(rsp *http.Response) (*JSONExampleResponse, error) 
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Example
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -2145,14 +2145,23 @@ func ParseMultipleRequestAndResponseTypesResponse(rsp *http.Response) (*Multiple
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Example
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
 
-	case rsp.StatusCode == 200:
+	case rsp.StatusCode == http.StatusOK:
+	// Content-type (application/x-www-form-urlencoded) unsupported
+
+	case rsp.StatusCode == http.StatusOK:
+	// Content-type (image/png) unsupported
+
+	case rsp.StatusCode == http.StatusOK:
+	// Content-type (multipart/form-data) unsupported
+
+	case rsp.StatusCode == http.StatusOK:
 		// Content-type (text/plain) unsupported
 
 	}
@@ -2190,7 +2199,7 @@ func ParseRequiredJSONBodyResponse(rsp *http.Response) (*RequiredJSONBodyRespons
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Example
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -2248,7 +2257,7 @@ func ParseReusableResponsesResponse(rsp *http.Response) (*ReusableResponsesRespo
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Reusableresponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -2338,7 +2347,7 @@ func ParseHeadersExampleResponse(rsp *http.Response) (*HeadersExampleResponse, e
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == http.StatusOK:
 		var dest Example
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -2364,14 +2373,14 @@ func ParseUnionExampleResponse(rsp *http.Response) (*UnionExampleResponse, error
 	}
 
 	switch {
-	case rsp.Header.Get("Content-Type") == "application/alternative+json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/alternative+json" && rsp.StatusCode == http.StatusOK:
 		var dest Example
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.ApplicationalternativeJSON200 = &dest
 
-	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == 200:
+	case rsp.Header.Get("Content-Type") == "application/json" && rsp.StatusCode == http.StatusOK:
 		var dest UnionExample200JSONResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -352,7 +352,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -360,7 +360,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 type JSONExample400Response = BadrequestResponse
 
 func (response JSONExample400Response) VisitJSONExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -387,7 +387,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -396,7 +396,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 type MultipartExample400Response = BadrequestResponse
 
 func (response MultipartExample400Response) VisitMultipartExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -423,7 +423,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", mime.FormatMediaType("multipart/related", map[string]string{"boundary": writer.Boundary()}))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -432,7 +432,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 type MultipartRelatedExample400Response = BadrequestResponse
 
 func (response MultipartRelatedExample400Response) VisitMultipartRelatedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -466,7 +466,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -480,7 +480,7 @@ func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultiple
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -496,7 +496,7 @@ func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultiple
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -511,7 +511,7 @@ func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipl
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -522,7 +522,7 @@ type MultipleRequestAndResponseTypes200TextResponse string
 func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -531,7 +531,7 @@ func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequ
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -558,7 +558,7 @@ func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(204)
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 
@@ -579,7 +579,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -587,7 +587,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 type RequiredJSONBody400Response = BadrequestResponse
 
 func (response RequiredJSONBody400Response) VisitRequiredJSONBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -613,7 +613,7 @@ type RequiredTextBody200TextResponse string
 func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -622,7 +622,7 @@ func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w 
 type RequiredTextBody400Response = BadrequestResponse
 
 func (response RequiredTextBody400Response) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -648,7 +648,7 @@ type ReservedGoKeywordParameters200TextResponse string
 func (response ReservedGoKeywordParameters200TextResponse) VisitReservedGoKeywordParametersResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -673,7 +673,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -681,7 +681,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 type ReusableResponses400Response = BadrequestResponse
 
 func (response ReusableResponses400Response) VisitReusableResponsesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -707,7 +707,7 @@ type TextExample200TextResponse string
 func (response TextExample200TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -716,7 +716,7 @@ func (response TextExample200TextResponse) VisitTextExampleResponse(w http.Respo
 type TextExample400Response = BadrequestResponse
 
 func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -748,7 +748,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -760,7 +760,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 type UnknownExample400Response = BadrequestResponse
 
 func (response UnknownExample400Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -794,7 +794,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -806,7 +806,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 type UnspecifiedContentType400Response = BadrequestResponse
 
 func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -814,7 +814,7 @@ type UnspecifiedContentType401Response struct {
 }
 
 func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(401)
+	w.WriteHeader(http.StatusUnauthorized)
 	return nil
 }
 
@@ -822,7 +822,7 @@ type UnspecifiedContentType403Response struct {
 }
 
 func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(403)
+	w.WriteHeader(http.StatusForbidden)
 	return nil
 }
 
@@ -852,7 +852,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -860,7 +860,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 type URLEncodedExample400Response = BadrequestResponse
 
 func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -909,7 +909,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -917,7 +917,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 type HeadersExample400Response = BadrequestResponse
 
 func (response HeadersExample400Response) VisitHeadersExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -957,7 +957,7 @@ func (response UnionExample200ApplicationAlternativePlusJSONResponse) VisitUnion
 	w.Header().Set("Content-Type", "application/alternative+json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -976,7 +976,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -984,7 +984,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 type UnionExample400Response = BadrequestResponse
 
 func (response UnionExample400Response) VisitUnionExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 

--- a/internal/test/strict-server/fiber/server.gen.go
+++ b/internal/test/strict-server/fiber/server.gen.go
@@ -487,7 +487,7 @@ type JSONExample200JSONResponse Example
 
 func (response JSONExample200JSONResponse) VisitJSONExampleResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/json")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -495,7 +495,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(ctx *fiber.C
 type JSONExample400Response = BadrequestResponse
 
 func (response JSONExample400Response) VisitJSONExampleResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -521,7 +521,7 @@ type MultipartExample200MultipartResponse func(writer *multipart.Writer) error
 func (response MultipartExample200MultipartResponse) VisitMultipartExampleResponse(ctx *fiber.Ctx) error {
 	writer := multipart.NewWriter(ctx.Response().BodyWriter())
 	ctx.Response().Header.Set("Content-Type", writer.FormDataContentType())
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -530,7 +530,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 type MultipartExample400Response = BadrequestResponse
 
 func (response MultipartExample400Response) VisitMultipartExampleResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -556,7 +556,7 @@ type MultipartRelatedExample200MultipartResponse func(writer *multipart.Writer) 
 func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelatedExampleResponse(ctx *fiber.Ctx) error {
 	writer := multipart.NewWriter(ctx.Response().BodyWriter())
 	ctx.Response().Header.Set("Content-Type", mime.FormatMediaType("multipart/related", map[string]string{"boundary": writer.Boundary()}))
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -565,7 +565,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 type MultipartRelatedExample400Response = BadrequestResponse
 
 func (response MultipartRelatedExample400Response) VisitMultipartRelatedExampleResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -594,7 +594,7 @@ type MultipleRequestAndResponseTypes200JSONResponse Example
 
 func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/json")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -603,7 +603,7 @@ type MultipleRequestAndResponseTypes200FormdataResponse Example
 
 func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	if form, err := runtime.MarshalForm(response, nil); err != nil {
 		return err
@@ -623,7 +623,7 @@ func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultiple
 	if response.ContentLength != 0 {
 		ctx.Response().Header.Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -637,7 +637,7 @@ type MultipleRequestAndResponseTypes200MultipartResponse func(writer *multipart.
 func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipleRequestAndResponseTypesResponse(ctx *fiber.Ctx) error {
 	writer := multipart.NewWriter(ctx.Response().BodyWriter())
 	ctx.Response().Header.Set("Content-Type", writer.FormDataContentType())
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -647,7 +647,7 @@ type MultipleRequestAndResponseTypes200TextResponse string
 
 func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "text/plain")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	_, err := ctx.WriteString(string(response))
 	return err
@@ -656,7 +656,7 @@ func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequ
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -683,7 +683,7 @@ func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(ctx *f
 	if response.Headers.OptionalHeader != nil {
 		ctx.Response().Header.Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	ctx.Status(204)
+	ctx.Status(http.StatusNoContent)
 	return nil
 }
 
@@ -699,7 +699,7 @@ type RequiredJSONBody200JSONResponse Example
 
 func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/json")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -707,7 +707,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(ct
 type RequiredJSONBody400Response = BadrequestResponse
 
 func (response RequiredJSONBody400Response) VisitRequiredJSONBodyResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -732,7 +732,7 @@ type RequiredTextBody200TextResponse string
 
 func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "text/plain")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	_, err := ctx.WriteString(string(response))
 	return err
@@ -741,7 +741,7 @@ func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(ct
 type RequiredTextBody400Response = BadrequestResponse
 
 func (response RequiredTextBody400Response) VisitRequiredTextBodyResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -766,7 +766,7 @@ type ReservedGoKeywordParameters200TextResponse string
 
 func (response ReservedGoKeywordParameters200TextResponse) VisitReservedGoKeywordParametersResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "text/plain")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	_, err := ctx.WriteString(string(response))
 	return err
@@ -786,7 +786,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 	ctx.Response().Header.Set("header1", fmt.Sprint(response.Headers.Header1))
 	ctx.Response().Header.Set("header2", fmt.Sprint(response.Headers.Header2))
 	ctx.Response().Header.Set("Content-Type", "application/json")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response.Body)
 }
@@ -794,7 +794,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 type ReusableResponses400Response = BadrequestResponse
 
 func (response ReusableResponses400Response) VisitReusableResponsesResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -819,7 +819,7 @@ type TextExample200TextResponse string
 
 func (response TextExample200TextResponse) VisitTextExampleResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "text/plain")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	_, err := ctx.WriteString(string(response))
 	return err
@@ -828,7 +828,7 @@ func (response TextExample200TextResponse) VisitTextExampleResponse(ctx *fiber.C
 type TextExample400Response = BadrequestResponse
 
 func (response TextExample400Response) VisitTextExampleResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -859,7 +859,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(ct
 	if response.ContentLength != 0 {
 		ctx.Response().Header.Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -871,7 +871,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(ct
 type UnknownExample400Response = BadrequestResponse
 
 func (response UnknownExample400Response) VisitUnknownExampleResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -904,7 +904,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 	if response.ContentLength != 0 {
 		ctx.Response().Header.Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -916,7 +916,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 type UnspecifiedContentType400Response = BadrequestResponse
 
 func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -924,7 +924,7 @@ type UnspecifiedContentType401Response struct {
 }
 
 func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(ctx *fiber.Ctx) error {
-	ctx.Status(401)
+	ctx.Status(http.StatusUnauthorized)
 	return nil
 }
 
@@ -932,7 +932,7 @@ type UnspecifiedContentType403Response struct {
 }
 
 func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(ctx *fiber.Ctx) error {
-	ctx.Status(403)
+	ctx.Status(http.StatusForbidden)
 	return nil
 }
 
@@ -957,7 +957,7 @@ type URLEncodedExample200FormdataResponse Example
 
 func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	if form, err := runtime.MarshalForm(response, nil); err != nil {
 		return err
@@ -970,7 +970,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 type URLEncodedExample400Response = BadrequestResponse
 
 func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -1014,7 +1014,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(ctx *f
 		ctx.Response().Header.Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
 	ctx.Response().Header.Set("Content-Type", "application/json")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response.Body)
 }
@@ -1022,7 +1022,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(ctx *f
 type HeadersExample400Response = BadrequestResponse
 
 func (response HeadersExample400Response) VisitHeadersExampleResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 
@@ -1057,7 +1057,7 @@ func (response UnionExample200ApplicationAlternativePlusJSONResponse) VisitUnion
 	ctx.Response().Header.Set("header1", fmt.Sprint(response.Headers.Header1))
 	ctx.Response().Header.Set("header2", fmt.Sprint(response.Headers.Header2))
 	ctx.Response().Header.Set("Content-Type", "application/alternative+json")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response.Body)
 }
@@ -1071,7 +1071,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(ctx *fiber
 	ctx.Response().Header.Set("header1", fmt.Sprint(response.Headers.Header1))
 	ctx.Response().Header.Set("header2", fmt.Sprint(response.Headers.Header2))
 	ctx.Response().Header.Set("Content-Type", "application/json")
-	ctx.Status(200)
+	ctx.Status(http.StatusOK)
 
 	return ctx.JSON(&response.Body.union)
 }
@@ -1079,7 +1079,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(ctx *fiber
 type UnionExample400Response = BadrequestResponse
 
 func (response UnionExample400Response) VisitUnionExampleResponse(ctx *fiber.Ctx) error {
-	ctx.Status(400)
+	ctx.Status(http.StatusBadRequest)
 	return nil
 }
 

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -412,7 +412,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -420,7 +420,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 type JSONExample400Response = BadrequestResponse
 
 func (response JSONExample400Response) VisitJSONExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -447,7 +447,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -456,7 +456,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 type MultipartExample400Response = BadrequestResponse
 
 func (response MultipartExample400Response) VisitMultipartExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -483,7 +483,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", mime.FormatMediaType("multipart/related", map[string]string{"boundary": writer.Boundary()}))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -492,7 +492,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 type MultipartRelatedExample400Response = BadrequestResponse
 
 func (response MultipartRelatedExample400Response) VisitMultipartRelatedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -526,7 +526,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -540,7 +540,7 @@ func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultiple
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -556,7 +556,7 @@ func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultiple
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -571,7 +571,7 @@ func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipl
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -582,7 +582,7 @@ type MultipleRequestAndResponseTypes200TextResponse string
 func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -591,7 +591,7 @@ func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequ
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -618,7 +618,7 @@ func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(204)
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 
@@ -639,7 +639,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -647,7 +647,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 type RequiredJSONBody400Response = BadrequestResponse
 
 func (response RequiredJSONBody400Response) VisitRequiredJSONBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -673,7 +673,7 @@ type RequiredTextBody200TextResponse string
 func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -682,7 +682,7 @@ func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w 
 type RequiredTextBody400Response = BadrequestResponse
 
 func (response RequiredTextBody400Response) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -708,7 +708,7 @@ type ReservedGoKeywordParameters200TextResponse string
 func (response ReservedGoKeywordParameters200TextResponse) VisitReservedGoKeywordParametersResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -733,7 +733,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -741,7 +741,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 type ReusableResponses400Response = BadrequestResponse
 
 func (response ReusableResponses400Response) VisitReusableResponsesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -767,7 +767,7 @@ type TextExample200TextResponse string
 func (response TextExample200TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -776,7 +776,7 @@ func (response TextExample200TextResponse) VisitTextExampleResponse(w http.Respo
 type TextExample400Response = BadrequestResponse
 
 func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -808,7 +808,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -820,7 +820,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 type UnknownExample400Response = BadrequestResponse
 
 func (response UnknownExample400Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -854,7 +854,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -866,7 +866,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 type UnspecifiedContentType400Response = BadrequestResponse
 
 func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -874,7 +874,7 @@ type UnspecifiedContentType401Response struct {
 }
 
 func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(401)
+	w.WriteHeader(http.StatusUnauthorized)
 	return nil
 }
 
@@ -882,7 +882,7 @@ type UnspecifiedContentType403Response struct {
 }
 
 func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(403)
+	w.WriteHeader(http.StatusForbidden)
 	return nil
 }
 
@@ -912,7 +912,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -920,7 +920,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 type URLEncodedExample400Response = BadrequestResponse
 
 func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -969,7 +969,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -977,7 +977,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 type HeadersExample400Response = BadrequestResponse
 
 func (response HeadersExample400Response) VisitHeadersExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1017,7 +1017,7 @@ func (response UnionExample200ApplicationAlternativePlusJSONResponse) VisitUnion
 	w.Header().Set("Content-Type", "application/alternative+json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1036,7 +1036,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1044,7 +1044,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 type UnionExample400Response = BadrequestResponse
 
 func (response UnionExample400Response) VisitUnionExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 

--- a/internal/test/strict-server/gorilla/server.gen.go
+++ b/internal/test/strict-server/gorilla/server.gen.go
@@ -530,7 +530,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -538,7 +538,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 type JSONExample400Response = BadrequestResponse
 
 func (response JSONExample400Response) VisitJSONExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -565,7 +565,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -574,7 +574,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 type MultipartExample400Response = BadrequestResponse
 
 func (response MultipartExample400Response) VisitMultipartExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -601,7 +601,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", mime.FormatMediaType("multipart/related", map[string]string{"boundary": writer.Boundary()}))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -610,7 +610,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 type MultipartRelatedExample400Response = BadrequestResponse
 
 func (response MultipartRelatedExample400Response) VisitMultipartRelatedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -644,7 +644,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -658,7 +658,7 @@ func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultiple
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -674,7 +674,7 @@ func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultiple
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -689,7 +689,7 @@ func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipl
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -700,7 +700,7 @@ type MultipleRequestAndResponseTypes200TextResponse string
 func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -709,7 +709,7 @@ func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequ
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -736,7 +736,7 @@ func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(204)
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 
@@ -757,7 +757,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -765,7 +765,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 type RequiredJSONBody400Response = BadrequestResponse
 
 func (response RequiredJSONBody400Response) VisitRequiredJSONBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -791,7 +791,7 @@ type RequiredTextBody200TextResponse string
 func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -800,7 +800,7 @@ func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w 
 type RequiredTextBody400Response = BadrequestResponse
 
 func (response RequiredTextBody400Response) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -826,7 +826,7 @@ type ReservedGoKeywordParameters200TextResponse string
 func (response ReservedGoKeywordParameters200TextResponse) VisitReservedGoKeywordParametersResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -851,7 +851,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -859,7 +859,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 type ReusableResponses400Response = BadrequestResponse
 
 func (response ReusableResponses400Response) VisitReusableResponsesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -885,7 +885,7 @@ type TextExample200TextResponse string
 func (response TextExample200TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -894,7 +894,7 @@ func (response TextExample200TextResponse) VisitTextExampleResponse(w http.Respo
 type TextExample400Response = BadrequestResponse
 
 func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -926,7 +926,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -938,7 +938,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 type UnknownExample400Response = BadrequestResponse
 
 func (response UnknownExample400Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -972,7 +972,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -984,7 +984,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 type UnspecifiedContentType400Response = BadrequestResponse
 
 func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -992,7 +992,7 @@ type UnspecifiedContentType401Response struct {
 }
 
 func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(401)
+	w.WriteHeader(http.StatusUnauthorized)
 	return nil
 }
 
@@ -1000,7 +1000,7 @@ type UnspecifiedContentType403Response struct {
 }
 
 func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(403)
+	w.WriteHeader(http.StatusForbidden)
 	return nil
 }
 
@@ -1030,7 +1030,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -1038,7 +1038,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 type URLEncodedExample400Response = BadrequestResponse
 
 func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1087,7 +1087,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1095,7 +1095,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 type HeadersExample400Response = BadrequestResponse
 
 func (response HeadersExample400Response) VisitHeadersExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1135,7 +1135,7 @@ func (response UnionExample200ApplicationAlternativePlusJSONResponse) VisitUnion
 	w.Header().Set("Content-Type", "application/alternative+json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1154,7 +1154,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1162,7 +1162,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 type UnionExample400Response = BadrequestResponse
 
 func (response UnionExample400Response) VisitUnionExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 

--- a/internal/test/strict-server/iris/server.gen.go
+++ b/internal/test/strict-server/iris/server.gen.go
@@ -309,7 +309,7 @@ type JSONExample200JSONResponse Example
 
 func (response JSONExample200JSONResponse) VisitJSONExampleResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -317,7 +317,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(ctx iris.Con
 type JSONExample400Response = BadrequestResponse
 
 func (response JSONExample400Response) VisitJSONExampleResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -343,7 +343,7 @@ type MultipartExample200MultipartResponse func(writer *multipart.Writer) error
 func (response MultipartExample200MultipartResponse) VisitMultipartExampleResponse(ctx iris.Context) error {
 	writer := multipart.NewWriter(ctx.ResponseWriter())
 	ctx.ResponseWriter().Header().Set("Content-Type", writer.FormDataContentType())
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -352,7 +352,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 type MultipartExample400Response = BadrequestResponse
 
 func (response MultipartExample400Response) VisitMultipartExampleResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -378,7 +378,7 @@ type MultipartRelatedExample200MultipartResponse func(writer *multipart.Writer) 
 func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelatedExampleResponse(ctx iris.Context) error {
 	writer := multipart.NewWriter(ctx.ResponseWriter())
 	ctx.ResponseWriter().Header().Set("Content-Type", mime.FormatMediaType("multipart/related", map[string]string{"boundary": writer.Boundary()}))
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -387,7 +387,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 type MultipartRelatedExample400Response = BadrequestResponse
 
 func (response MultipartRelatedExample400Response) VisitMultipartRelatedExampleResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -416,7 +416,7 @@ type MultipleRequestAndResponseTypes200JSONResponse Example
 
 func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -425,7 +425,7 @@ type MultipleRequestAndResponseTypes200FormdataResponse Example
 
 func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	if form, err := runtime.MarshalForm(response, nil); err != nil {
 		return err
@@ -445,7 +445,7 @@ func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultiple
 	if response.ContentLength != 0 {
 		ctx.ResponseWriter().Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -459,7 +459,7 @@ type MultipleRequestAndResponseTypes200MultipartResponse func(writer *multipart.
 func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipleRequestAndResponseTypesResponse(ctx iris.Context) error {
 	writer := multipart.NewWriter(ctx.ResponseWriter())
 	ctx.ResponseWriter().Header().Set("Content-Type", writer.FormDataContentType())
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -469,7 +469,7 @@ type MultipleRequestAndResponseTypes200TextResponse string
 
 func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "text/plain")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	_, err := ctx.WriteString(string(response))
 	return err
@@ -478,7 +478,7 @@ func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequ
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -505,7 +505,7 @@ func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(ctx ir
 	if response.Headers.OptionalHeader != nil {
 		ctx.ResponseWriter().Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	ctx.StatusCode(204)
+	ctx.StatusCode(http.StatusNoContent)
 	return nil
 }
 
@@ -521,7 +521,7 @@ type RequiredJSONBody200JSONResponse Example
 
 func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response)
 }
@@ -529,7 +529,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(ct
 type RequiredJSONBody400Response = BadrequestResponse
 
 func (response RequiredJSONBody400Response) VisitRequiredJSONBodyResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -554,7 +554,7 @@ type RequiredTextBody200TextResponse string
 
 func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "text/plain")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	_, err := ctx.WriteString(string(response))
 	return err
@@ -563,7 +563,7 @@ func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(ct
 type RequiredTextBody400Response = BadrequestResponse
 
 func (response RequiredTextBody400Response) VisitRequiredTextBodyResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -588,7 +588,7 @@ type ReservedGoKeywordParameters200TextResponse string
 
 func (response ReservedGoKeywordParameters200TextResponse) VisitReservedGoKeywordParametersResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "text/plain")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	_, err := ctx.WriteString(string(response))
 	return err
@@ -608,7 +608,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 	ctx.ResponseWriter().Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	ctx.ResponseWriter().Header().Set("header2", fmt.Sprint(response.Headers.Header2))
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response.Body)
 }
@@ -616,7 +616,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 type ReusableResponses400Response = BadrequestResponse
 
 func (response ReusableResponses400Response) VisitReusableResponsesResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -641,7 +641,7 @@ type TextExample200TextResponse string
 
 func (response TextExample200TextResponse) VisitTextExampleResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "text/plain")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	_, err := ctx.WriteString(string(response))
 	return err
@@ -650,7 +650,7 @@ func (response TextExample200TextResponse) VisitTextExampleResponse(ctx iris.Con
 type TextExample400Response = BadrequestResponse
 
 func (response TextExample400Response) VisitTextExampleResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -681,7 +681,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(ct
 	if response.ContentLength != 0 {
 		ctx.ResponseWriter().Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -693,7 +693,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(ct
 type UnknownExample400Response = BadrequestResponse
 
 func (response UnknownExample400Response) VisitUnknownExampleResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -726,7 +726,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 	if response.ContentLength != 0 {
 		ctx.ResponseWriter().Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -738,7 +738,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 type UnspecifiedContentType400Response = BadrequestResponse
 
 func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -746,7 +746,7 @@ type UnspecifiedContentType401Response struct {
 }
 
 func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(ctx iris.Context) error {
-	ctx.StatusCode(401)
+	ctx.StatusCode(http.StatusUnauthorized)
 	return nil
 }
 
@@ -754,7 +754,7 @@ type UnspecifiedContentType403Response struct {
 }
 
 func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(ctx iris.Context) error {
-	ctx.StatusCode(403)
+	ctx.StatusCode(http.StatusForbidden)
 	return nil
 }
 
@@ -779,7 +779,7 @@ type URLEncodedExample200FormdataResponse Example
 
 func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(ctx iris.Context) error {
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	if form, err := runtime.MarshalForm(response, nil); err != nil {
 		return err
@@ -792,7 +792,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 type URLEncodedExample400Response = BadrequestResponse
 
 func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -836,7 +836,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(ctx ir
 		ctx.ResponseWriter().Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response.Body)
 }
@@ -844,7 +844,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(ctx ir
 type HeadersExample400Response = BadrequestResponse
 
 func (response HeadersExample400Response) VisitHeadersExampleResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 
@@ -879,7 +879,7 @@ func (response UnionExample200ApplicationAlternativePlusJSONResponse) VisitUnion
 	ctx.ResponseWriter().Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	ctx.ResponseWriter().Header().Set("header2", fmt.Sprint(response.Headers.Header2))
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/alternative+json")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response.Body)
 }
@@ -893,7 +893,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(ctx iris.C
 	ctx.ResponseWriter().Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	ctx.ResponseWriter().Header().Set("header2", fmt.Sprint(response.Headers.Header2))
 	ctx.ResponseWriter().Header().Set("Content-Type", "application/json")
-	ctx.StatusCode(200)
+	ctx.StatusCode(http.StatusOK)
 
 	return ctx.JSON(&response.Body.union)
 }
@@ -901,7 +901,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(ctx iris.C
 type UnionExample400Response = BadrequestResponse
 
 func (response UnionExample400Response) VisitUnionExampleResponse(ctx iris.Context) error {
-	ctx.StatusCode(400)
+	ctx.StatusCode(http.StatusBadRequest)
 	return nil
 }
 

--- a/internal/test/strict-server/stdhttp/server.gen.go
+++ b/internal/test/strict-server/stdhttp/server.gen.go
@@ -524,7 +524,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -532,7 +532,7 @@ func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.Respo
 type JSONExample400Response = BadrequestResponse
 
 func (response JSONExample400Response) VisitJSONExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -559,7 +559,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -568,7 +568,7 @@ func (response MultipartExample200MultipartResponse) VisitMultipartExampleRespon
 type MultipartExample400Response = BadrequestResponse
 
 func (response MultipartExample400Response) VisitMultipartExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -595,7 +595,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", mime.FormatMediaType("multipart/related", map[string]string{"boundary": writer.Boundary()}))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -604,7 +604,7 @@ func (response MultipartRelatedExample200MultipartResponse) VisitMultipartRelate
 type MultipartRelatedExample400Response = BadrequestResponse
 
 func (response MultipartRelatedExample400Response) VisitMultipartRelatedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -638,7 +638,7 @@ func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequ
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -652,7 +652,7 @@ func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultiple
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -668,7 +668,7 @@ func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultiple
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -683,7 +683,7 @@ func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipl
 	writer := multipart.NewWriter(w)
 
 	w.Header().Set("Content-Type", writer.FormDataContentType())
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	defer writer.Close()
 	return response(writer)
@@ -694,7 +694,7 @@ type MultipleRequestAndResponseTypes200TextResponse string
 func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -703,7 +703,7 @@ func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequ
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
 
 func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -730,7 +730,7 @@ func (response NoContentHeaders204Response) VisitNoContentHeadersResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(204)
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 
@@ -751,7 +751,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -759,7 +759,7 @@ func (response RequiredJSONBody200JSONResponse) VisitRequiredJSONBodyResponse(w 
 type RequiredJSONBody400Response = BadrequestResponse
 
 func (response RequiredJSONBody400Response) VisitRequiredJSONBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -785,7 +785,7 @@ type RequiredTextBody200TextResponse string
 func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -794,7 +794,7 @@ func (response RequiredTextBody200TextResponse) VisitRequiredTextBodyResponse(w 
 type RequiredTextBody400Response = BadrequestResponse
 
 func (response RequiredTextBody400Response) VisitRequiredTextBodyResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -820,7 +820,7 @@ type ReservedGoKeywordParameters200TextResponse string
 func (response ReservedGoKeywordParameters200TextResponse) VisitReservedGoKeywordParametersResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -845,7 +845,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -853,7 +853,7 @@ func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(
 type ReusableResponses400Response = BadrequestResponse
 
 func (response ReusableResponses400Response) VisitReusableResponsesResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -879,7 +879,7 @@ type TextExample200TextResponse string
 func (response TextExample200TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(response))
 	return err
@@ -888,7 +888,7 @@ func (response TextExample200TextResponse) VisitTextExampleResponse(w http.Respo
 type TextExample400Response = BadrequestResponse
 
 func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -920,7 +920,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -932,7 +932,7 @@ func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w 
 type UnknownExample400Response = BadrequestResponse
 
 func (response UnknownExample400Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -966,7 +966,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 
 	if closer, ok := response.Body.(io.ReadCloser); ok {
 		defer closer.Close()
@@ -978,7 +978,7 @@ func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTy
 type UnspecifiedContentType400Response = BadrequestResponse
 
 func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -986,7 +986,7 @@ type UnspecifiedContentType401Response struct {
 }
 
 func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(401)
+	w.WriteHeader(http.StatusUnauthorized)
 	return nil
 }
 
@@ -994,7 +994,7 @@ type UnspecifiedContentType403Response struct {
 }
 
 func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
-	w.WriteHeader(403)
+	w.WriteHeader(http.StatusForbidden)
 	return nil
 }
 
@@ -1024,7 +1024,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 		return err
 	}
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(form.Encode()))
 	return err
 }
@@ -1032,7 +1032,7 @@ func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleRespo
 type URLEncodedExample400Response = BadrequestResponse
 
 func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1081,7 +1081,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 	if response.Headers.OptionalHeader != nil {
 		w.Header().Set("optional-header", fmt.Sprint(*response.Headers.OptionalHeader))
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1089,7 +1089,7 @@ func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http
 type HeadersExample400Response = BadrequestResponse
 
 func (response HeadersExample400Response) VisitHeadersExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 
@@ -1129,7 +1129,7 @@ func (response UnionExample200ApplicationAlternativePlusJSONResponse) VisitUnion
 	w.Header().Set("Content-Type", "application/alternative+json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1148,7 +1148,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
 	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := buf.WriteTo(w)
 	return err
 }
@@ -1156,7 +1156,7 @@ func (response UnionExample200JSONResponse) VisitUnionExampleResponse(w http.Res
 type UnionExample400Response = BadrequestResponse
 
 func (response UnionExample400Response) VisitUnionExampleResponse(w http.ResponseWriter) error {
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	return nil
 }
 

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -628,6 +628,83 @@ func (r ResponseDefinition) HasFixedStatusCode() bool {
 	return err == nil
 }
 
+// HttpStatusConstant returns the net/http constant name for a fixed status code (e.g. "http.StatusOK"),
+// or the raw integer string if no named constant exists.
+func (r ResponseDefinition) HttpStatusConstant() string {
+	return httpStatusConstant(r.StatusCode)
+}
+
+func httpStatusConstant(code string) string {
+	constants := map[string]string{
+		"100": "http.StatusContinue",
+		"101": "http.StatusSwitchingProtocols",
+		"102": "http.StatusProcessing",
+		"103": "http.StatusEarlyHints",
+		"200": "http.StatusOK",
+		"201": "http.StatusCreated",
+		"202": "http.StatusAccepted",
+		"203": "http.StatusNonAuthoritativeInfo",
+		"204": "http.StatusNoContent",
+		"205": "http.StatusResetContent",
+		"206": "http.StatusPartialContent",
+		"207": "http.StatusMultiStatus",
+		"208": "http.StatusAlreadyReported",
+		"226": "http.StatusIMUsed",
+		"300": "http.StatusMultipleChoices",
+		"301": "http.StatusMovedPermanently",
+		"302": "http.StatusFound",
+		"303": "http.StatusSeeOther",
+		"304": "http.StatusNotModified",
+		"305": "http.StatusUseProxy",
+		"307": "http.StatusTemporaryRedirect",
+		"308": "http.StatusPermanentRedirect",
+		"400": "http.StatusBadRequest",
+		"401": "http.StatusUnauthorized",
+		"402": "http.StatusPaymentRequired",
+		"403": "http.StatusForbidden",
+		"404": "http.StatusNotFound",
+		"405": "http.StatusMethodNotAllowed",
+		"406": "http.StatusNotAcceptable",
+		"407": "http.StatusProxyAuthRequired",
+		"408": "http.StatusRequestTimeout",
+		"409": "http.StatusConflict",
+		"410": "http.StatusGone",
+		"411": "http.StatusLengthRequired",
+		"412": "http.StatusPreconditionFailed",
+		"413": "http.StatusRequestEntityTooLarge",
+		"414": "http.StatusRequestURITooLong",
+		"415": "http.StatusUnsupportedMediaType",
+		"416": "http.StatusRequestedRangeNotSatisfiable",
+		"417": "http.StatusExpectationFailed",
+		"418": "http.StatusTeapot",
+		"421": "http.StatusMisdirectedRequest",
+		"422": "http.StatusUnprocessableEntity",
+		"423": "http.StatusLocked",
+		"424": "http.StatusFailedDependency",
+		"425": "http.StatusTooEarly",
+		"426": "http.StatusUpgradeRequired",
+		"428": "http.StatusPreconditionRequired",
+		"429": "http.StatusTooManyRequests",
+		"431": "http.StatusRequestHeaderFieldsTooLarge",
+		"451": "http.StatusUnavailableForLegalReasons",
+		"500": "http.StatusInternalServerError",
+		"501": "http.StatusNotImplemented",
+		"502": "http.StatusBadGateway",
+		"503": "http.StatusServiceUnavailable",
+		"504": "http.StatusGatewayTimeout",
+		"505": "http.StatusHTTPVersionNotSupported",
+		"506": "http.StatusVariantAlsoNegotiates",
+		"507": "http.StatusInsufficientStorage",
+		"508": "http.StatusLoopDetected",
+		"510": "http.StatusNotExtended",
+		"511": "http.StatusNetworkAuthenticationRequired",
+	}
+	if c, ok := constants[code]; ok {
+		return c
+	}
+	return code
+}
+
 func (r ResponseDefinition) GoName() string {
 	return SchemaNameToTypeName(r.StatusCode)
 }

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -162,8 +162,9 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 		// If there is no content-type then we have no unmarshaling to do:
 		if len(responseRef.Value.Content) == 0 {
 			caseAction := "break // No content-type"
-			caseClauseKey := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
-			unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
+			caseClause := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
+			caseKey := fmt.Sprintf("%s.%s", prefixLeastSpecific, typeDefinition.ResponseName)
+			unhandledCaseClauses[caseKey] = fmt.Sprintf("%s\n%s\n", caseClause, caseAction)
 			continue
 		}
 
@@ -238,8 +239,9 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			// Everything else:
 			default:
 				caseAction := fmt.Sprintf("// Content-type (%s) unsupported", contentTypeName)
-				caseClauseKey := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
-				unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
+				caseClause := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
+				caseKey := fmt.Sprintf("%s.%s.%s", prefixLeastSpecific, contentTypeName, typeDefinition.ResponseName)
+				unhandledCaseClauses[caseKey] = fmt.Sprintf("%s\n%s\n", caseClause, caseAction)
 			}
 		}
 	}
@@ -309,7 +311,7 @@ func getConditionOfResponseName(statusCodeVar, responseName string) string {
 	case "1XX", "2XX", "3XX", "4XX", "5XX":
 		return fmt.Sprintf("%s / 100 == %s", statusCodeVar, responseName[:1])
 	default:
-		return fmt.Sprintf("%s == %s", statusCodeVar, responseName)
+		return fmt.Sprintf("%s == %s", statusCodeVar, httpStatusConstant(responseName))
 	}
 }
 

--- a/pkg/codegen/templates/strict/strict-fiber-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-fiber-interface.tmpl
@@ -22,6 +22,7 @@
 
     {{range .Responses}}
         {{$statusCode := .StatusCode -}}
+        {{$statusCodeHttpConstant := .HttpStatusConstant -}}
         {{$hasHeaders := ne 0 (len .Headers) -}}
         {{$fixedStatusCode := .HasFixedStatusCode -}}
         {{$isRef := .IsRef -}}
@@ -101,7 +102,7 @@
                         ctx.Response().Header.Set("Content-Length", fmt.Sprint(response.ContentLength))
                     }
                 {{end -}}
-                ctx.Status({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                ctx.Status({{if $fixedStatusCode}}{{$statusCodeHttpConstant}}{{else}}response.StatusCode{{end}})
                 {{$hasBodyVar := or ($hasHeaders) (not $fixedStatusCode) (not .IsSupported)}}
                 {{if .IsJSON }}
                     {{$hasUnionElements := ne 0 (len .Schema.UnionElements)}}
@@ -183,7 +184,7 @@
                         ctx.Response().Header.Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
                     {{end -}}
                 {{end -}}
-                ctx.Status({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                ctx.Status({{if $fixedStatusCode}}{{$statusCodeHttpConstant}}{{else}}response.StatusCode{{end}})
                 return nil
             }
         {{end}}

--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -22,6 +22,7 @@
 
     {{range .Responses}}
         {{$statusCode := .StatusCode -}}
+        {{$statusCodeHttpConstant := .HttpStatusConstant -}}
         {{$hasHeaders := ne 0 (len .Headers) -}}
         {{$fixedStatusCode := .HasFixedStatusCode -}}
         {{$isRef := .IsRef -}}
@@ -103,7 +104,7 @@
                             w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
                         {{end -}}
                     {{end -}}
-                    w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                    w.WriteHeader({{if $fixedStatusCode}}{{$statusCodeHttpConstant}}{{else}}response.StatusCode{{end}})
                     _, err := buf.WriteTo(w)
                     return err
                 {{else if eq .NameTag "Formdata" -}}
@@ -125,7 +126,7 @@
                             w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
                         {{end -}}
                     {{end -}}
-                    w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                    w.WriteHeader({{if $fixedStatusCode}}{{$statusCodeHttpConstant}}{{else}}response.StatusCode{{end}})
                     _, err = w.Write([]byte(form.Encode()))
                     return err
                 {{else -}}
@@ -148,7 +149,7 @@
                             w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
                         {{end -}}
                     {{end -}}
-                    w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                    w.WriteHeader({{if $fixedStatusCode}}{{$statusCodeHttpConstant}}{{else}}response.StatusCode{{end}})
 
                     {{if eq .NameTag "Text" -}}
                         _, err := w.Write([]byte({{if $hasBodyVar}}response.Body{{else}}response{{end}}))
@@ -222,7 +223,7 @@
                         w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
                     {{end -}}
                 {{end -}}
-                w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                w.WriteHeader({{if $fixedStatusCode}}{{$statusCodeHttpConstant}}{{else}}response.StatusCode{{end}})
                 return nil
             }
         {{end}}

--- a/pkg/codegen/templates/strict/strict-iris-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-iris-interface.tmpl
@@ -22,6 +22,7 @@
 
     {{range .Responses}}
         {{$statusCode := .StatusCode -}}
+        {{$statusCodeHttpConstant := .HttpStatusConstant -}}
         {{$hasHeaders := ne 0 (len .Headers) -}}
         {{$fixedStatusCode := .HasFixedStatusCode -}}
         {{$isRef := .IsRef -}}
@@ -101,7 +102,7 @@
                         ctx.ResponseWriter().Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
                     }
                 {{end -}}
-                ctx.StatusCode({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                ctx.StatusCode({{if $fixedStatusCode}}{{$statusCodeHttpConstant}}{{else}}response.StatusCode{{end}})
                 {{$hasBodyVar := or ($hasHeaders) (not $fixedStatusCode) (not .IsSupported)}}
                 {{if .IsJSON -}}
                     {{$hasUnionElements := ne 0 (len .Schema.UnionElements)}}
@@ -184,7 +185,7 @@
                         ctx.ResponseWriter().Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
                     {{end -}}
                 {{end -}}
-                ctx.StatusCode({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                ctx.StatusCode({{if $fixedStatusCode}}{{$statusCodeHttpConstant}}{{else}}response.StatusCode{{end}})
                 return nil
             }
         {{end}}


### PR DESCRIPTION
Closes: #2397

Replace raw integer literals in generated strict server code with named net/http constants (e.g. http.StatusOK instead of 200). Covers WriteHeader/Status/StatusCode calls in all strict server templates and status code comparisons in generated client switch statements.