### PR TITLE
fix: delegate JSON methods for inline union request bodies

### DIFF
--- a/internal/test/aggregates/hoisting/hoisting_implicit.gen.go
+++ b/internal/test/aggregates/hoisting/hoisting_implicit.gen.go
@@ -133,6 +133,14 @@ type PostBodyPropertyOneOfJSONRequestBody PostBodyPropertyOneOfJSONBody
 // PostBodyRootOneOfJSONRequestBody defines body for PostBodyRootOneOf for application/json ContentType.
 type PostBodyRootOneOfJSONRequestBody PostBodyRootOneOfJSONBody
 
+func (t PostBodyRootOneOfJSONRequestBody) MarshalJSON() ([]byte, error) {
+	return PostBodyRootOneOfJSONBody(t).MarshalJSON()
+}
+
+func (t *PostBodyRootOneOfJSONRequestBody) UnmarshalJSON(b []byte) error {
+	return (*PostBodyRootOneOfJSONBody)(t).UnmarshalJSON(b)
+}
+
 // TriggerCallbackJSONRequestBody defines body for TriggerCallback for application/json ContentType.
 type TriggerCallbackJSONRequestBody TriggerCallbackJSONBody
 
@@ -142,11 +150,27 @@ type WebhookBodyPropertyOneOfJSONRequestBody WebhookBodyPropertyOneOfJSONBody
 // WebhookBodyRootOneOfJSONRequestBody defines body for WebhookBodyRootOneOf for application/json ContentType.
 type WebhookBodyRootOneOfJSONRequestBody WebhookBodyRootOneOfJSONBody
 
+func (t WebhookBodyRootOneOfJSONRequestBody) MarshalJSON() ([]byte, error) {
+	return WebhookBodyRootOneOfJSONBody(t).MarshalJSON()
+}
+
+func (t *WebhookBodyRootOneOfJSONRequestBody) UnmarshalJSON(b []byte) error {
+	return (*WebhookBodyRootOneOfJSONBody)(t).UnmarshalJSON(b)
+}
+
 // CallbackBodyPropertyOneOfJSONRequestBody defines body for CallbackBodyPropertyOneOf for application/json ContentType.
 type CallbackBodyPropertyOneOfJSONRequestBody CallbackBodyPropertyOneOfJSONBody
 
 // CallbackBodyRootOneOfJSONRequestBody defines body for CallbackBodyRootOneOf for application/json ContentType.
 type CallbackBodyRootOneOfJSONRequestBody CallbackBodyRootOneOfJSONBody
