### PR TITLE
chore: use go mod tidy instead of tidied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,6 @@ readme-toc-check: $(GOBIN)/mdtoc
 
 tidy-ci:
 	# for the root module, explicitly run the step, to prevent recursive calls
-	tidied -verbose
+	go mod tidy -diff
 	# then, for all child modules, use a module-managed `Makefile`
 	git ls-files '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $$(dirname {}) && make tidy-ci'

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,4 +15,4 @@ tidy:
 	go mod tidy
 
 tidy-ci:
-	tidied -verbose
+	go mod tidy -diff

--- a/internal/test/Makefile
+++ b/internal/test/Makefile
@@ -14,4 +14,4 @@ tidy:
 	go mod tidy
 
 tidy-ci:
-	tidied -verbose
+	go mod tidy -diff


### PR DESCRIPTION
The `tidied` is not needed, since we have `go mod tidy -diff`. From https://gitlab.com/jamietanna/tidied:

<img width="694" height="178" alt="image" src="https://github.com/user-attachments/assets/450bfe02-9076-4019-b739-159b59d4fa8d" />
