### PR TITLE
fix(stdhttp): reject mixed path-parameter segments at codegen

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -178,6 +178,11 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 	if err := ValidateSpec(spec); err != nil {
 		return "", err
 	}
+	if opts.Generate.StdHTTPServer {
+		if err := ValidateStdHTTPPaths(spec); err != nil {
+			return "", err
+		}
+	}
 
 	// if we are provided an override for the response type suffix update it
 	if opts.OutputOptions.ResponseTypeSuffix != "" {

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -15,6 +15,7 @@ package codegen
 
 import (
 	"bytes"
+	"errors"
 	"cmp"
 	"fmt"
 	"go/token"
@@ -680,6 +681,42 @@ func SwaggerUriToStdHttpUri(uri string) string {
 	}
 
 	return uri
+}
+
+// ValidateStdHTTPPath reports whether an OpenAPI path can be registered with
+// net/http ServeMux. ServeMux wildcards must occupy an entire path segment, so
+// mixed segments such as "{resourceId}:apply" are rejected at codegen time
+// instead of panicking at server startup (see #2488).
+func ValidateStdHTTPPath(path string) error {
+	for _, seg := range strings.Split(path, "/") {
+		if seg == "" || seg == "{$}" {
+			continue
+		}
+		loc := pathParamRE.FindStringIndex(seg)
+		if loc == nil {
+			// pure literal segment
+			continue
+		}
+		// Wildcard must be the entire segment.
+		if loc[0] != 0 || loc[1] != len(seg) {
+			return fmt.Errorf("path %q: segment %q mixes a path parameter with literal text; net/http ServeMux requires wildcards to occupy an entire path segment (std-http-server)", path, seg)
+		}
+	}
+	return nil
+}
+
+// ValidateStdHTTPPaths validates every path in the document for ServeMux.
+func ValidateStdHTTPPaths(spec *openapi3.T) error {
+	if spec == nil || spec.Paths == nil {
+		return nil
+	}
+	var errs []error
+	for _, path := range SortedMapKeys(spec.Paths.Map()) {
+		if err := ValidateStdHTTPPath(path); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // OrderedParamsFromUri returns the argument names, in order, in a given URI string, so for

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -706,12 +706,19 @@ func ValidateStdHTTPPath(path string) error {
 }
 
 // ValidateStdHTTPPaths validates every path in the document for ServeMux.
+// Paths whose operations have all been removed (e.g. by tag or operation-id
+// filtering) emit no routes, so they are skipped.
 func ValidateStdHTTPPaths(spec *openapi3.T) error {
 	if spec == nil || spec.Paths == nil {
 		return nil
 	}
 	var errs []error
-	for _, path := range SortedMapKeys(spec.Paths.Map()) {
+	pathMap := spec.Paths.Map()
+	for _, path := range SortedMapKeys(pathMap) {
+		pathItem := pathMap[path]
+		if pathItem == nil || len(pathItem.Operations()) == 0 {
+			continue
+		}
 		if err := ValidateStdHTTPPath(path); err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -837,3 +837,62 @@ func Test_replaceInitialism(t *testing.T) {
 		})
 	}
 }
+
+
+func TestValidateStdHTTPPath(t *testing.T) {
+	tests := []struct {
+		path    string
+		wantErr bool
+	}{
+		{"/resources/{resourceId}", false},
+		{"/resources/{resourceId}/apply", false},
+		{"/resources/{resourceId}:apply", true},
+		{"/resources/prefix{resourceId}", true},
+		{"/resources/{resourceId}suffix", true},
+		{"/pets:validate", false}, // pure literal segment with colon is fine for ServeMux
+		{"/path/{arg1}/{arg2}/foo", false},
+	}
+	for _, tt := range tests {
+		err := ValidateStdHTTPPath(tt.path)
+		if tt.wantErr && err == nil {
+			t.Errorf("path %q: expected error", tt.path)
+		}
+		if !tt.wantErr && err != nil {
+			t.Errorf("path %q: unexpected error: %v", tt.path, err)
+		}
+	}
+}
+
+func TestGenerateRejectsMixedServeMuxPathParam(t *testing.T) {
+	spec := `openapi: 3.0.3
+info:
+  title: mixed path param
+  version: 1.0.0
+paths:
+  /resources/{resourceId}:apply:
+    post:
+      operationId: applyResource
+      parameters:
+        - name: resourceId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Applied
+`
+	loader := openapi3.NewLoader()
+	swagger, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+
+	_, err = Generate(swagger, Configuration{
+		PackageName: "api",
+		Generate: GenerateOptions{
+			StdHTTPServer: true,
+			Models:        true,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mixes a path parameter")
+}

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -896,3 +896,49 @@ paths:
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "mixes a path parameter")
 }
+
+func TestGenerateAllowsMixedServeMuxPathParamWhenFilteredOut(t *testing.T) {
+	spec := `openapi: 3.0.3
+info:
+  title: mixed path param filtered out
+  version: 1.0.0
+paths:
+  /resources/{resourceId}:apply:
+    post:
+      operationId: applyResource
+      tags: [excluded]
+      parameters:
+        - name: resourceId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Applied
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+`
+	loader := openapi3.NewLoader()
+	swagger, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+
+	// Tag filtering removes the only operation on the mixed segment but leaves
+	// the path key in the spec; no route is emitted for it, so generation must
+	// succeed.
+	_, err = Generate(swagger, Configuration{
+		PackageName: "api",
+		Generate: GenerateOptions{
+			StdHTTPServer: true,
+			Models:        true,
+		},
+		OutputOptions: OutputOptions{
+			ExcludeTags: []string{"excluded"},
+		},
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
`std-http-server` previously generated ServeMux patterns for mixed wildcard+literal segments such as:

```
/resources/{resourceId}:apply
```

Registering that with `net/http.ServeMux` panics:

```
bad wildcard segment (must end with '}')
```

Maintainer guidance on #2488 prefers a **codegen-time error** over silent rewriting.

## Fix
- Add `ValidateStdHTTPPath` / `ValidateStdHTTPPaths`
- Run them from `Generate` when `StdHTTPServer` is enabled
- Reject any path segment that mixes a `{param}` with surrounding literals

## Test plan
- [x] `go test ./pkg/codegen/ -run 'TestValidateStdHTTPPath|TestGenerateRejectsMixedServeMuxPathParam|TestSwaggerUriToStdHttpUriUri'`

Fixes #2488
