### PR TITLE
chore: downgrade Go requirement to 1.25.0

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/oapi-codegen/oapi-codegen/v2/examples
 
-go 1.25.9
+go 1.25.0
 
 replace github.com/oapi-codegen/oapi-codegen/v2 => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oapi-codegen/oapi-codegen/v2
 
-go 1.25.9
+go 1.25.0
 
 require (
 	github.com/getkin/kin-openapi v0.140.0

--- a/internal/test/go.mod
+++ b/internal/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/oapi-codegen/oapi-codegen/v2/internal/test
 
-go 1.25.9
+go 1.25.0
 
 replace github.com/oapi-codegen/oapi-codegen/v2 => ../../
 


### PR DESCRIPTION
Instead of a `.9` release, which doesn't need to be required for our
use-cases, we can keep it at the minimum setting to reduce unnecessary
Go version bumps across our users.
