### PR TITLE
fix: render Godoc correctly for renamed + union types

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -234,7 +234,7 @@ type Client struct {
 // ClientWithExtension defines model for ClientWithExtension.
 type ClientWithExtension = ClientRenamedByExtension
 
-// ClientRenamedByExtension defines model for .
+// ClientRenamedByExtension defines model for ClientWithExtension.
 type ClientRenamedByExtension struct {
 	Id   *float32 `json:"id,omitempty"`
 	Name string   `json:"name"`

--- a/examples/extensions/xgotypename/gen.go
+++ b/examples/extensions/xgotypename/gen.go
@@ -12,7 +12,7 @@ type Client struct {
 // ClientWithExtension defines model for ClientWithExtension.
 type ClientWithExtension = ClientRenamedByExtension
 
-// ClientRenamedByExtension defines model for .
+// ClientRenamedByExtension defines model for ClientWithExtension.
 type ClientRenamedByExtension struct {
 	Id   *float32 `json:"id,omitempty"`
 	Name string   `json:"name"`

--- a/internal/test/aggregates/anyof/anyof.gen.go
+++ b/internal/test/aggregates/anyof/anyof.gen.go
@@ -113,7 +113,7 @@ type Issue1189Test struct {
 	FieldC *Issue1189Test_FieldC `json:"fieldC,omitempty"`
 }
 
-// Issue1189TestFieldA0 defines model for .
+// Issue1189TestFieldA0 defines model for Issue1189Test.FieldA.0.
 type Issue1189TestFieldA0 = string
 
 // Issue1189TestFieldA1 defines model for Issue1189Test.FieldA.1.
@@ -127,7 +127,7 @@ type Issue1189Test_FieldA struct {
 // Issue1189TestFieldB defines model for Issue1189Test.FieldB.
 type Issue1189TestFieldB string
 
-// Issue1189TestFieldC0 defines model for .
+// Issue1189TestFieldC0 defines model for Issue1189Test.FieldC.0.
 type Issue1189TestFieldC0 = string
 
 // Issue1189TestFieldC1 defines model for Issue1189Test.FieldC.1.
@@ -143,13 +143,13 @@ type ParamAnyOf struct {
 	union json.RawMessage
 }
 
-// ParamAnyOf0 defines model for .
+// ParamAnyOf0 defines model for ParamAnyOf.0.
 type ParamAnyOf0 struct {
 	Item1 string `json:"item1"`
 	Item2 string `json:"item2"`
 }
 
-// ParamAnyOf1 defines model for .
+// ParamAnyOf1 defines model for ParamAnyOf.1.
 type ParamAnyOf1 struct {
 	Item2 *string `json:"item2,omitempty"`
 	Item3 *string `json:"item3,omitempty"`
@@ -160,10 +160,10 @@ type ParamOneOf struct {
 	union json.RawMessage
 }
 
-// ParamOneOf0 defines model for .
+// ParamOneOf0 defines model for ParamOneOf.0.
 type ParamOneOf0 = int
 
-// ParamOneOf1 defines model for .
+// ParamOneOf1 defines model for ParamOneOf.1.
 type ParamOneOf1 = string
 
 // RefCat This is a cat ($ref anyOf case)

--- a/internal/test/aggregates/hoisting/hoisting_schemas.gen.go
+++ b/internal/test/aggregates/hoisting/hoisting_schemas.gen.go
@@ -9,7 +9,7 @@ type OuterTypeWithAnonymousInner struct {
 	Name  string                      `json:"name"`
 }
 
-// InnerRenamedAnonymousObject defines model for .
+// InnerRenamedAnonymousObject defines model for OuterTypeWithAnonymousInner.inner.
 type InnerRenamedAnonymousObject struct {
 	Id int `json:"id"`
 }

--- a/internal/test/aggregates/oneof/components.gen.go
+++ b/internal/test/aggregates/oneof/components.gen.go
@@ -29,22 +29,22 @@ type OneOfObject10 struct {
 	union json.RawMessage
 }
 
-// OneOfObject100 defines model for .
+// OneOfObject100 defines model for OneOfObject10.0.
 type OneOfObject100 = interface{}
 
-// OneOfObject101 defines model for .
+// OneOfObject101 defines model for OneOfObject10.1.
 type OneOfObject101 = interface{}
 
 // OneOfObject11 additional properties of oneOf
 type OneOfObject11 map[string]OneOfObject11_AdditionalProperties
 
-// OneOfObject110 defines model for .
+// OneOfObject110 defines model for OneOfObject11.0.
 type OneOfObject110 = bool
 
-// OneOfObject111 defines model for .
+// OneOfObject111 defines model for OneOfObject11.1.
 type OneOfObject111 = float32
 
-// OneOfObject112 defines model for .
+// OneOfObject112 defines model for OneOfObject11.2.
 type OneOfObject112 = string
 
 // OneOfObject11_AdditionalProperties defines model for OneOfObject11.AdditionalProperties.
@@ -57,10 +57,10 @@ type OneOfObject12 struct {
 	union json.RawMessage
 }
 
-// OneOfObject120 defines model for .
+// OneOfObject120 defines model for OneOfObject12.0.
 type OneOfObject120 = string
 
-// OneOfObject121 defines model for .
+// OneOfObject121 defines model for OneOfObject12.1.
 type OneOfObject121 = float32
 
 // OneOfObject13 oneOf with fixed discriminator and other fields allowed
@@ -75,15 +75,15 @@ type OneOfObject2 struct {
 	union json.RawMessage
 }
 
-// OneOfObject20 defines model for .
+// OneOfObject20 defines model for OneOfObject2.0.
 type OneOfObject20 struct {
 	Name *string `json:"name,omitempty"`
 }
 
-// OneOfObject21 defines model for .
+// OneOfObject21 defines model for OneOfObject2.1.
 type OneOfObject21 = []float32
 
-// OneOfObject22 defines model for .
+// OneOfObject22 defines model for OneOfObject2.2.
 type OneOfObject22 = bool
 
 // OneOfObject3 inline OneOf

--- a/internal/test/extensions/x_go_type/x_go_type.gen.go
+++ b/internal/test/extensions/x_go_type/x_go_type.gen.go
@@ -104,7 +104,7 @@ type MyTestRequestNestedField struct {
 	Field2 string `json:"field2"`
 }
 
-// MyTestRequest defines model for .
+// MyTestRequest defines model for Test.
 type MyTestRequest struct {
 	// Field1 A array of enum values
 	Field1 *[]TestField1 `json:"field1,omitempty"`

--- a/internal/test/naming/conflicts/conflicts.gen.go
+++ b/internal/test/naming/conflicts/conflicts.gen.go
@@ -120,10 +120,10 @@ type N200ResourcePatchResponseJSON2ApplicationJSONPatchPlusJSON struct {
 	union json.RawMessage
 }
 
-// N200ResourcePatchApplicationJSONPatchPlusJSON1 defines model for .
+// N200ResourcePatchApplicationJSONPatchPlusJSON1 defines model for 200ResourcePatch.ApplicationJSONPatchPlusJSON.1.
 type N200ResourcePatchApplicationJSONPatchPlusJSON1 = []Resource
 
-// N200ResourcePatchApplicationJSONPatchPlusJSON2 defines model for .
+// N200ResourcePatchApplicationJSONPatchPlusJSON2 defines model for 200ResourcePatch.ApplicationJSONPatchPlusJSON.2.
 type N200ResourcePatchApplicationJSONPatchPlusJSON2 = string
 
 // N200ResourcePatchResponseJSON3ApplicationJSONPatchQueryPlusJSON defines model for 200Resource_Patch.
@@ -131,10 +131,10 @@ type N200ResourcePatchResponseJSON3ApplicationJSONPatchQueryPlusJSON struct {
 	union json.RawMessage
 }
 
-// N200ResourcePatchApplicationJSONPatchQueryPlusJSON1 defines model for .
+// N200ResourcePatchApplicationJSONPatchQueryPlusJSON1 defines model for 200ResourcePatch.ApplicationJSONPatchQueryPlusJSON.1.
 type N200ResourcePatchApplicationJSONPatchQueryPlusJSON1 = []Resource
 
-// N200ResourcePatchApplicationJSONPatchQueryPlusJSON2 defines model for .
+// N200ResourcePatchApplicationJSONPatchQueryPlusJSON2 defines model for 200ResourcePatch.ApplicationJSONPatchQueryPlusJSON.2.
 type N200ResourcePatchApplicationJSONPatchQueryPlusJSON2 = string
 
 // N200ResourcePatchResponseJSON4ApplicationMergePatchPlusJSON defines model for 200Resource_Patch.

--- a/internal/test/naming/conflicts/conflicts.gen.go
+++ b/internal/test/naming/conflicts/conflicts.gen.go
@@ -80,7 +80,7 @@ type QueryResponse struct {
 // Qux defines model for Qux.
 type Qux = CustomQux
 
-// CustomQux defines model for .
+// CustomQux defines model for Qux.
 type CustomQux struct {
 	Label *string `json:"label,omitempty"`
 }

--- a/internal/test/options/name_normalizer/to_camel_case/name_normalizer.gen.go
+++ b/internal/test/options/name_normalizer/to_camel_case/name_normalizer.gen.go
@@ -31,12 +31,12 @@ type OneOf2things struct {
 	union json.RawMessage
 }
 
-// OneOf2things0 defines model for .
+// OneOf2things0 defines model for OneOf2things.0.
 type OneOf2things0 struct {
 	Id int `json:"id"`
 }
 
-// OneOf2things1 defines model for .
+// OneOf2things1 defines model for OneOf2things.1.
 type OneOf2things1 struct {
 	Id openapi_types.UUID `json:"id"`
 }

--- a/internal/test/options/name_normalizer/to_camel_case_with_additional_initialisms/name_normalizer.gen.go
+++ b/internal/test/options/name_normalizer/to_camel_case_with_additional_initialisms/name_normalizer.gen.go
@@ -31,12 +31,12 @@ type OneOf2Things struct {
 	union json.RawMessage
 }
 
-// OneOf2Things0 defines model for .
+// OneOf2Things0 defines model for OneOf2Things.0.
 type OneOf2Things0 struct {
 	ID int `json:"id"`
 }
 
-// OneOf2Things1 defines model for .
+// OneOf2Things1 defines model for OneOf2Things.1.
 type OneOf2Things1 struct {
 	ID openapi_types.UUID `json:"id"`
 }

--- a/internal/test/options/name_normalizer/to_camel_case_with_digits/name_normalizer.gen.go
+++ b/internal/test/options/name_normalizer/to_camel_case_with_digits/name_normalizer.gen.go
@@ -31,12 +31,12 @@ type OneOf2Things struct {
 	union json.RawMessage
 }
 
-// OneOf2Things0 defines model for .
+// OneOf2Things0 defines model for OneOf2Things.0.
 type OneOf2Things0 struct {
 	Id int `json:"id"`
 }
 
-// OneOf2Things1 defines model for .
+// OneOf2Things1 defines model for OneOf2Things.1.
 type OneOf2Things1 struct {
 	Id openapi_types.UUID `json:"id"`
 }

--- a/internal/test/options/name_normalizer/to_camel_case_with_initialisms/name_normalizer.gen.go
+++ b/internal/test/options/name_normalizer/to_camel_case_with_initialisms/name_normalizer.gen.go
@@ -31,12 +31,12 @@ type OneOf2Things struct {
 	union json.RawMessage
 }
 
-// OneOf2Things0 defines model for .
+// OneOf2Things0 defines model for OneOf2Things.0.
 type OneOf2Things0 struct {
 	ID int `json:"id"`
 }
 
-// OneOf2Things1 defines model for .
+// OneOf2Things1 defines model for OneOf2Things.1.
 type OneOf2Things1 struct {
 	ID openapi_types.UUID `json:"id"`
 }

--- a/internal/test/options/name_normalizer/unset/name_normalizer.gen.go
+++ b/internal/test/options/name_normalizer/unset/name_normalizer.gen.go
@@ -31,12 +31,12 @@ type OneOf2things struct {
 	union json.RawMessage
 }
 
-// OneOf2things0 defines model for .
+// OneOf2things0 defines model for OneOf2things.0.
 type OneOf2things0 struct {
 	Id int `json:"id"`
 }
 
-// OneOf2things1 defines model for .
+// OneOf2things1 defines model for OneOf2things.1.
 type OneOf2things1 struct {
 	Id openapi_types.UUID `json:"id"`
 }

--- a/internal/test/schemas/recursive/recursive.gen.go
+++ b/internal/test/schemas/recursive/recursive.gen.go
@@ -27,7 +27,7 @@ type FilterPredicate struct {
 	union json.RawMessage
 }
 
-// FilterPredicate1 defines model for .
+// FilterPredicate1 defines model for FilterPredicate.1.
 type FilterPredicate1 = []FilterPredicate
 
 // FilterPredicateOp defines model for FilterPredicateOp.
@@ -36,7 +36,7 @@ type FilterPredicateOp struct {
 	None *FilterPredicateOp_None `json:"$none,omitempty"`
 }
 
-// FilterPredicateOpAny0 defines model for .
+// FilterPredicateOpAny0 defines model for FilterPredicateOp.Any.0.
 type FilterPredicateOpAny0 = []FilterPredicate
 
 // FilterPredicateOp_Any defines model for FilterPredicateOp.Any.
@@ -44,7 +44,7 @@ type FilterPredicateOp_Any struct {
 	union json.RawMessage
 }
 
-// FilterPredicateOpNone1 defines model for .
+// FilterPredicateOpNone1 defines model for FilterPredicateOp.None.1.
 type FilterPredicateOpNone1 = []FilterPredicate
 
 // FilterPredicateOp_None defines model for FilterPredicateOp.None.
@@ -62,10 +62,10 @@ type FilterRangeValue struct {
 	union json.RawMessage
 }
 
-// FilterRangeValue0 defines model for .
+// FilterRangeValue0 defines model for FilterRangeValue.0.
 type FilterRangeValue0 = float32
 
-// FilterRangeValue1 defines model for .
+// FilterRangeValue1 defines model for FilterRangeValue.1.
 type FilterRangeValue1 = string
 
 // FilterValue defines model for FilterValue.
@@ -73,13 +73,13 @@ type FilterValue struct {
 	union json.RawMessage
 }
 
-// FilterValue0 defines model for .
+// FilterValue0 defines model for FilterValue.0.
 type FilterValue0 = float32
 
-// FilterValue1 defines model for .
+// FilterValue1 defines model for FilterValue.1.
 type FilterValue1 = string
 
-// FilterValue2 defines model for .
+// FilterValue2 defines model for FilterValue.2.
 type FilterValue2 = bool
 
 // NonRecursiveObject defines model for NonRecursiveObject.

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -1480,7 +1480,7 @@ func generateUnion(outSchema *Schema, elements openapi3.SchemaRefs, discriminato
 			if elementSchema.TypeDecl() == elementName {
 				elementSchema.GoType = elementName
 			} else {
-				td := TypeDefinition{Schema: elementSchema, TypeName: elementName}
+				td := TypeDefinition{Schema: elementSchema, TypeName: elementName, JsonName: strings.Join(elementPath, ".")}
 				outSchema.AdditionalTypes = append(outSchema.AdditionalTypes, td)
 				elementSchema.GoType = td.TypeName
 			}

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -924,6 +924,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 
 			newTypeDef := TypeDefinition{
 				TypeName: typeName,
+				JsonName: strings.Join(path, "."),
 				Schema:   outSchema,
 			}
 			outSchema = Schema{


### PR DESCRIPTION
As otherwise we see `defines model for .`, which isn't correct.


