### PR TITLE
Reject import-mapping keys that are JSON pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,11 @@ When you've got a large OpenAPI specification, you may find it useful to split t
 
 This is supported by `oapi-codegen`, through the ability to perform "Import Mapping".
 
+> [!NOTE]
+> The keys of `import-mapping` are the paths of the `$ref`'d documents — a relative file path or a URL, exactly as it is written in the `$ref` — and the values are the Go packages their types are generated into.
+>
+> A key cannot be a JSON pointer such as `#/components/schemas`. References within a single document always resolve to the package being generated, so there's nothing to map — if you want your models in a different Go package to your server, split them into their own spec file and map that file, as shown below.
+
 For instance, let's say that we have a large API, which has a user-facing API and an admin API, both of which use a common set of API models.
 
 In this case, we may have an Admin API that looks like:

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 )
 
 // defaultStreamingContentTypes are the regex patterns matched against
@@ -95,6 +96,16 @@ func (o Configuration) Validate() error {
 	if problems := o.OutputOptions.Validate(); problems != nil {
 		for k, v := range problems {
 			errs = append(errs, fmt.Errorf("`output-options` configuration for %v was incorrect: %v", k, v))
+		}
+	}
+
+	// import-mapping keys are the paths of $ref'd documents (a relative
+	// file path or URL). A JSON pointer key can never match anything —
+	// references within the same document always resolve to the package
+	// being generated — so it is a configuration mistake, not a mapping.
+	for _, specPath := range SortedMapKeys(o.ImportMapping) {
+		if strings.HasPrefix(specPath, "#") {
+			errs = append(errs, fmt.Errorf("`import-mapping` key %q is a JSON pointer, but keys must be the path or URL of a $ref'd document; references within the same document cannot be remapped to another package — see https://github.com/oapi-codegen/oapi-codegen/tree/main/examples/import-mapping", specPath))
 		}
 	}
 

--- a/pkg/codegen/configuration_test.go
+++ b/pkg/codegen/configuration_test.go
@@ -1,0 +1,34 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigurationValidateImportMappingKeys verifies that import-mapping
+// keys which are JSON pointers are rejected: keys must be the path or URL of
+// a $ref'd document, and same-document references can never be remapped.
+// Please see https://github.com/oapi-codegen/oapi-codegen/issues/2459
+func TestConfigurationValidateImportMappingKeys(t *testing.T) {
+	cfg := Configuration{
+		PackageName: "api",
+		Generate:    GenerateOptions{Models: true},
+		ImportMapping: map[string]string{
+			"#/components/schemas": "example.com/mymodule/dto",
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JSON pointer")
+	assert.Contains(t, err.Error(), `"#/components/schemas"`)
+
+	// Document paths and URLs are fine, as is the current-package mapping.
+	cfg.ImportMapping = map[string]string{
+		"../common/api.yaml":           "example.com/mymodule/common",
+		"https://example.com/api.yaml": "example.com/mymodule/remote",
+		"./sibling.yaml":               "-",
+	}
+	require.NoError(t, cfg.Validate())
+}


### PR DESCRIPTION
Closes: #2459

import-mapping keys are the paths of $ref'd documents — a relative file path or a URL — but users occasionally write a JSON pointer like "#/components/schemas" expecting internal references to be remapped to another Go package (seen in #2078). Such an entry can never match anything, since same-document references always resolve to the package being generated, so the user just sees unresolved types with no hint of the misconfiguration.

Configuration validation now rejects keys starting with "#" with an error explaining what keys must be and pointing at the import-mapping examples. This is an error rather than a warning because warnings are emitted to stderr and easily lost when generation output goes to stdout, and there is no legitimate configuration this rejects.

The README's Import Mapping section gains a note stating the same up front: keys are document paths, internal refs cannot be remapped, and schemas wanted in a separate package should be split into their own spec file.