### PR TITLE
Cover remaining OpenAPI 3.1 union test positions

### DIFF
--- a/internal/test/openapi31/openapi31.gen.go
+++ b/internal/test/openapi31/openapi31.gen.go
@@ -4,6 +4,9 @@
 package openapi31
 
 import (
+	"encoding/json"
+
+	"github.com/oapi-codegen/runtime"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
@@ -167,6 +170,19 @@ type FileUploadFields struct {
 	RawFile openapi_types.File `json:"rawFile"`
 }
 
+// FlexibleId defines model for FlexibleId.
+type FlexibleId struct {
+	union json.RawMessage
+}
+
+// FlexibleId0 defines model for FlexibleId.0.
+type FlexibleId0 struct {
+	Id string `json:"id"`
+}
+
+// FlexibleId1 defines model for FlexibleId.1.
+type FlexibleId1 = any
+
 // Measurement defines model for Measurement.
 type Measurement struct {
 	NullableValue any `json:"nullableValue"`
@@ -199,6 +215,9 @@ type PetStatus string
 // Port defines model for Port.
 type Port int
 
+// ReadingList defines model for ReadingList.
+type ReadingList = []any
+
 // Severity How urgent a problem is.
 type Severity int
 
@@ -210,3 +229,65 @@ type UnionEnum = any
 
 // UnionValue defines model for UnionValue.
 type UnionValue = any
+
+// AsFlexibleId0 returns the union data inside the FlexibleId as a FlexibleId0
+func (t FlexibleId) AsFlexibleId0() (FlexibleId0, error) {
+	var body FlexibleId0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromFlexibleId0 overwrites any union data inside the FlexibleId as the provided FlexibleId0
+func (t *FlexibleId) FromFlexibleId0(v FlexibleId0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeFlexibleId0 performs a merge with any union data inside the FlexibleId, using the provided FlexibleId0
+func (t *FlexibleId) MergeFlexibleId0(v FlexibleId0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsFlexibleId1 returns the union data inside the FlexibleId as a FlexibleId1
+func (t FlexibleId) AsFlexibleId1() (FlexibleId1, error) {
+	var body FlexibleId1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromFlexibleId1 overwrites any union data inside the FlexibleId as the provided FlexibleId1
+func (t *FlexibleId) FromFlexibleId1(v FlexibleId1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeFlexibleId1 performs a merge with any union data inside the FlexibleId, using the provided FlexibleId1
+func (t *FlexibleId) MergeFlexibleId1(v FlexibleId1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t FlexibleId) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *FlexibleId) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}

--- a/internal/test/openapi31/openapi31_test.go
+++ b/internal/test/openapi31/openapi31_test.go
@@ -314,6 +314,35 @@ func TestUnionEnumDropsConstants(t *testing.T) {
 	assert.Equal(t, "two", v)
 }
 
+// Union in array-items position: the element carries the permissive mapping,
+// so the component is an `[]any` alias and mixed member values round-trip.
+func TestReadingListUnionItems(t *testing.T) {
+	var r ReadingList
+	require.NoError(t, json.Unmarshal([]byte(`["low",97.5]`), &r))
+	assert.Equal(t, ReadingList{"low", 97.5}, r)
+}
+
+// A union as a oneOf branch keeps the outer schema's standard union
+// machinery, with that branch's accessor typed `any`. Because `any` accepts
+// every JSON value, As... on the union branch can never fail, so
+// discriminating between branches falls to the caller.
+func TestFlexibleIdUnionBranch(t *testing.T) {
+	var f FlexibleId
+	require.NoError(t, json.Unmarshal([]byte(`"user-7"`), &f))
+	v, err := f.AsFlexibleId1()
+	require.NoError(t, err)
+	assert.Equal(t, "user-7", v)
+
+	require.NoError(t, f.FromFlexibleId0(FlexibleId0{Id: "abc"}))
+	obj, err := f.AsFlexibleId0()
+	require.NoError(t, err)
+	assert.Equal(t, "abc", obj.Id)
+
+	v, err = f.AsFlexibleId1()
+	require.NoError(t, err, "the any-typed accessor succeeds even on the object branch's data")
+	assert.Equal(t, map[string]any{"id": "abc"}, v)
+}
+
 // petFieldComments extracts the doc comment text for each field of the Pet
 // struct from a parsed AST. Returns map[fieldName]commentText.
 func petFieldComments(t *testing.T, f *ast.File) map[string]string {

--- a/internal/test/openapi31/openapi31_test.go
+++ b/internal/test/openapi31/openapi31_test.go
@@ -323,9 +323,8 @@ func TestReadingListUnionItems(t *testing.T) {
 }
 
 // A union as a oneOf branch keeps the outer schema's standard union
-// machinery, with that branch's accessor typed `any`. Because `any` accepts
-// every JSON value, As... on the union branch can never fail, so
-// discriminating between branches falls to the caller.
+// machinery, with the branch accessor typed `any`. As... to `any` never
+// fails, so branch discrimination falls to the caller.
 func TestFlexibleIdUnionBranch(t *testing.T) {
 	var f FlexibleId
 	require.NoError(t, json.Unmarshal([]byte(`"user-7"`), &f))

--- a/internal/test/openapi31/spec.yaml
+++ b/internal/test/openapi31/spec.yaml
@@ -255,11 +255,9 @@ components:
       items:
         type: [string, number]
 
-    # A union as a oneOf BRANCH. The outer schema still gets the standard
-    # oneOf union machinery (union field, As.../From... accessors); the union
-    # branch's accessor is typed `any`, so its As... conversion can never
-    # fail and discrimination falls to the caller, the same as a typeless
-    # branch.
+    # A union as a oneOf branch. The outer schema keeps the standard oneOf
+    # union machinery. The union branch's accessor is typed `any`, so its
+    # As... conversion never fails, the same as a typeless branch.
     FlexibleId:
       oneOf:
         - type: object

--- a/internal/test/openapi31/spec.yaml
+++ b/internal/test/openapi31/spec.yaml
@@ -247,3 +247,24 @@ components:
       enum:
         - 1
         - two
+
+    # Union in array-items position: the element type carries the permissive
+    # mapping, so the component lowers to `[]any`.
+    ReadingList:
+      type: array
+      items:
+        type: [string, number]
+
+    # A union as a oneOf BRANCH. The outer schema still gets the standard
+    # oneOf union machinery (union field, As.../From... accessors); the union
+    # branch's accessor is typed `any`, so its As... conversion can never
+    # fail and discrimination falls to the caller, the same as a typeless
+    # branch.
+    FlexibleId:
+      oneOf:
+        - type: object
+          required: [id]
+          properties:
+            id:
+              type: string
+        - type: [string, integer]

--- a/internal/test/openapi31params/doc.go
+++ b/internal/test/openapi31params/doc.go
@@ -3,7 +3,7 @@
 // lowering of unions to `any` is covered in the sibling openapi31 suite;
 // this suite generates a std-http server and client so the emitted
 // bind-option Types lists are exercised against the real runtime binder
-// (runtime >= v1.7.0), in path, query, and header positions:
+// (runtime >= v1.7.0), in path, query, header, and response header positions:
 //
 //   - the value binds to the first union member that parses, trying
 //     boolean, integer, number, then string — so "42" arrives as int64(42)

--- a/internal/test/openapi31params/openapi31params.gen.go
+++ b/internal/test/openapi31params/openapi31params.gen.go
@@ -299,6 +299,11 @@ type ClientWithResponsesInterface interface {
 	UpdateThingWithResponse(ctx context.Context, id any, params *UpdateThingParams, body UpdateThingJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateThingResponse, error)
 }
 
+// UpdateThingResponse200Headers the declared response headers of an HTTP 200 response for UpdateThing
+type UpdateThingResponse200Headers struct {
+	XEcho any
+}
+
 type UpdateThingResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -306,6 +311,8 @@ type UpdateThingResponse struct {
 	JSON200 *struct {
 		Id any `json:"id,omitempty"`
 	}
+	// Headers200 the parsed response headers for an HTTP 200 response
+	Headers200 *UpdateThingResponse200Headers
 }
 
 // GetJSON200 returns the response for an HTTP 200 `application/json` response
@@ -389,6 +396,19 @@ func ParseUpdateThingResponse(rsp *http.Response) (*UpdateThingResponse, error) 
 		}
 		response.JSON200 = &dest
 
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		var headers UpdateThingResponse200Headers
+		if values := rsp.Header.Values("X-Echo"); len(values) > 0 {
+			var value any
+			if err := runtime.BindStyledParameterWithOptions("simple", "X-Echo", values[0], &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "", Format: "", Types: []string{"integer", "string"}}); err != nil {
+				return nil, err
+			}
+			headers.XEcho = value
+		}
+		response.Headers200 = &headers
 	}
 
 	return response, nil

--- a/internal/test/openapi31params/openapi31params_test.go
+++ b/internal/test/openapi31params/openapi31params_test.go
@@ -105,9 +105,9 @@ func TestUnionParamClientRoundTrip(t *testing.T) {
 	assert.Equal(t, float64(42), echoed["id"], "response body is plain JSON, so the id comes back as a JSON number")
 }
 
-// A union-typed response header is parsed by the generated ClientWithResponses
-// through the same Types-carrying styled binder, so the header value comes
-// back as the first member that parses.
+// The generated ClientWithResponses binds declared response headers through
+// the styled binder with Types, so a union-typed header comes back as the
+// first member that parses.
 func TestUnionResponseHeaderClientBinding(t *testing.T) {
 	capture := &captureServer{}
 	srv := httptest.NewServer(Handler(capture))

--- a/internal/test/openapi31params/openapi31params_test.go
+++ b/internal/test/openapi31params/openapi31params_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,6 +27,7 @@ func (s *captureServer) UpdateThing(w http.ResponseWriter, r *http.Request, id a
 	s.body = nil
 	_ = json.NewDecoder(r.Body).Decode(&s.body)
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Echo", fmt.Sprint(id))
 	_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 }
 
@@ -101,4 +103,28 @@ func TestUnionParamClientRoundTrip(t *testing.T) {
 	var echoed map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&echoed))
 	assert.Equal(t, float64(42), echoed["id"], "response body is plain JSON, so the id comes back as a JSON number")
+}
+
+// A union-typed response header is parsed by the generated ClientWithResponses
+// through the same Types-carrying styled binder, so the header value comes
+// back as the first member that parses.
+func TestUnionResponseHeaderClientBinding(t *testing.T) {
+	capture := &captureServer{}
+	srv := httptest.NewServer(Handler(capture))
+	defer srv.Close()
+
+	client, err := NewClientWithResponses(srv.URL)
+	require.NoError(t, err)
+
+	resp, err := client.UpdateThingWithResponse(context.Background(), 42, nil,
+		UpdateThingJSONRequestBody("x"))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Headers200)
+	assert.Equal(t, int64(42), resp.Headers200.XEcho, "header [integer, string]: integer member wins for a numeric token")
+
+	resp, err = client.UpdateThingWithResponse(context.Background(), "abc", nil,
+		UpdateThingJSONRequestBody("x"))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Headers200)
+	assert.Equal(t, "abc", resp.Headers200.XEcho, "non-numeric token falls to the string member")
 }

--- a/internal/test/openapi31params/spec.yaml
+++ b/internal/test/openapi31params/spec.yaml
@@ -14,10 +14,10 @@ info:
   version: "1.0.0"
   description: |
     Exercises multi-type unions in every parameter position the runtime
-    binds: path, query, and header, plus a union request/response body.
-    Each union parameter lowers to `any`, and the generated bind calls
-    carry Types so runtime >= v1.7.0 picks the first member that parses
-    (boolean, integer, number, string).
+    binds: path, query, header, and response header, plus a union
+    request/response body. Each union parameter lowers to `any`, and the
+    generated bind calls carry Types so runtime >= v1.7.0 picks the first
+    member that parses (boolean, integer, number, string).
 paths:
   /things/{id}:
     post:
@@ -54,6 +54,13 @@ paths:
       responses:
         "200":
           description: echo of what was bound
+          headers:
+            # Response-header position: the generated ClientWithResponses
+            # binds declared headers through the same styled binder, so a
+            # union-typed header needs its Types list too.
+            X-Echo:
+              schema:
+                type: [integer, string]
           content:
             application/json:
               schema:


### PR DESCRIPTION
Adds conformance tests for the multi-type union positions the [#2522 review](https://github.com/oapi-codegen/oapi-codegen/pull/2522#issuecomment-5304403558) found missing.

A union in array-items position lowers to a `[]any` alias and round-trips mixed member values. A union as a oneOf branch keeps the outer schema's union machinery with an `any`-typed accessor, so `As...` never fails and branch discrimination falls to the caller. A union-typed response header exercises the `Types` list that `ClientWithResponses` passes when binding declared headers, which had no test. The allOf position is skipped because #2526 already covers both member orderings.

Test-only. Repo-wide `make generate` changes nothing outside the two openapi31 suites.
