### PR TITLE
Fix v2.6.0 omitempty regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,9 +1293,11 @@ The default behaviour in `oapi-codegen` is to generate:
 
 ```go
 type S struct {
-	Field *string `json:"field,omitempty"`
+	Field *string `json:"field"`
 }
 ```
+
+Note that there is no `omitempty` here: since the field is nullable, a `nil` pointer marshals as an explicit `null`, and `omitempty` would make that `null` impossible to produce.
 
 However, you lose the ability to understand the three cases, as there's no way to distinguish two of the types from each other:
 

--- a/internal/test/schemas/nullable/defaultbehaviour/types.gen.go
+++ b/internal/test/schemas/nullable/defaultbehaviour/types.gen.go
@@ -6,7 +6,7 @@ package defaultbehaviour
 // ComplexOptionalNullable Complex, optional and nullable
 type ComplexOptionalNullable struct {
 	// AliasName Optional and nullable
-	AliasName *string `json:"alias_name,omitempty"`
+	AliasName *string `json:"alias_name"`
 
 	// Name Optional and non nullable
 	Name *string `json:"name,omitempty"`
@@ -21,7 +21,7 @@ type ComplexRequiredNullable struct {
 // PatchRequest A request to patch an existing user object.
 type PatchRequest struct {
 	// ComplexOptionalNullable Complex, optional and nullable
-	ComplexOptionalNullable *ComplexOptionalNullable `json:"complex_optional_nullable,omitempty"`
+	ComplexOptionalNullable *ComplexOptionalNullable `json:"complex_optional_nullable"`
 
 	// ComplexRequiredNullable Complex required and nullable
 	ComplexRequiredNullable *ComplexRequiredNullable `json:"complex_required_nullable"`
@@ -30,7 +30,7 @@ type PatchRequest struct {
 	SimpleOptionalNonNullable *SimpleOptionalNonNullable `json:"simple_optional_non_nullable,omitempty"`
 
 	// SimpleOptionalNullable Simple optional and nullable
-	SimpleOptionalNullable *SimpleOptionalNullable `json:"simple_optional_nullable,omitempty"`
+	SimpleOptionalNullable *SimpleOptionalNullable `json:"simple_optional_nullable"`
 
 	// SimpleRequiredNullable Simple required and nullable
 	SimpleRequiredNullable *SimpleRequiredNullable `json:"simple_required_nullable"`

--- a/internal/test/schemas/nullable/nullable_schemas.gen.go
+++ b/internal/test/schemas/nullable/nullable_schemas.gen.go
@@ -6,7 +6,7 @@ package schemasnullable
 // NullableProperties defines model for NullableProperties.
 type NullableProperties struct {
 	Optional            *string `json:"optional,omitempty"`
-	OptionalAndNullable *string `json:"optionalAndNullable,omitempty"`
+	OptionalAndNullable *string `json:"optionalAndNullable"`
 	Required            string  `json:"required"`
 	RequiredAndNullable *string `json:"requiredAndNullable"`
 }

--- a/internal/test/schemas/nullable/nullable_test.go
+++ b/internal/test/schemas/nullable/nullable_test.go
@@ -420,8 +420,10 @@ func TestNullableViaAnyOfOneOf_3_1(t *testing.T) {
 	assert.Nil(t, p2.NicknameOneOf)
 
 	// JSON round-trip: an explicit string in / explicit string out;
-	// missing field decodes to nil and re-encodes as absent (omitempty).
-	const populated = `{"name":"fluffy","nicknameAnyOf":"rex","nicknameOneOf":"rex"}`
+	// missing field decodes to nil and re-encodes as an explicit null —
+	// nullable fields never get omitempty (issue #2503).
+	const populated = `{"name":"fluffy","nicknameAnyOf":"rex","nicknameOneOf":"rex",` +
+		`"nickname":null,"extras":null,"favorite":null,"metadata":null,"owner":null,"tags":null}`
 	encoded, err := json.Marshal(p)
 	require.NoError(t, err)
 	assert.JSONEq(t, populated, string(encoded))
@@ -496,56 +498,56 @@ func TestNullTypeComponentIsAny_3_1(t *testing.T) {
 }
 
 // TestJsonRoundTrip_NullableFields_AcrossVersions asserts that a JSON
-// payload with an explicit null nickname unmarshals to (*string)(nil) in
-// both spec versions, and that JSON output omits the field when nil due
-// to omitempty. The two generated structs must marshal identically for
-// the nullable field.
+// payload unmarshals to the same (*string) nickname in both spec
+// versions, and that nil nullable fields marshal as explicit nulls in
+// both. Nullable fields never get omitempty (issue #2503), so an
+// absent nullable field re-encodes as an explicit null; the two spec
+// versions must agree on that treatment even though their Pet types
+// have different field sets.
 func TestJsonRoundTrip_NullableFields_AcrossVersions(t *testing.T) {
-	const withName = `{"name":"fluffy"}`
-	const withBoth = `{"name":"fluffy","nickname":"rex"}`
+	// The nullable fields shared by both Pet versions, and the extra
+	// nullable fields only present in the 3.1 version.
+	const nulls30 = `"extras":null,"owner":null,"tags":null`
+	const nulls31 = nulls30 + `,"favorite":null,"metadata":null,"nicknameAnyOf":null,"nicknameOneOf":null`
 
 	for _, tc := range []struct {
-		name string
-		// fn30 / fn31 unmarshal the input into each version's Pet type
-		// and return a JSON re-marshal so we can assert equality.
-		fn30 func(input string) (string, *string, error)
-		fn31 func(input string) (string, *string, error)
+		name  string
+		in    string
+		out30 string
+		out31 string
 	}{
 		{
-			name: "unmarshal/marshal symmetric across versions",
-			fn30: func(input string) (string, *string, error) {
-				var p spec30.Pet
-				if err := json.Unmarshal([]byte(input), &p); err != nil {
-					return "", nil, err
-				}
-				out, err := json.Marshal(p)
-				return string(out), p.Nickname, err
-			},
-			fn31: func(input string) (string, *string, error) {
-				var p spec31.Pet
-				if err := json.Unmarshal([]byte(input), &p); err != nil {
-					return "", nil, err
-				}
-				out, err := json.Marshal(p)
-				return string(out), p.Nickname, err
-			},
+			name:  "absent nickname re-encodes as explicit null",
+			in:    `{"name":"fluffy"}`,
+			out30: `{"name":"fluffy","nickname":null,` + nulls30 + `}`,
+			out31: `{"name":"fluffy","nickname":null,` + nulls31 + `}`,
+		},
+		{
+			name:  "populated nickname survives the round-trip",
+			in:    `{"name":"fluffy","nickname":"rex"}`,
+			out30: `{"name":"fluffy","nickname":"rex",` + nulls30 + `}`,
+			out31: `{"name":"fluffy","nickname":"rex",` + nulls31 + `}`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			for _, in := range []string{withName, withBoth} {
-				out30, n30, err30 := tc.fn30(in)
-				require.NoError(t, err30)
-				out31, n31, err31 := tc.fn31(in)
-				require.NoError(t, err31)
-				assert.JSONEq(t, in, out30, "3.0 round-trip should be lossless")
-				assert.JSONEq(t, in, out31, "3.1 round-trip should be lossless")
-				assert.JSONEq(t, out30, out31, "3.0 and 3.1 must marshal identically")
-				if n30 == nil {
-					assert.Nil(t, n31)
-				} else {
-					require.NotNil(t, n31)
-					assert.Equal(t, *n30, *n31)
-				}
+			var p30 spec30.Pet
+			require.NoError(t, json.Unmarshal([]byte(tc.in), &p30))
+			out30, err := json.Marshal(p30)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.out30, string(out30))
+
+			var p31 spec31.Pet
+			require.NoError(t, json.Unmarshal([]byte(tc.in), &p31))
+			out31, err := json.Marshal(p31)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.out31, string(out31))
+
+			// The nullable nickname must decode identically across versions.
+			if p30.Nickname == nil {
+				assert.Nil(t, p31.Nickname)
+			} else {
+				require.NotNil(t, p31.Nickname)
+				assert.Equal(t, *p30.Nickname, *p31.Nickname)
 			}
 		})
 	}

--- a/internal/test/schemas/nullable/spec30/types.gen.go
+++ b/internal/test/schemas/nullable/spec30/types.gen.go
@@ -8,19 +8,19 @@ type Pet struct {
 	// Extras Optional, nullable *unspecified* object (no `properties:`).
 	// 3.0 control case for the 3.1 `type: ["object","null"]`
 	// equivalent; expected shape: `*map[string]interface{}`.
-	Extras *map[string]interface{} `json:"extras,omitempty"`
+	Extras *map[string]interface{} `json:"extras"`
 
 	// Name Required, non-nullable.
 	Name string `json:"name"`
 
 	// Nickname Optional, nullable scalar via 3.0 `nullable: true`.
-	Nickname *string `json:"nickname,omitempty"`
+	Nickname *string `json:"nickname"`
 
 	// Owner Optional, nullable inline object.
 	Owner *struct {
 		Id *string `json:"id,omitempty"`
-	} `json:"owner,omitempty"`
+	} `json:"owner"`
 
 	// Tags Optional, nullable array.
-	Tags *[]string `json:"tags,omitempty"`
+	Tags *[]string `json:"tags"`
 }

--- a/internal/test/schemas/nullable/spec31/types.gen.go
+++ b/internal/test/schemas/nullable/spec31/types.gen.go
@@ -18,7 +18,7 @@ type Cat struct {
 
 // ChallengeOpenJson defines model for ChallengeOpenJson.
 type ChallengeOpenJson struct {
-	Challenger any     `json:"challenger,omitempty"`
+	Challenger any     `json:"challenger"`
 	Id         string  `json:"id"`
 	Url        *string `json:"url,omitempty"`
 }
@@ -45,7 +45,7 @@ type Pet struct {
 	// primary type as "object", routing the schema away from
 	// the unspecified-object code path. Expected shape:
 	// `*map[string]interface{}`.
-	Extras *map[string]interface{} `json:"extras,omitempty"`
+	Extras *map[string]interface{} `json:"extras"`
 
 	// Favorite Nullable discriminated union (`oneOf: [Cat, Dog, null]` with a
 	// discriminator). Before this branch's fix to the union-
@@ -54,37 +54,37 @@ type Pet struct {
 	// expected-mapping count, so generation failed with
 	// `discriminator: not all schemas were mapped`. The two real
 	// branches must map and the null branch must be tolerated.
-	Favorite *DiscriminatedPet `json:"favorite,omitempty"`
+	Favorite *DiscriminatedPet `json:"favorite"`
 
 	// Metadata Same as `extras` but with the type-array order reversed.
 	// Both orderings must resolve identically; this guards
 	// against any code path that inspects only the first
 	// element of the type array.
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Metadata *map[string]interface{} `json:"metadata"`
 
 	// Name Required, non-nullable.
 	Name string `json:"name"`
 
 	// Nickname Optional, nullable scalar via 3.1 type-array idiom.
-	Nickname *string `json:"nickname,omitempty"`
+	Nickname *string `json:"nickname"`
 
 	// NicknameAnyOf OpenAPI 3.1: a `{"type": "null"}` branch in `anyOf` is a
 	// nullability marker, not a separate union variant. Should
 	// generate the same shape as `type: ["string","null"]` (i.e.
 	// `*string`). Regression for a previous crash with
 	// "unhandled Schema type: &[null]".
-	NicknameAnyOf *string `json:"nicknameAnyOf,omitempty"`
+	NicknameAnyOf *string `json:"nicknameAnyOf"`
 
 	// NicknameOneOf Same as `nicknameAnyOf` but using `oneOf`.
-	NicknameOneOf *string `json:"nicknameOneOf,omitempty"`
+	NicknameOneOf *string `json:"nicknameOneOf"`
 
 	// Owner Optional, nullable inline object.
 	Owner *struct {
 		Id *string `json:"id,omitempty"`
-	} `json:"owner,omitempty"`
+	} `json:"owner"`
 
 	// Tags Optional, nullable array.
-	Tags *[]string `json:"tags,omitempty"`
+	Tags *[]string `json:"tags"`
 }
 
 // RequiredNull defines model for RequiredNull.

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -125,8 +125,8 @@ func TestExtPropGoTypeSkipOptionalPointer(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that optional pointer fields are skipped if requested
-	assert.Contains(t, code, "NullableFieldSkipFalse *string `json:\"nullableFieldSkipFalse,omitempty\"`")
-	assert.Contains(t, code, "NullableFieldSkipTrue  string  `json:\"nullableFieldSkipTrue,omitempty\"`")
+	assert.Contains(t, code, "NullableFieldSkipFalse *string `json:\"nullableFieldSkipFalse\"`")
+	assert.Contains(t, code, "NullableFieldSkipTrue  string  `json:\"nullableFieldSkipTrue\"`")
 	assert.Contains(t, code, "OptionalField          *string `json:\"optionalField,omitempty\"`")
 	assert.Contains(t, code, "OptionalFieldSkipFalse *string `json:\"optionalFieldSkipFalse,omitempty\"`")
 	assert.Contains(t, code, "OptionalFieldSkipTrue  string  `json:\"optionalFieldSkipTrue,omitempty\"`")

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -1435,7 +1435,18 @@ func GenFieldsFromProperties(props []Property) []string {
 		shouldOmitEmpty := (!p.Required || p.ReadOnly || p.WriteOnly) &&
 			(!p.Required || !p.ReadOnly || !globalState.options.Compatibility.DisableRequiredReadOnlyAsPointer)
 
-		omitEmpty := shouldOmitEmpty
+		// Nullable fields don't get omitempty: `null` is a meaningful wire
+		// value distinct from key absence, and a nil pointer under omitempty
+		// could never produce it. Required+nullable fields must always
+		// serialize their key per JSON Schema `required` semantics. The
+		// nullable-type option is the exception — nullable.Nullable[T]
+		// distinguishes absent from null itself and relies on omitempty for
+		// the absent case. Issue #2503.
+		omitEmpty := !p.Nullable && shouldOmitEmpty
+
+		if p.Nullable && globalState.options.OutputOptions.NullableType {
+			omitEmpty = shouldOmitEmpty
+		}
 
 		omitZero := false
 


### PR DESCRIPTION
Fixes #2503

Since v2.6.0, nullable struct fields received an `omitempty` JSON tag, changing the wire format for unchanged specs: required+nullable fields lost their always-present key (a JSON Schema `required` violation when the pointer is nil), and optional+nullable fields could no longer emit an explicit `null`, collapsing the null-vs-absent distinction that `nullable: true` exists to express. The guard was removed by d567e49b (#2221), which aligned the code with an inaccurate README example that issue #2091 had taken as the documented behavior.

Restore the pre-2.6.0 rule in GenFieldsFromProperties: nullable fields never get `omitempty`, except under the `nullable-type` output option, where nullable.Nullable[T] models absent-vs-null itself and relies on `omitempty` for the absent case. The rule applies uniformly to OpenAPI 3.0 `nullable: true` and the 3.1 `type: [..., "null"]` / null-branch idioms, since Property.Nullable covers both.

Also revert the test expectations flipped by d567e49b, update the two nullable round-trip tests that had baked in the regressed behavior (nil nullable fields now marshal as explicit nulls, identically across spec versions), regenerate the affected fixtures, and correct the README example that showed `omitempty` as the default for nullable fields.

Users who prefer omission for nullable fields can opt in explicitly via `x-omitempty: true` or the `nullable-type` output option.