+
+func (t CallbackBodyRootOneOfJSONRequestBody) MarshalJSON() ([]byte, error) {
+	return CallbackBodyRootOneOfJSONBody(t).MarshalJSON()
+}
+
+func (t *CallbackBodyRootOneOfJSONRequestBody) UnmarshalJSON(b []byte) error {
+	return (*CallbackBodyRootOneOfJSONBody)(t).UnmarshalJSON(b)
+}
 
 // AsImplicitCat returns the union data inside the PostBodyPropertyOneOfJSONBody_Pet as a ImplicitCat
 func (t PostBodyPropertyOneOfJSONBody_Pet) AsImplicitCat() (ImplicitCat, error) {

--- a/internal/test/aggregates/hoisting/hoisting_test.go
+++ b/internal/test/aggregates/hoisting/hoisting_test.go
@@ -162,6 +162,24 @@ func TestBodyRootOneOf_RoundTripCat(t *testing.T) {
 	require.Equal(t, cat, got)
 }
 
+func TestBodyRootOneOfRequestBody_RoundTripCat(t *testing.T) {
+	cat := ImplicitCat{Kind: Cat, Name: ptr("whiskers")}
+
+	var body PostBodyRootOneOfJSONBody
+	require.NoError(t, body.FromImplicitCat(cat))
+
+	requestBody := PostBodyRootOneOfJSONRequestBody(body)
+	b, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	var decoded PostBodyRootOneOfJSONRequestBody
+	require.NoError(t, json.Unmarshal(b, &decoded))
+
+	got, err := PostBodyRootOneOfJSONBody(decoded).AsImplicitCat()
+	require.NoError(t, err)
+	require.Equal(t, cat, got)
+}
+
 func TestBodyPropertyOneOf_RoundTripDog(t *testing.T) {
 	dog := ImplicitDog{Kind: Dog, Name: ptr("rex")}
 

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -92,6 +92,14 @@ func (s Schema) HasCustomMarshalJSON() bool {
 	return len(s.OAPISchema.OneOf) > 0 || len(s.OAPISchema.AnyOf) > 0
 }
 
+// HasCustomMarshalJSONForRequestBody reports whether a named request body
+// wrapper needs to delegate JSON marshaling to its underlying union type.
+// Unlike strict response types, request body wrappers have no direct union
+// encoding path, so local inline unions need delegation as well.
+func (s Schema) HasCustomMarshalJSONForRequestBody() bool {
+	return len(s.UnionElements) > 0 || s.HasCustomMarshalJSON()
+}
+
 func (s Schema) TypeDecl() string {
 	if s.IsRef() {
 		return s.RefType

--- a/pkg/codegen/templates/request-bodies.tmpl
+++ b/pkg/codegen/templates/request-bodies.tmpl
@@ -2,6 +2,7 @@
 {{range .Bodies}}
 {{if .IsSupported -}}
 {{$contentType := .ContentType -}}
+{{$isJSON := .IsJSON -}}
 {{with .TypeDef $opid}}
 // {{.TypeName}} defines body for {{$opid}} for {{$contentType}} ContentType.
 {{- with .DeprecationComment}}
@@ -9,6 +10,16 @@
 {{.}}
 {{- end}}
 type {{.TypeName}} {{if .IsAlias}}={{end}} {{.Schema.TypeDecl}}
+{{- if and $isJSON (not .IsAlias) .Schema.HasCustomMarshalJSONForRequestBody}}
+
+func (t {{.TypeName}}) MarshalJSON() ([]byte, error) {
+	return {{.Schema.TypeDecl}}(t).MarshalJSON()
+}
+
+func (t *{{.TypeName}}) UnmarshalJSON(b []byte) error {
+	return (*{{.Schema.TypeDecl}})(t).UnmarshalJSON(b)
+}
+{{- end}}
 {{end}}
 {{end}}
 {{end}}


### PR DESCRIPTION
## Problem

Fixes #2498.

Inline `oneOf` and `anyOf` request bodies generate an operation body type with custom JSON methods, followed by a distinct `...JSONRequestBody` type. Defined Go types do not inherit methods from their underlying type, so marshaling the request wrapper omits the private union payload and unmarshaling into it discards that payload.

The generated forwarding methods make `encoding/json` use the existing union implementation for the request wrapper, matching the approach used for strict response wrappers.



## Summary

- generate forwarding `MarshalJSON` and `UnmarshalJSON` methods for JSON request body wrappers backed by union types
- preserve the existing distinct request body types while delegating to their generated inline union implementations
- add request-wrapper round-trip coverage and regenerate the affected fixtures



## E2E testing

### OpenAPI schema

```yaml
paths:
  /demo:
    post:
      operationId: postDemo
      requestBody:
        required: true
        content:
          application/json:
            schema:
              type: object
              required: [type]
              properties:
                type:
                  type: string
                  enum: [foo]
              discriminator:
                propertyName: type
                mapping:
                  foo: "#/components/schemas/FooRequest"
              oneOf:
                - $ref: "#/components/schemas/FooRequest"
      responses:
        "202":
          description: accepted

components:
  schemas:
    FooRequest:
      type: object
      required: [type, another]
      properties:
        type:
          type: string
          enum: [foo]
        another:
          type: string
```

### Before: generated by v2.8.0

The inner operation body has the union storage and generated JSON methods, but the request wrapper has no methods:

```go
type PostDemoJSONBody struct {
	Type  PostDemoJSONBodyType `json:"type"`
	union json.RawMessage
}

type PostDemoJSONRequestBody PostDemoJSONBody
```

Using `PostDemoJSONRequestBody` directly therefore produces:

```text
marshal:   {"type":"foo"}
unmarshal: AsFooRequest() -> unexpected end of JSON input
```

The `another` field stored in the private union payload is lost.

### After: generated by this PR

The generated request wrapper delegates to the existing union implementation:

```go
type PostDemoJSONRequestBody PostDemoJSONBody

func (t PostDemoJSONRequestBody) MarshalJSON() ([]byte, error) {
	return PostDemoJSONBody(t).MarshalJSON()
}

func (t *PostDemoJSONRequestBody) UnmarshalJSON(b []byte) error {
	return (*PostDemoJSONBody)(t).UnmarshalJSON(b)
}
```

The same request-body values now produce:

```text
marshal:   {"another":"value","type":"foo"}
unmarshal: FooRequest{Another:"value", Type:"foo"}
```

This confirms the generated wrapper preserves the complete `oneOf` payload in both directions.

