### PR TITLE
Make sure to escape user strings (#2433)

### DIFF
--- a/pkg/codegen/templates/chi/chi-handler.tmpl
+++ b/pkg/codegen/templates/chi/chi-handler.tmpl
@@ -43,7 +43,7 @@ ErrorHandlerFunc: options.ErrorHandlerFunc,
 }
 {{end}}
 {{range .}}r.Group(func(r chi.Router) {
-r.{{.Method | lower | title }}(options.BaseURL+"{{.Path | swaggerUriToChiUri}}", wrapper.{{.HandlerName}})
+r.{{.Method | lower | title }}(options.BaseURL+{{.Path | swaggerUriToChiUri | toGoString}}, wrapper.{{.HandlerName}})
 })
 {{end}}
 return r

--- a/pkg/codegen/templates/constants.tmpl
+++ b/pkg/codegen/templates/constants.tmpl
@@ -9,7 +9,7 @@ const (
 // Defines values for {{$Enum.TypeName}}.
 const (
 {{range $name, $value := $Enum.GetValues}}
-  {{$name}} {{$Enum.TypeName}} = {{$Enum.ValueWrapper}}{{$value}}{{$Enum.ValueWrapper -}}
+  {{$name}} {{$Enum.TypeName}} = {{if $Enum.ValueWrapper}}{{$value | toGoString}}{{else}}{{$value}}{{end -}}
 {{end}}
 )
 {{if not $.SkipEnumValidate}}

--- a/pkg/codegen/templates/echo/echo-register.tmpl
+++ b/pkg/codegen/templates/echo/echo-register.tmpl
@@ -47,6 +47,6 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
         Handler: si,
     }
 {{end}}
-{{range .}}router.{{.Method}}(options.BaseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.HandlerName}}, options.OperationMiddlewares["{{.MiddlewareKey}}"]...)
+{{range .}}router.{{.Method}}(options.BaseURL + {{.Path | swaggerUriToEchoUri | toGoString}}, wrapper.{{.HandlerName}}, options.OperationMiddlewares["{{.MiddlewareKey}}"]...)
 {{end}}
 }

--- a/pkg/codegen/templates/echo/v5/echo-register.tmpl
+++ b/pkg/codegen/templates/echo/v5/echo-register.tmpl
@@ -47,6 +47,6 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
         Handler: si,
     }
 {{end}}
-{{range .}}router.{{.Method}}(options.BaseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.HandlerName}}, options.OperationMiddlewares["{{.MiddlewareKey}}"]...)
+{{range .}}router.{{.Method}}(options.BaseURL + {{.Path | swaggerUriToEchoUri | toGoString}}, wrapper.{{.HandlerName}}, options.OperationMiddlewares["{{.MiddlewareKey}}"]...)
 {{end}}
 }

--- a/pkg/codegen/templates/fiber/fiber-handler.tmpl
+++ b/pkg/codegen/templates/fiber/fiber-handler.tmpl
@@ -22,6 +22,6 @@ for _, m := range options.Middlewares {
 }
 {{end}}
 {{range .}}
-router.{{.Method | lower | title }}(options.BaseURL+"{{.Path | swaggerUriToFiberUri}}", wrapper.{{.HandlerName}})
+router.{{.Method | lower | title }}(options.BaseURL+{{.Path | swaggerUriToFiberUri | toGoString}}, wrapper.{{.HandlerName}})
 {{end}}
 }

--- a/pkg/codegen/templates/gin/gin-register.tmpl
+++ b/pkg/codegen/templates/gin/gin-register.tmpl
@@ -28,6 +28,6 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
     {{end}}
 
     {{range . -}}
-    router.{{.Method }}(options.BaseURL+"{{.Path | swaggerUriToGinUri }}", wrapper.{{.HandlerName}})
+    router.{{.Method }}(options.BaseURL+{{.Path | swaggerUriToGinUri | toGoString}}, wrapper.{{.HandlerName}})
     {{end -}}
 }

--- a/pkg/codegen/templates/gorilla/gorilla-register.tmpl
+++ b/pkg/codegen/templates/gorilla/gorilla-register.tmpl
@@ -43,7 +43,7 @@ ErrorHandlerFunc: options.ErrorHandlerFunc,
 }
 {{end}}
 {{range .}}
-r.HandleFunc(options.BaseURL+"{{.Path | swaggerUriToGorillaUri }}", wrapper.{{.HandlerName}}).Methods({{.Method | httpMethodConstant}})
+r.HandleFunc(options.BaseURL+{{.Path | swaggerUriToGorillaUri | toGoString}}, wrapper.{{.HandlerName}}).Methods({{.Method | httpMethodConstant}})
 {{end}}
 return r
 }

--- a/pkg/codegen/templates/iris/iris-handler.tmpl
+++ b/pkg/codegen/templates/iris/iris-handler.tmpl
@@ -17,7 +17,7 @@ func RegisterHandlersWithOptions(router *iris.Application, si ServerInterface, o
         Handler: si,
     }
 {{end}}
-{{range .}}router.{{.Method | lower | title}}(options.BaseURL + "{{.Path | swaggerUriToIrisUri}}", wrapper.{{.HandlerName}})
+{{range .}}router.{{.Method | lower | title}}(options.BaseURL + {{.Path | swaggerUriToIrisUri | toGoString}}, wrapper.{{.HandlerName}})
 {{end}}
     router.Build()
 }

--- a/pkg/codegen/templates/stdhttp/std-http-handler.tmpl
+++ b/pkg/codegen/templates/stdhttp/std-http-handler.tmpl
@@ -49,7 +49,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 		ErrorHandlerFunc: options.ErrorHandlerFunc,
 	}
 {{end}}
-{{range .}}m.HandleFunc({{.Method | httpMethodConstant}}+" "+options.BaseURL+"{{.Path | swaggerUriToStdHttpUri}}", wrapper.{{.HandlerName}})
+{{range .}}m.HandleFunc({{.Method | httpMethodConstant}}+" "+options.BaseURL+{{.Path | swaggerUriToStdHttpUri | toGoString}}, wrapper.{{.HandlerName}})
 {{end}}
 	return m
 }


### PR DESCRIPTION
Spec-derived paths and string enum values were interpolated into generated Go source without escaping, so a value containing a quote could produce malformed output. Route paths in the server registration templates and string enum constants are now emitted through strconv.Quote (the existing toGoString helper) so they are always valid, properly-escaped Go string literals. Generated output is unchanged for normal specs.