### PR TITLE
fiber: fix extra brace in optional pass-through cookie binding

### DIFF
--- a/pkg/codegen/templates/fiber/fiber-middleware.tmpl
+++ b/pkg/codegen/templates/fiber/fiber-middleware.tmpl
@@ -145,7 +145,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *fiber.Ctx) error {
       if cookie != "" {
 
       {{- if .IsPassThrough}}
-        params.{{.GoName}} = {{if .HasOptionalPointer}}}&{{end}}cookie
+        params.{{.GoName}} = {{if .HasOptionalPointer}}&{{end}}cookie
       {{end}}
 
       {{- if .IsJson}}


### PR DESCRIPTION
The cookie `IsPassThrough` branch in the fiber v2 middleware template emitted `}&cookie` instead of `&cookie` when `HasOptionalPointer` is true, producing a compile error in any generated server with an optional pass-through cookie parameter. No committed fixture exercises such a parameter, which is how it went unnoticed.