### PR TITLE
feat(codegen): migrate embedded spec compression to `compress/lzw`

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -593,39 +593,45 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"xFTBbts4EP2VwewCexFsJ1nsQTcHyQIOCrRoDeQQBwgjji22MskMR3GNQP9ekJQcNU7T9tSLLZLDN/Pe",
-	"vOETVm7rnSUrAcsnDFVNW5U+L5kdxw/PzhOLobRdOU3xX1Oo2HgxzmKZgyGdFbh2vFWCJRorZ6dYoOw9",
-	"5SVtiLErcEshqM0PgYbjw9UgbOwGu65ApofWMGksb7BPOITfdgUu6xh4VLZV25TtbbwUdUC5NlIvLuIt",
-	"1TTv11jePOHfTGss8a/ps27TXrRpTt0VL3MbHX/Hqvz37yuqvKjFaLztbuNuoKplI/tPMU+GPCfFxPNW",
-	"6ri6T6v/hwRX10sscitjgnz6nLAW8dhFYGPX7rgFcwv0VW19QzD/sIBdbaoa2kABMhKI+0IWQuU8BVBW",
-	"w9X1ElSspUAx0sQksTSyYiolpBPOZcbEAh+JQ051MplNZtEPzpNV3mCJZ2mrQK+kTlSnEmVNnxuS43I/",
-	"krRsAyhoTBBwa8gXJnBOlWoDxXUAsto7YwW0o2D/EXCPxGx0PKaV3TTuXjUwSF2AEei7EaEjw7XjxLKn",
-	"ZZydrCym2jktFxpLfGeCLHPFsZ/BOxtyz05nszxAVsgmIsr7poeafg6RzTCByTZC23Txp57rjdodWqyY",
-	"1T73+HuxXoqUY7wLrwg71zpST4EgLup0JPFyLG04aBpScNZ0ZQdRIVsyWWak7V0GK3d32VNgLDjWyWjg",
-	"iePggFrZHRuh1ySfa51HLw8QBTl3ev9bWv/CWB+LOX/WxthALBMYzBjp5z3SfdTOSA3KwuICx4Mu3FJ3",
-	"5JSTP+6U5ZjBcsQAWmseWoo8xo9Teh3Hz9INDn3N79ibsTHiWwAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudamgKToXY8g3I0ueTCnCTRirLpc2dQuXMV2f",
+	"d/PuLdNXx1/LmBH7VMz4Sho6aJIQcRmGDZsnZvwKJHE3t9gRLwgaRKiQ4YuIEyvOecFa7lQWIEWSNInS",
+	"ZZrSAoHKEeqUjg0agzW3FVGUDlSpfeqG1svXL/m+iBHXnVNmTB2ZS6dIpFgdo5AyYdwlRxB1wOaSGAAK",
+	"aERQYQwllhJXUDEYcvzdhGCAUq21mQho0EEHHHTVVRRQW6HU1Uw1uXFTEG6AUAYel8HBRhkgBAFFEiDc",
+	"sZhEINRB3xwgXCggCHS8sYZCIEQEGUoghOEGGSBASEWTBaIR3mszrlhlcWmM0SBpNd4IQhEwGpSlT3aQ",
+	"NAdYKooVgwswwPmcCEtaBkcaN80Ap5w+wdEgGpS9ABtjlEXloEBceZXiTVKUQcd9bgAZBghspPEWCG+Y",
+	"QeRics3hAgj/eekjjYMCqRAZB5UHAhlvoOTGCXRgmuZG15E6ERdysfGGGLUlWd99r+XBAgivgbDeaJJG",
+	"GSEI2lEJG5depugCroMtKUeDbCZRmghMWEpHc2c0BBpKB0Xan0AywACDSwQ9tRBtcMjYJbYIvaDGHGFB",
+	"tF9F1pnXBmW8leGbCMAJV25xy1GoHHOcnuEabLLNKd5NAV6bR4g+JYoimxRT6i2mmg7aKcYiHPRWiTFt",
+	"HJYIQZBBRrIin0HkG5vSWOmlmW5K6KesmfpkqgsB+casMsFUMwhn6MorG7jSZx9+eSS5L41OQnnsXcmC",
+	"EfMcOtwBhtRLEttiRyyVVSQIkWnXRpO43oFfGdOq6JO19Lqh7YougzvYeijRIURgF2PUrnnvYhRGvJVG",
+	"y6a9+Lapb3JhuBTwwAUXdHDQx+1rEcOepVeXxl+tHITOcs0sNn0lfdroo3JEenRRqJsHZcw5voZGky1G",
+	"PK5o7ekAVx1lqEcuQj+6lG4M7CJE+KEiHC6v4vXem68ICkeO0WsUAdzbTZUPlxDm1S8H7sOxzVbXxGJV",
+	"HMbFnmdsoqIci6UYjbBPBya4tcPWZI9upJEXjRFLj0+cBqyl6EYE/8HQgKrknq11TQTxaR/1fgW1AyZQ",
+	"QAQykGkiGBA=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/authenticated-api/stdhttp/api/api.gen.go
+++ b/examples/authenticated-api/stdhttp/api/api.gen.go
@@ -7,7 +7,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -682,39 +682,45 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	return m
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"xFTBbts4EP2VwewCexFsJ1nsQTcHyQIOCrRoDeQQBwgjji22MskMR3GNQP9ekJQcNU7T9tSLLZLDN/Pe",
-	"vOETVm7rnSUrAcsnDFVNW5U+L5kdxw/PzhOLobRdOU3xX1Oo2HgxzmKZgyGdFbh2vFWCJRorZ6dYoOw9",
-	"5SVtiLErcEshqM0PgYbjw9UgbOwGu65ApofWMGksb7BPOITfdgUu6xh4VLZV25TtbbwUdUC5NlIvLuIt",
-	"1TTv11jePOHfTGss8a/ps27TXrRpTt0VL3MbHX/Hqvz37yuqvKjFaLztbuNuoKplI/tPMU+GPCfFxPNW",
-	"6ri6T6v/hwRX10sscitjgnz6nLAW8dhFYGPX7rgFcwv0VW19QzD/sIBdbaoa2kABMhKI+0IWQuU8BVBW",
-	"w9X1ElSspUAx0sQksTSyYiolpBPOZcbEAh+JQ051MplNZtEPzpNV3mCJZ2mrQK+kTlSnEmVNnxuS43I/",
-	"krRsAyhoTBBwa8gXJnBOlWoDxXUAsto7YwW0o2D/EXCPxGx0PKaV3TTuXjUwSF2AEei7EaEjw7XjxLKn",
-	"ZZydrCym2jktFxpLfGeCLHPFsZ/BOxtyz05nszxAVsgmIsr7poeafg6RzTCByTZC23Txp57rjdodWqyY",
-	"1T73+HuxXoqUY7wLrwg71zpST4EgLup0JPFyLG04aBpScNZ0ZQdRIVsyWWak7V0GK3d32VNgLDjWyWjg",
-	"iePggFrZHRuh1ySfa51HLw8QBTl3ev9bWv/CWB+LOX/WxthALBMYzBjp5z3SfdTOSA3KwuICx4Mu3FJ3",
-	"5JSTP+6U5ZjBcsQAWmseWoo8xo9Teh3Hz9INDn3N79ibsTHiWwAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudamgKToXY8g3I0ueTCnCTRirLpc2dQuXMV2f",
+	"d/PuLdNXx1/LmBH7VMz4Sho6aJIQcRmGDZsnZvwKJHE3t9gRLwgaRKiQ4YuIEyvOecFa7lQWIEWSNInS",
+	"ZZrSAoHKEeqUjg0agzW3FVGUDlSpfeqG1svXL/m+iBHXnVNmTB2ZS6dIpFgdo5AyYdwlRxB1wOaSGAAK",
+	"aERQYQwllhJXUDEYcvzdhGCAUq21mQho0EEHHHTVVRRQW6HU1Uw1uXFTEG6AUAYel8HBRhkgBAFFEiDc",
+	"sZhEINRB3xwgXCggCHS8sYZCIEQEGUoghOEGGSBASEWTBaIR3mszrlhlcWmM0SBpNd4IQhEwGpSlT3aQ",
+	"NAdYKooVgwswwPmcCEtaBkcaN80Ap5w+wdEgGpS9ABtjlEXloEBceZXiTVKUQcd9bgAZBghspPEWCG+Y",
+	"QeRics3hAgj/eekjjYMCqRAZB5UHAhlvoOTGCXRgmuZG15E6ERdysfGGGLUlWd99r+XBAgivgbDeaJJG",
+	"GSEI2lEJG5depugCroMtKUeDbCZRmghMWEpHc2c0BBpKB0Xan0AywACDSwQ9tRBtcMjYJbYIvaDGHGFB",
+	"tF9F1pnXBmW8leGbCMAJV25xy1GoHHOcnuEabLLNKd5NAV6bR4g+JYoimxRT6i2mmg7aKcYiHPRWiTFt",
+	"HJYIQZBBRrIin0HkG5vSWOmlmW5K6KesmfpkqgsB+casMsFUMwhn6MorG7jSZx9+eSS5L41OQnnsXcmC",
+	"EfMcOtwBhtRLEttiRyyVVSQIkWnXRpO43oFfGdOq6JO19Lqh7YougzvYeijRIURgF2PUrnnvYhRGvJVG",
+	"y6a9+Lapb3JhuBTwwAUXdHDQx+1rEcOepVeXxl+tHITOcs0sNn0lfdroo3JEenRRqJsHZcw5voZGky1G",
+	"PK5o7ekAVx1lqEcuQj+6lG4M7CJE+KEiHC6v4vXem68ICkeO0WsUAdzbTZUPlxDm1S8H7sOxzVbXxGJV",
+	"HMbFnmdsoqIci6UYjbBPBya4tcPWZI9upJEXjRFLj0+cBqyl6EYE/8HQgKrknq11TQTxaR/1fgW1AyZQ",
+	"QAQykGkiGBA=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/overlay/api/ping.gen.go
+++ b/examples/overlay/api/ping.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -172,35 +172,37 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 	return r
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"XFLBbtQwEP0Va+AAUna97YqLbxVCaMVhV4Jb1YPrTGKXxGPsSWlV+d/ROLsUepp48uz33sx7AUdzooiR",
-	"C5gXKM7jbNvnieIoNWVKmDlg66awdvHJzmlCMJAE1wE/JzkVzoKotYOMv5aQsQdzu167+4ui+wd0DB08",
-	"bUbaRDtL8/iIOYe+x9ioq7wR4kBCx4Eb2ZeVVjGpEPvgLKPy9FvOS0HFHtUxYbw5HZQ8N9lnVRK6MAg0",
-	"UFQfPHMqRusxsF/ut45mfbw56DN68/1f9Efo4BFzCRTBwNV2t901zXQG25SmIAbF9uJ4ydhffkLtgBJG",
-	"mwIY2J/vJsu+zVHbfg5R24WpODutU60d6MuAR2QpPRaXQ+JVwmeP7qdib7lZFZuhqLzEGOKojt+gceYm",
-	"/iC6viKfQttPxpIolnWL17udFEeRMTaeZmV1rR+KkF3CIF/vMw5g4J1+TYs+R0W/Lut/rSfMA+VZWSWW",
-	"lKQBC7dkFMwyVjC3bw3+8Kh6HOwysVpRW+hgyRMYkM0ZrSdydvJU2Ow/XV3vod7VWuufAAAA//8=",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIqAgPONQIBw5b+CUkUMnTZmLHtO44YixDJ4wBtmUcSji",
+	"4EoRLETQySOS5hw6clRy7NMnp5wyceqkOUrG4ZaaQkV0ybmzpw4Rb8SoKTOGDk4ReFqcedPCDcyZV5/Y",
+	"GRmUDBmFGm8SLSpCpZk3HXWmoSOTZpGXMcuAoPMGhEoyacaEoSMYzZs7gwvXmSOYzkQQT0S6CQIlCea1",
+	"ctiEyQNijsgxacwkXpwGIQgUaOjQgTNHx4sXZ/aiqSPGBcE2L54ESRIctOg8LaacTr26JMIUX0HPae2G",
+	"ZgwXMLB/DfvG+OgWYeDAYWOy6dWfcup0rcO0RfeRx0XQDakwfBqaM7BrzwlnMRqUIrwQBhltqCRgHYRF",
+	"FAZ5Nz1E1wtwRIXRGWV4hdFbEQUFh3PVXTXERGOsMRgai40oGGeepTEHCOm54YZQmC3xFX1ysIZQEuaJ",
+	"cESFUERl1Ek2UQagDDDAkBdBCylkoUDhjdccdS+oMQdCeUU0UUV5kXCUGTSN8MJvNik5xwtWUmTRC3EN",
+	"RVROGI6hIYc0QTHSXXK0AUIYIES4EotI1XGSV2uKQJkc0jklUJtvUkcTFZe9ZUYYdbBBR2kjgebCV+yx",
+	"QVNss9n2AhtvKMaGYz/pMEMNMcgwg3xdzNVHQA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/chi/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore-server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -356,55 +356,71 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	return r
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/echo-v5/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/echo-v5/api/petstore-server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -201,55 +201,71 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/echo/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -201,55 +201,71 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/fiber/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/fiber/api/petstore-server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -237,55 +237,71 @@ func RegisterHandlersWithOptions(router fiber.Router, si ServerInterface, option
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/fiberv3/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/fiberv3/api/petstore-server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -195,55 +195,71 @@ func RegisterHandlersWithOptions(router fiber.Router, si ServerInterface, option
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/gin/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/gin/api/petstore-server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -216,55 +216,71 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/pets/:id", wrapper.FindPetByID)
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/gorilla/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/gorilla/api/petstore-server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -323,55 +323,71 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 	return r
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/iris/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/iris/api/petstore-server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -189,55 +189,71 @@ func RegisterHandlersWithOptions(router *iris.Application, si ServerInterface, o
 	router.Build()
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/stdhttp/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/stdhttp/api/petstore-server.gen.go
@@ -7,7 +7,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -327,55 +327,71 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	return m
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/petstore-expanded/strict/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -672,55 +672,71 @@ func (sh *strictHandler) FindPetByID(w http.ResponseWriter, r *http.Request, id 
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"5Fdbjxu50f0rBX7fY6c1sRd50FO8Hi8gIGtP4t28rOehhl2SasFLD1nUWBjovwdFtm4jeTZBgiBBXnTp",
-	"ZjVPnXOqWP1sbPRjDBQkm/mzyXZNHuvPDynFpD/GFEdKwlQv2ziQfg+UbeJROAYzb4uh3uvMMiaPYuaG",
-	"g7x9Yzoj25HaX1pRMrvOeMoZV9980P72ITRL4rAyu11nEj0WTjSY+S9m2nC//H7XmY/0dEdyiTugv7Ld",
-	"R/QEcQmyJhhJLjfsjODqMu6n7fh63AugdXeFN2FD5z4tzfyXZ/P/iZZmbv5vdhRiNqkwm3LZdS+T4eES",
-	"0s+BHwsBD+e4TsX4w3dXxHiBlAdzv7vf6WUOy9gkD4K24iaP7Mzc4MhC6P+Yn3C1otRzNN1EsfncrsG7",
-	"uwX8ROhNZ0rSoLXImOez2UnQrnuRxTvI6EdHNVrWKFAyZUDNJktMBJgBA9DXtkwiDORjyJJQCJaEUhJl",
-	"4FA5+DRS0Ce97W8gj2R5yRbrVp1xbClkOprDvBvRrgne9DcXmJ+ennqst/uYVrMpNs/+tHj/4ePnD797",
-	"09/0a/GuOoaSz5+Wnylt2NLVxGd1zUzlYHGnrN1NeZrObCjlxsrv+5v+Rh8dRwo4spmbt/VSZ0aUdfXE",
-	"TBnSH6tmsXNe/0JSUsiAzlUqYZmirxTlbRbyjWv9XzIlWCvL1lLOIPFL+IgeMg1gYxjYU5DigbL08COS",
-	"pYAZhPwYE2RcsQhnyDgyhQ4CWUjrGGzJkMmfLGAB9CQ9vKNAGAAFVgk3PCBgWRXqAC0w2uK4hvbwviR8",
-	"YCkJ4sARXEzkO4gpYCKgFQmQowldINuBLSmXrCXhyErJPdwWzuAZpKSRcwdjcRsOmHQvSlGT7kA4WB5K",
-	"ENhg4pLh15Il9rAIsEYLawWBOROMDoUQBrZSvNKxaEWlueDAI2fLYQUYRLM55u54VRweMh/XmEgS7knU",
-	"9eCjoyxMwH6kNLAy9VfeoG8JoePHgh4GRmUmYYZHzW1DjgVCDCAxSUxKCS8pDIfde7hLSJmCKEwK7I8A",
-	"SgoIm+iKjCiwoUABFXAjVz88lqTPWITjk5eUJtaXaNlxPtuk7qAf3VFfCzkO6EiFHTrl0VJC0cT0u4fP",
-	"JY8UBlaWHap5huhi6tSBmayom2uW1SqadQcbWrMtDkFbWxqKB8cPlGIPP8b0wECFs4/DqQx6uxrboeXA",
-	"2H8JX8JnGqoSJcOS1HwuPsRUAygeHZOKpOJ70NrwWB84kc/ZdUDlrFqa5OCK+lDd2cPdGjM51wpjpDSF",
-	"V5qrvCSwxGL5oTTCcb+PrjuN35CbpOMNpYTd+dZaJ8BDdyjEwA/rHn4WGMk5CkJZT44x5kJaSfsi6kGp",
-	"wH0VaNHtudw/aZ9WZbKrQA62CCVYkMRZ6sG0YUHq4YeSLQFJ7QZD4UMVaKfIlhwlrnCaf/cBXt1SsJrH",
-	"Fp8xgMeVpkxuUquHP5cW6qNT3Zp6VJp3jlC6Q/MBLFaLpK2c7NnSnswxNZlDNapZVGDg0B2hTIUbOPMe",
-	"cFYMlqUMrFBzRiiy99kkZNvpjLS6Xw93p8JU5iaMYyLh4k86VzNN6U78ra23/6JnnA4N9bxbDGZufuAw",
-	"6PlSj42kBFDKdQo5PywEV9r3YclOKMHD1ugwYObmsVDaHk96XWe6aWisc4mQr2fQ5RTVLmBKuNX/Wbb1",
-	"2NPxpA445wg8fmWvbbz4B0o60STKxUmFlepZ9g1Mjj3LGajfHEd39zoC5VFbS0X/5uZmP/dQaPPaOLpp",
-	"cpj9mhXi87W0Xxvm2iT3gojdxQA0ksAeTBuPllic/EN4XoPRxvorG5dAX0dtrdqD25rO5OI9pu2VAUKx",
-	"jTFfGTXeJ0KpM1ugJ127H8bqXKNncMOuS3Secy4+0XBh1neDetW06ZSyfB+H7b+Mhf1kfUnDHYl6DIdB",
-	"vw6wzemULKnQ7p/0zG9a5b/HGheC1/t1Hp0987BrFnEkV17A2nWNzRxWrr61wANqm43NNYtbyEVzuuKR",
-	"2xrdbPJqR1vcag8Zm7YTlql/6AB9bB88XCj9rV5y/W3qspd8d5m1Amkohv8kIW8PYlQVtrC4VXivv1Cc",
-	"K3bQcXH7rePn+2299/frtSSx63+bXP+zZfxC0aZ+XUJps5fp/K14/1Len7zZ6uvp7n73twAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkfNGjkOBcDjCKSOHTpoyFwUSJFPmowiWEeWkgWMS",
+	"ocOMGzuCWNmShQgzHSvSuZlm4QwZInzSyTOS6MIyZ0iK6OOzDco5YaK6hDlGJs00NnXg5CgHhNU5WLUq",
+	"ZdpS7Bw6Mt2cmUpVhJwyceqkuUvG4ZaBb1gmFXE2bcsudZ2UuQOlzFCMId+MLHkypQg3YaxuRdl1Zk03",
+	"N51kLgPijRkQdCaCGDl0bVO3cIvOrUsn6+aYnsGCFkuFbenTqUmzHrz0tYi3cWfXvZt3b5m+Ov5i1ozY",
+	"Z+PHAsOwYfPEjF+BJO56FzviBUGDCBUyfBFxYsU5LxQzdjyVBUiRJE2idJkGukCuXn12UxVupJEXaf39",
+	"hppqw/kElBxCOUWHDTQQx5aEUEnVx3J46cWXXyL0JwJiiG3oU1FAuUTQQmGMgZ0IFIWRBhs3hQFHGnSU",
+	"kRkQc9yRVVRyuADWYNO1JcIUPp4BJAhBQJEECFTo2MZgdchBo1ho0EEHHHPo8AJ7SQIp5Bv1vcRZgLrd",
+	"FAQIWBnEBmlNPplaGHSAUMccKIEQxmqOvdURaRbp6QYIZeCRGRxvovYGCCy1gRBydJJmho50VJlnUQuS",
+	"9sRIbsQJwgwuwMDmSGOkYUYaY9CZpk9soKoQni4VqSYcLaomQ6hUWnlTllt2+eUdwLpgY61luNDRGS+0",
+	"OsarKL3ARBJDFOHEFEW0cCsMLmTZBo20kdTGHN1NQZIdru6qJZdegvkjSWO+kCOE8BGH45s3IbluWdf5",
+	"eddgdpA0R5pixRAqrnVJppCNadwEKrYwDEZrapa9wJplUb0IYG5hiSCFY1W6MYee2/HJEAhmcNRGpmzm",
+	"8RZFC9KJ8p0kgYBGoC0ui5aiXLgh2sl4krETQmSkYdVCdZyMEh0ugNBEGGUsi9nHOaJXVlo4mvQxVjcq",
+	"xAIICY0BghxoIDTGnWyyTLWWaVyNo55WIc2kQjoO6vIZcoRBLhl7hlHHGXWUsXWLIKTRYh2tXk1R0kNU",
+	"GYYYOFZZWtCLsvFnG1t3hNldhFZM6JtDV3py11uPLcccZCf4pot3Jk2EXh+3kQZqVd44x9ZwEE7u5Xp6",
+	"TdIbH7e4tUlulEpGHQuBYEcYMpGtxp10vJF0EoPO7PXMjNeGlnBsRLpn0Kh/6zb0OS7pchhBy16qXILm",
+	"+DebWVWdNgit8p190kHAHcagcMx8F1x7Rn1QWffLkVne8Ka3nCRwBiFJ0ByTNCuk4XhtKJ3PtGOgOmSG",
+	"UYJrA+Lq9rHmfKxfraqTGxCiqJLopAxvMpVCfHY2qyUNCnVDiXr0VCeFCG01+nNM3ewkB8wYj4B12JLL",
+	"+pUQzFgtc45BYp0qUqW0PW9QKCyDCt3gs0lBSD1FI1mLZpQ2J4IAhkzDU/FsaLQCUQ4EdLNbf/LmtTkE",
+	"Rjt56hntsresutUpQSShU9KmcCdOBe168Bvcx8hAwI6E7lFNy1GlyjJCue2tb8ZD4db6hQZUEW5PRXnX",
+	"8E7WKjHsLmlN6AjjCMU6R7GwfWj7WCd3Vzaf0bEognNBznImLp/5j2yTKhz83iCGjhzxTYuqHRtuh7yv",
+	"BVEORUvazsxCpyOCcG0FmgMbtlaGOvyMikLDIifTIL89saEOqPtY1144Mzxth2x4SmBZnllDzVHwQHUy",
+	"g95KJYbUgQB6emJmKjeHI3JaBIXf/CAKeehDcvVrI2E4JDY7l0XJ3eVk/dka2MRGtgKJAQ1Jq0KdRrId",
+	"9aDkQKvhXd8wF0WGahAEtczn8ZL3scCABZSifN1Eg0e2+F0SfmnwJEcmOdAoTtFnbiCe12JjQJCSqzbF",
+	"AoER7rQsQtUpnYzSC/3sN6iusWlZb5LJHEDaPBMGSalMJU1FCmhBvOVubN+6HzPPUNCB3nIOSYsC60Dq",
+	"qO28L5fvqyajClkWoprkQFv7V51GM1hwdpVkKHxfGu8Whj0+B6c6jdzktlbXox2wZ1xLGxsC54a/jQGt",
+	"WBmU/3QSzTQkbakRIY0b7VqqSgVtUO/Bip3q9MoC7UkoLkTpY0G4OSlOioq7fOgLAerRrULyqExDrC5D",
+	"4pg0FI12titKMRNbwzpQs5SBYV/W3CBL0PjEYHbUTRKgIwIjFIUM+XIY8gjrr++YCTdfyVhtzgC1RZ2K",
+	"De8CgRjyMJii3ORAcuCvT2Qllvk2xCftiRF/omaZ4hgJObIpk4NrhFD+1uUteaCXWB40Jar850wY2w1h",
+	"woAHoWUxqG3QqYLuQjr81vdrHOthf0UMYAFfZjQ3aZXrWnMciSgYIxymk4SOYiHjZDJDHtlQF3zC4oN4",
+	"bD8YkQEMGoaRFeVoIS6xEaJQpSqEvEANbtwNRHxckQVTxDLhKcN4RFCe8zhZPfBJ8HtecB0JX0gsyKub",
+	"hU303s7EV8SsgfEcnAyrurBEnoR7kZXVk2U4bDlVn/lymF0i5zC4JM1rbnNB3ryQOJPZIi/QCFnoYmgQ",
+	"//kmxCsUqXLkM5KMms+ka0NFAnyTjS3SYyDb7MTKdJC33MbPAhLLEO4Sqd5xbTEi4yzK9JXU1T262HrC",
+	"nHYkd4fnDAa8XXbDeNVEBvTSh8kdOpoQAsPfKiPkyi/SsrKyLemwjNk9lsYIpm+iafQUcT2Vho986ryh",
+	"UsM32CK4jqL01O2BB4dNXe2JXTrkHOjApW8cGjQiLSNlKqvk3IzGiLq5HGkwu7vH8L60eOhtnk2np9Ps",
+	"+TR8+M3ni51aLIFuMiLLdGi94VdFGMeyxh297o5PGiOVFrmaSe7mk+Nb5aHOSZJbbmqApxoPq36sqztC",
+	"FwQXbdblFsGwKZWnPSXkDiKruggk1qcX7KE/fdjMm3L0azRljCVr7zqbZJOoQIvhnz4j4cGTQAQ21YHn",
+	"J+nLdyeT7W2LhQhRzFGdfUKrurWtvdH58L8BJgK+KyjQzWNU4hXuX5jTCQ1EwrFYRATu5nxIBw/3G8h/",
+	"LJAgPyZEC6FQkY10ZCDRZckLl/iTKQ6DCmHE5QAPNNwdY+1SI/rm5n6KzrMDeEjrpt1iXn2Z5T1y8pTc",
+	"3nBOObzhI2qq99snwKf806PeaqWLPdZYvwni425su+fhnkQoU8XaHuJaxxjXe7I73ksjt7nLJVF8d22E",
+	"9xmGV17ndR1CkAcByHjr9Xij417hlzGWZxrJlnmTQgcSMWM38TCgN2CiFyKCt3CmZ22oh0yqF3RAFhRC",
+	"NnqxVyGuQXtPYXtKBm66hye8Z3GAoXzp1nzs5nHRh4LgUX1sdn2cdnTbR2f08X195naAlkQy92Q0p2Y2",
+	"p2g5t4PP5nMfB4QiMG/WV3T35mlH2H1L52/AJn4JAXWJJHXmB2tXhzxZZ2sd035JtF/wR2oINi6QtwUC",
+	"USVXIgK8gi5fMjEJ5wI9ci/tgjBTgRgBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/examples/streaming/stdhttp/sse/streaming.gen.go
+++ b/examples/streaming/stdhttp/sse/streaming.gen.go
@@ -7,7 +7,7 @@ package sse
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -295,34 +295,36 @@ func (sh *strictHandler) GetStream(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"ZJJBb9swDIX/CsHTBjipnNz0B4YNxTbAPe2m2kzCwqI0iQlWFP7vA+UtXbKLZVB473t80BuyHBL6N1TW",
-	"mdDjwDHPBF+Gb18fYdBCIbIcYaBy4ZGwwwuVyknQY791W4dLhymThMzocd9GHeagp2q2D/Y5ktoxUR0L",
-	"Z13V30u68EQVAtSGgXRoWJjSeI4kWuFDEoJMBWYW6iDkPPMYzODhpSaZP8KYRAOLRQygHKlqiBmCTFDp",
-	"55lkJJBzfKayxRa0NPnnCT1+Il0XxA4L1ZykUgu9c84O8yZp0f8j25B+BevKfv+y0PcdWgz0uHO7/abv",
-	"Nzv31Du/d965H9ZWHU8Ug6lysUDKK/Xd476q4XYTK0pPBHQhUVtLX7MBWZSOVIyxRrj3ebr2c+9wSCUG",
-	"RY9TUNo09dW2amE54rJcJ+n5hUbFxUa3hH+fTVPUc4yhvP65gkcWqu/3y/I7AAD//w==",
+	"APeISOPGzBsROgTSSUOHTRmEIqakaQPHIQglU544YQJiCh05ZcK0IXimYxk5dtKMechChJ2Tc9K8cQMx",
+	"hgsYN0X0afkGThk3YeCkgTjjZs6WcMLQQTMHocAXTkWcKUMnKpkyc8bISQNn4UyIUOS8SXl1DogwIOZ8",
+	"DNkGxBszFzM6AUHmzZg6bX7SMYtiZhkQPuWAYEOwDIuzcCqqVCrTzQs1c2aySQFizEw6YQiSPAtiYV61",
+	"IuGcdUMmbZk4dX6uBOEGr5iTLkTwDMx4ZhIyEI9Q9QhSpGwRIOfAmTkHa1QZMGBEteyGjt6oQRWPqe0Y",
+	"suSoZfCEdhi1OGrVD3XEaOk5vAjkMma0iBGjBXIqMWDomCE/uRadLbOiKdMmTFQ4YgW2kHEJieBdam6s",
+	"ZBVWWnHlFU06RHQagqu11sZrgr3V2X4glPFSc7GRl4dPEBHk3FRy4CdCeQtmtVVXjUFExURYYUaRW3At",
+	"9ZeHeoUogkFy9FdVhGQoVUYLLIpIYoRqbeXGGTrttOKI5r0hhhpljFFVH1y2VFaDMH4VIUYaccQbW1Hm",
+	"h1d/cuQBEZlzMVGYWWf6xiWXAQE=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/bodies/content_types/multi_json/multi_json.gen.go
+++ b/internal/test/bodies/content_types/multi_json/multi_json.gen.go
@@ -5,7 +5,7 @@ package multijson
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -779,34 +779,37 @@ func (sh *strictHandler) Test(ctx *gin.Context) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"zFOxUsMwDP0XwYavSQuTRzZm2DgGN5Fb91LLWOodpZd/52S3hd61QzayWI6s9/T07AN0tE0UMQqDPUBG",
-	"ThQZy2bpvnXpKApG0dClNITOSaDYLF1+2DBF/c/dGrdOo/uMHizcNb+4Tc2yVsA4mgsUTzQRxRPBqJ85",
-	"FpReX3feh69n6ve6S5kSZglVhw849HONZJ8QLLDkEFcwmppaXEmNBjJ+7kLGHuz7CeJc8GFOBbTcYCeK",
-	"pfKuc18lUHaiCd1WzSF6Aht3w2CAEkaXAlh4nLWzFgwkJ+uC0nAZiIYrLN4pR5n5Sw/2OK83ZIGqFFlO",
-	"07thuCDLRK/+uFK7v7hfi/ZJlx65yyEpB1hYEfXHw4XxpoJz7xeI7T++sQYW7fzW4bOORp9dMXv8CQAA",
-	"//8=",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWE0YNxIEI6Cul0DAMHDps0Y8LQSYPwhUY5K9TMQdhx",
+	"zhg0ZdqE6UgiohmHIka8IGgQYcg5L2zi1In0pYg+fViIIGkSpUqWbl6YefMm5kw3NW/m3PlQRM8yP3UE",
+	"HVqQ4tGkYplq5foUKlSpSsc2LDuljhkzafAIeUMmT0c4ct7AKSNn5cWygMuwIROjI508i4HOoSMnjZsz",
+	"T6VGnizDMuYymjl7Bn1XRMQ4ddJEJONwi4jRlEWITiOZTOkuUi9nVvtGjJoyY0RGFeG0LGLFjB3vFYi7",
+	"dFnhqNVu7vy57vKtbw4nXtyY9/TbvCdXvn46NXfWdpd73urQTR02bKRCd0MyDdAZLsAQoG4iwKESGucl",
+	"5RdgeHR0RhkilQWdHFchlARtavX1V2BUSCSSVK/V4eFghXVE0EIhjVTSSSmt1BJIm3lFU1l56cSTT0AJ",
+	"RZRbCyFVYxhIacggiYbFB6JEFFl0ngww0NARGRKN0RkcLoKl1hlc0WakCC/AGKFAD34pwoQVunEhUB1u",
+	"RmBEEyGkZEdMwmDiRymWRRWLZboUBkwyzSjQjzeilSNbRSXUI1xLAamnHHVJdadVVc7VVZ9W/hkXWQKd",
+	"ldZaOxp16I9IgefdckyulymOaunYlqcMvcBmkhLpyVF8UAUE",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/extensions/x_go_type/x_go_type.gen.go
+++ b/internal/test/extensions/x_go_type/x_go_type.gen.go
@@ -5,7 +5,7 @@ package extensionsxgotype
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -920,43 +920,55 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"zFZfb9tGDP8qAre3yZLjbi/qU4dshbE/AZoVe2gD4yzR8rXSUbmjUhuBvvvAkyxLkZpkBbb2Jb4ceeSP",
-	"/37iPaRUVmTQsIPkHly6x1L54yWldYmG5VxZqtCyRi8xqkT55WOFkIBjq00OTQiOFddeBU1dQvIOyCCE",
-	"wJ9I/u4tyn87qi3chA+eh3BY5LSQy0XroEewuW7tNk3/iLYfMGXxeVK67n2Pwd6pop5DO2drfTlVHOCC",
-	"BHKivMC61ln09u36coRalxVZPidooAwhVIr3cqd5X2+jlMq4FcdeLnCuqcS1YczRDmDo7uZRT1YxDnxQ",
-	"oUwekc3jQ8y6xNjLTz6u2ngnmdKGN8ptRHdT6FJ7le8t7iCB7+Jzn8Rdk8RDwOM0iY3od2+jCU+Gu4R+",
-	"sdFzn3UGfea+2Nx/V8omBIu3tbaYyQyMw+/Rb3W+0YYHk3BuxL/QzRRop7HILuSUoUutrliTgQReBcpa",
-	"dQxoF8jcBb7lnXhiLMfj6J9cQNidVtM5bEIo1WHdvvypl3oPIvQgVnMgDDrGLGijCD5p3geqKChVcuvz",
-	"GH42oM7LlqhAZcZ+poM7zG5no38wSecMsfxxlAS/wdsaHf/pYf8qr3u/L54XH9X8TYQ4JbOngvZNdqzw",
-	"b837V0VxtZuhAz9bqhW+e3zK1pfQhPcDn+6jrhZtj6liUZGwmIWEbY3NzSz3ntBcdY/agkxQKf5qFB0+",
-	"M74QFG/O9ftaH5QHTTTENNNAnlV3NO37Hk6wIxv4A92htTpD9zJ4CNYr4YHRGlUElUo/qhzdy/dm3I5e",
-	"TZtCG2wpy6JRpTZ5oEz2YNBOoqGRIKVyqw1mLc08UZfovZH1Q3MhIQs64zQZFx82OW18JkK4Q+vaiC+i",
-	"ZbSUclOFRlUaEngRXUTLLue+DWM8qLIq/GKRo6+RdKkSx+sMEvillb9GmUWLriLj2g5eLZfyk5LhbrtS",
-	"VVXo1L+NPzjBcFrEnvq69TuaL+C4cFe/yW0T9lhXzwC7+j/Q9uvcI5gtEX8W72vkNyKXglhVIqN1nqO0",
-	"GLmt0R4hPA2NEr0zwB3ZUkgEMsW4kO0Iwm+bT5qb+ZqMUyeLTpApVqcMcrdDzGbQLxgtQaDjnyk7PlJl",
-	"sfTDvyu1t990JDSC/uMUek7kCatpmn8CAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIoi8GVOnjUI6DgXCkfMGThk5dNKUuSjQTRiPIUXQyWPS",
+	"oYg5dOSkcXNGRB8WN+mEoVOHpQiFHR1uEYGwjAigdO68eSoTjZwyToGaeVNHjoguUGk61RFUJ0+qeFqc",
+	"edNipskWLmGS1cjR48IvU4QSbdjnp0yxNt+IUVNmDEi/dDt+zDu0aMyRJU+mXBnTThg2dcYKdDu27M6e",
+	"fcPWJCuYsGGfQJMQicnZJk6zPYGmXdsWMNm1b86wKVOnThoyLqpUUY1WLVvOLdIYfIMyZtzOuHXz9k2G",
+	"KpyhaGyeSUMHTR0xLgi2eRF994vev336nVKwTJKFZc6cZG1bxE468efLNl77rfKDzWH0nE1yDJWVCNd1",
+	"p90bbITBkwvMnfECHi+k5NELBeKnHlDsefTEYIWBhBFkJqGkklH3fWHRFxmW8QUbynEXEwlXmWHTCC+I",
+	"d1BCC83xQkQTVeRjh+7BJ59X+9HWGlktusBEjIcBleKKr302Y4035ljQjh/5CCRFFr1A5Hv4HVmckvVV",
+	"eZZfU87xBXrVYURjGTaShaOOTfX4o0RgDtkemfkhKcJsx9VX3nS/BTfcakkW6t9yAbb0EnRv5LYbnNZh",
+	"px133oEnHnmVSnceder5dVUcvl0V51JtfqFmbPbdtaIYaZzxxX1fidZZaSGiJgIVK4koEkklTmaUGSqx",
+	"QUYMMZGx0hg6wZESQjYFAUIYchSYBwhvmAECUm2AYBlmlEmJXxtGgasUU9KmgRCzQJU0rRsy5PrXaJ6t",
+	"CVRFeCRx7kU16GoTttr6imwZytaLkbMRRTtvtSAkhFMZZHALomEg3MHptWywsZGBFQ8IFImSnRjTwcoy",
+	"i9GSIohR6W4OGpwsGQpvlmZOVoYmwqmpUrwuystSBXS9YN2768UgNdpfGXBNalMTeQCLkxRloBqsE8FS",
+	"bMTMMiNMxgzNPuuwu25ALDF+FfOKscbdcUUHxx6PAXLETo9MbMmUYQS0yjbj6zKDZcTs19D04fvqhjtX",
+	"3fOqIuwt9MxEC0wa0oizrHbSg/KH3IBkQS01HVRbjZOvVIh1BadBdPxEncNGZmLeAqWH0WVsrK6UQHPW",
+	"KcKdW+bJ0J5BhkncTwIRunQLc6yRBhwtyEv2ZS0cdN98OuSUWR9d6Gw55X6VbtLp3T3RLkKXbe31Y3e/",
+	"btRQhXd2uNIsHwqnosTBL1ZykAorAuciyE/qyJq6Dae+E56CgMpSZRhVevxiPOQkb3nNG59L2BC9N0zP",
+	"K9WTw/WAMhQWKS4Nqmqfa3B2Fvvhy3+JEk79MoemRwFIf/xDYXUAqCABdoeAnzqUAqvTF1N9MIQ6WEoH",
+	"eQZCnxVte6Y5jM52spWwNWx5DyNLA8UCgq3IAQSc4ZYdTqIThu0ABFN0IXPeZsVv4QE/cpggCK4zhjWE",
+	"QT5z2AEX3BBGpj2niswBwU5glJBvuaEjILhKXD5zLTeELGtpQ1ogFfKSz8iRjpqjonholZCKsQ0NYIzk",
+	"Wx7IPOeRj4LSg48cXDBHqqSEDruxSRnOqJA5kM1HePjCWr7QGqBsUQ6upBZZYuACGPTSV5FxCRzSYJMZ",
+	"uICXMMhUd4zyglW+BA6pxIh89Oe6oZAtCXESQRHw8MzdHKEMmLvKHHY0B9iJQAYwSCZGCAKfhcQkDHCA",
+	"ZhrkNq8XqGEOuoQInypyJTplCU88+t2XhPSCxNhFiX5hGLSgSDabPGEJpfJLM7lpkN3UrH/gjEk154VN",
+	"m2yzm2X4Jh3qBRRxktOc6FSnQNiJH3fOLp4woifZ7InPsmFkoGHop+54t5yAemmfYTLoYvTimB4CRaFj",
+	"06UIHhpRoGCoUvqbpkZLZE2EdJQsIpUCVDNVII+g8SJbiJ1NRWA1OeSBKvxjH1BwejLmVEREIiCDgdqi",
+	"nAOx7H0sdBSlEDg/FTIqr8f7zxid47TbhOpS/0NQAPs3QE8ZUIeYYqAmmcbJCM4LeqFEo0OsV4a+FM2k",
+	"CCmnUVLqxIVK0CZEAoFchdJUEVQoWDGRKkY2es1sfo4qPAuWEN5AhrOuEyEt1R885SlThLwWJyu4Zz5v",
+	"AlSd/rN3PgVen15w2x76cJyhRSkMaFDapI4VNzy0bh8CAg==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/naming/identifiers/identifiers_schemas.gen.go
+++ b/internal/test/naming/identifiers/identifiers_schemas.gen.go
@@ -5,7 +5,7 @@ package namingidentifiers
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -629,38 +629,42 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"lFTBbttIDP0VgpvDLiBbcpI9RLfFAg3SQxE0AXJIchhrKM800ozKoZwahv69mJEdK7XbokeK5Lz3SD5t",
-	"sfJt5x05CVhusVOsWhLiFN0JW7e6cbdKTIw1hYptJ9Y7LPE/CCkPnRIDb52YoY3p+BUzdKolLDFITDB9",
-	"7S2TxlK4pwxDZahV8WnZdLsy61Y4DMM+mYj8eyeKJTxYMZ/6dkl8zObe2ABjC0RMCKkFXq0YUODGtmwP",
-	"5JdfqBJMOFT1bGVzF5sp4amqohBm4l/IxXhJiok/eG6VYIkfH+5ndQpgrIRUOX9yuKMdIcamA6QR6UZl",
-	"1tX+WME1OWIVA/A1rFVjNVx7sJqc2NoSB6jZt8AUiNek4YU2r551yEDblZVZQ0rHfUT5IXtyZ0z1TFPV",
-	"KCZ9WFDIQDkNZtMZckpIw34Cs5H7+MCoRqw0kbxTrXWrfErm792CoPaN/gczXBOHUcpiXswLHDL0HTnV",
-	"WSzxYl7MF5ils0gzzm0IPYX8vLjKz7ZBeIhfVyTHk/nfUPUSwNYTEaCY4CCOfUfcbDBBjlO80VjiTQQ5",
-	"L64imelxP24xjgdL/Cs/WCA/lOTvjn94HrI3xhdFvq1V04hh36/McEz4848rgmB832hYEnRMtf1GGqyD",
-	"tWKrls1+4pjt9Z8QcVGc0HDCaRNmf+S4qcLLRb5dJKifL+V2z2Rit3h9yXBvdjsh5HI8g9/pGPF/KeHU",
-	"BndHmR//MqLEqd8T8HunPz4Pz8P3AAAA//8=",
+	"APeIGPOmDZw3bsq4oTNHhA6BcMLICdOmDJ0ycho+FDGFjpw0bs4kcQMlDB00DgWSKTNnzEc4dNIgdCgi",
+	"CIg5HkGeARHxJE+JFC1iFMFCBEiaPVEWdROUJk45REXIKROnTpqpZBx6rFOmaEs0ZdqESSmCTh44ZZzm",
+	"DCmij1uvY8CK1SiwRkeJDK+kOemkThsxQzeubPky5kwdIqigSTPnZtywYUAwrXiTDt7Gd/aiARHZjV/A",
+	"UIuaRUvzjRg1ZcbQadvHa+o6H81OeVyRrogwY8awnNOCzps1CskClojRyBs5YlcjVnKFSgszx5Nzzr0b",
+	"hG/gblxwcRP1a9i0iIdPDV32LHgRaOjQgcO6tVE30MkOdpkGpkzuiI8oxGjyPog3ZoBgRxhspEEGCEe8",
+	"AYKBCsVkRhoYNWaGHAWBMNUcGNlRxoHA5XHHcWTMwQIIZKRxxl4tsFFGGCWGJFlQIm5HwlRmtLDSGGwQ",
+	"d2BEE1V0UUYjhuHGgWicBRZTFx2I4Riw7ZVHC95RNhlL2nEn2l4q0jSZTi8wuFAaD0YIAgpRhiHhG2yQ",
+	"kUJUGmZ0H00xuACDnG0V9QZaTMGRBk0zyOlCDFElZVuXc8zB1RwvyABDDi+QsMdTfZB1hkXysUSffYeJ",
+	"MARYY6zRGJg/9ShURpxNRWJqOWLFE4VoycFGHlHdyZ9hbiSRFWJJFMqVojnUKQKPQf2o0RYCzViGGTSN",
+	"8AJBBiHUIKLA+hjhCx19FNJIJZ3UVhfuEWooSy/MAMMLe5hBIBsnUVjHGWhEKpilhb2JmBQsZbghCB1+",
+	"KEeIN6HxRh1pggDYqsemgce9IAkoURphiKHii7W5ENWkygkk60S02kpTrt+K62u0ow4r0FGIJRXVlDSZ",
+	"ywa6aKjLblRTVXXVhlrJwRVcco210WjnPaUTa9wW5e2hL9AQA7kxROuuQBRXSlh9tNJUkqg/QlxGZXjp",
+	"BEJmPnn211B2ttofQhrjqmsZRgcKlLQZOUTse0iZpJQIKCOW9NowU2UVVjXfLEKZZBmLLGLKMntQQgsh",
+	"WiaidlkmR16a9fU1VG5x+9bfr8UGqw5v46Zbob39Fhzn3HIbEA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/options/compatibility/compatibility.gen.go
+++ b/internal/test/options/compatibility/compatibility.gen.go
@@ -5,7 +5,7 @@ package optionscompatibility
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -15,34 +15,36 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"vJFPixsxDMW/itF1x0na3ua2lB7K0j/QHgNFY2snajyysdTdDWG+e7GHLmk/QE8W4vn5956vwPKYYbxC",
-	"JA2Vi3EWGOE7qamzE5orlZTqE/lceWbB5HOhik3oOfqAyjJ7Fk/LRDFS9FoouDNRaQ50lIrP7vXOx+jU",
-	"KsvsHmtemsB1PUuf/5hsyynlaec+8Qv1h+goKNGdacLpLuBC6U4Fz3Trrm75peYmegWPjl4wWLo4VPdc",
-	"2YxkdxQYwNgSwQi5x9Z9yEtB44kT2wUGeKKqWx9vdofdAdYBciHBwjDCu74aoKCdtDW4L2Rbk4mM2nSD",
-	"BSPYidWzevQ9wL3E9y3Cj2+f7x8+wACVtGRR6mZvD4d2hCxG0m2xlMSh2+1/aqO6goYTLdgmu5SWZKsW",
-	"1nUd/vnRLw/bdt4g/0abyb6S/SeGdV1/BwAA//8=",
+	"APeISOPGzBsROgSSKTNnjJw0cOikeeMGoQgqDOnMAUEHTRg6IODIYVhGjp0yLd48PEMwDJuUcEp+nOim",
+	"RRoyLcaEmUPwjM2aZdqIKUNmIc45MceAWFOmDJyNHctwcSMnzB0Qb2JWlUgxCRkQc+g8dHMGhBk5b9pw",
+	"RFMGbFIQBNe2DTq0KFG3ZZSKYfNGjAsQTdLgIZpzp1Q3Ydx8ZSomjJgVOtuUYbNiDmKmWLXO7EpmY5s6",
+	"YUEMDTlyTsmTX8vgCTOGDps8IHaCuPOQDp0yblxMFcFChETXZSxm5epmzosxaeHMFJOGTRo6eXiLOCmH",
+	"J0WLMVzA0C6iT++suMPASWNxhnbuvZV3nINQ4IuYdNqLWMimzG354LfS9GqxY5o5NgEYRguMORaEYkOE",
+	"IRkbX0zhRBBLFCFdaXBQZBp7CYkgAwwwyIecG7eBKJ94cDinE3EvqDHHdRk2xFYbYcgHXUwWhTXWGd31",
+	"4d18DDkEEXEWPbFEjjueYR9+mhHHnw4iGEkHFEf2RqGFDMm3YYcZfhhifBmSaOJmbqS4YkUtjvFijBnO",
+	"GByTNvZEZG8LNfRQRDQFOaSOePYREA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/parameters/roundtrip/chi/gen/server.gen.go
+++ b/internal/test/parameters/roundtrip/chi/gen/server.gen.go
@@ -5,7 +5,7 @@ package chiparamsgen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -1616,51 +1616,92 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	return r
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3FpNb+M2E/4rAt/3VMiWne1JPQXbbZuim6R1gC0Q5MBI44hbSeSSdDaB4f9ekJQsiZL1YUv56C2xhjPP",
-	"POQzFIfaooAmjKaQSoH8LeIgGE0F6H9WJGEx/JX9pH4JaCohlepPCU/SYzEmqfpPBBEkWP/+zAD5SEhO",
-	"0ge02+1cFIIIOGGS0BT56NwR2q+Tx3Lo/VcIJFKmxo+O/pEqq6cr89DfIsYpAy6JAXcRlqKRVMIDcLRz",
-	"0YU4DxMDKnt4T2kMOFUPC2f/57BGPvqfV+TvZcG9qwIPh28bwiFE/m0+2FWhizh3FbdVjGvChbzECTQQ",
-	"4yJO46YHVlRt5ZZc3WlOSbqmanBMAsgmJ9WB0OeLG+VdEqncoxsQ0lkBfwSOXPQIXJhpWM4X84UypAxS",
-	"zAjy0Yf5Yr5ELmJYRhq/l823yc/bMsxxslNPHkCnq5LFal7VbKBfQX4sD9CuOE5AAhfIv62sH8xYTAI9",
-	"2PsqqLWK2qanujAyNpCvYSM3p0FHRmUuJd/A7s6trvGzxeJQvL2dZwlhp2N6AaX/EGhnQ1vUaKgKgnGS",
-	"EEkelSE8sZiGgPw1jgVkiQW5mzw15JaoWlOeYGlE8OEMuTVN7NxeERU9BwLCyRGzKKGDOcfPfcPiSlgi",
-	"IRG94u9/MdEa8NRgtPE9HYw9LTQXTC9eaAVQv1Jmh65HbKPguIhTyb2aSWAMCg4bMwgoqpOgnjlCYi5J",
-	"+uB8JzJy0k1yr0tlo5elqBBhl267uoSwxptYHlthIN2YpdZYYD6lm+RaFRbRVWGu84cmReXWecTxBkSe",
-	"57cN8OfSCtOuZXSdFdEiY/UE+bfLxcI9Wyzu3B7FoF5yfzTcVGaCOvlqyZKPAIfA28rrb8bi1PIa5W6y",
-	"5P+eXZeGTFpoW0LPPmW14UVKbx3IubJuBvFihfgAqlcux3VUpjY1kzVFdT6E4N0V6XoimaM8IQvg0YeO",
-	"lKaz31dXl3mRcZ17uklDBwtHRuBw/N0xWJzMx2GBYiFmNxGnm4fomB3F9ricrTLr2Rcio9llbv1iu0yM",
-	"7yHO1q7Wl7ed64r6Q+ur/h/2sHohblJPn7f0cfTtIiGf9RlIZ4jGfPcvc5afjoaSduiQNAZrfcT/Uvzs",
-	"t7ThFJU34glY6rGkJqbokjYJr5uf6rgWdsrbxn9Ievv8q+IbQFyn+k5h7k3Ir6a7bnb66O0UXl5VcAmW",
-	"nDxZeiNhezX6XBt0TCki4eRCM9lNR9heaIMYO36P66BsmMKmJqcktZ8G8XPSBtdB0QCxTcZPbX8jYQ9y",
-	"Rtjd3rPi6pvbMNZO2Nreh+qqcutBzWn72pvWGcNCZMfRPhc014V56/XMgJP2q1y+6IblzwCsuHs7lHLJ",
-	"qqNVGAKw9t6P1ScNjeujNWO1TYqFEhaYxz7uZ8zFShEQthH3Z9WygzzBcABOmJs7rZ09i0cx1hVLwaCG",
-	"U4Bv6M0SdixcNj5chaaEdmyl/EJ50jnV2qhjlnt1k+3bhPHpUkPRwG6yherFQPXrKtucTX/HZ0UcI+A+",
-	"1a6LDzvbaa602yQ8WkCrY2zHab8wfOX+uwX2uDtSy8nAK9ITKpv5jqh6wOjRYFzVhr3dzrVJEU3GWuXL",
-	"ngG0vZ3e9dQMlc4a3W/Xq8aRr968nowj+3jfl6F3076enrn+39atmga+iQb2ZCwdIb4W1b1bma305tmf",
-	"g1X+RjIGAbXvVqdMN3vN+EJkZC7Cve2yR9a1YRP2NpYTNzcUw/pzXYN7w2Pko0hK5nte9q2uBCHnIQBL",
-	"MJtjgnZ3u38DAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FDGk4FU8T8CKRbkWjpw3POU8vbg2CRmdPH3GNHmmjJyiSJPMCUKmTUzAPXWIEPPmTccwMvsgjRt27EgS",
+	"Ec34HPGCoEGEJ+e8oGkTp2rOc4tqFhExTp00Ef/q2CICtufEfxMvbvy4y2zfdAXaxWt4r1qBZnADdRKm",
+	"TWSBdHZG/hl0KGLalq+LyB5YMlChboiWrX07t0PedzuKQBpdzvTqPY2XjWnmzUg2aYyhkEhruYGfT00k",
+	"QcV3T9Ehn2RUSEQHCFMYZodh84lwoX1QySRZDC7AEOJ3zBkIRxo+zRCiCzFkCEcYdKDxnAillXQSci/s",
+	"8aIc1fUxUmHJicAcj08h5JdPR5RBR1sL3SjXbyLsiJ9J9r0nEEFNLjRSGHC4FCCMHb6gxhxRrcUaWp+F",
+	"NlqNpyW0kGpnuvZCWxyVAdeTZO3nYZQwopGhgdb5JGUbGbKHWxm6BVVHGX10gZRWIfElkAwwwJBmGaJJ",
+	"RpppFKX2AqRcSfSCRnV+tFVFPRlVVo1vrJGGeECONCSYRuomQpJLVuZqT0gNqqRham0hkFI0NVXknnZt",
+	"lMZTF2Zop0tvKOWQGWGwYRFSj0lGUKuv/nmgZHBkGGdOa/UnB050iTDYDDJkSN52g5VR2GFHDbuUsR0K",
+	"KpRjzPIqwrNsRBuZomVgu+e2u3obqGRlhIvUuCOZi65gC7HrrnYUE4ZhvUndm4ZT+TKMB7RKkQFCGHLw",
+	"mIezIwcsrQ4EG+wTwt0iBeh2ZeT08Fk4jbTsTTNKDGPGFiP1bsbybmw0xpKhrLJsLNhb7MfH+uR0GCsj",
+	"BbDA01Z7rboH61qzCDdbLS7P5Ar0cxtBv3Hu0JKt2+7S5YGtMb10b3f1yhwTyxTVIf/bssAmf9UZSloP",
+	"/nLMYM8str9lM+zfzq2lLQJomK7JKWpvrob2a3hCLfXfIJcpZOiJkxwZtdYW3Li2jyu83eRmVX5ppiJs",
+	"6hbnDHleOeiHi05SlkFy6eUYtLohJpkeCgTxWpjjrnubno6rGp1vISfbbH7jazqnHeHhFeqvk8Qt5N+S",
+	"hNjo3u95M1V0oPxUeiDcsSwaILhRRxtiYCgz7OeTnU9i0BDKoWktRzNPd9IjG0fRBiShmpFSqFUHNgQp",
+	"eprbnZt6BypUqYZUVzFVpLY3mxcoZH8zitVaZnWsI0mmCPprAxRQVp0C8olH1qFSsNgHONPNEIe/kkP9",
+	"7geCE7YBBHao1qJsmC0R2MYwWSNb+ow4wxj9sDpns91ajPieGFSKBZSCgQOFli65Xaxu8ZpXAx8FQQ+O",
+	"hFI0GEn3eui+N4AASybRkqpKaJMwKOUwa1GhQFjYIRfeSklIyNkfXUTDHALLSh2bWumQta9lpaFZqXPZ",
+	"6rzmuib2cZE2Sx8WWgCFSvYriweEjtsmFreKzW08TLNb0uilGR5OUl/KOmUmuQYzOSzqfyL4pP+kuDAR",
+	"jLKUubxkGVpQBMUhCpU9K9cq4Wa3osESjU1SY988dkuRqc5ke2OZ6hzCOE8qcpiRM2YLgpAyrDHTmcGp",
+	"XSrVZRK2RWyaZXTlGeGVTaVdU2/t5FstI0m6qjUtoOLUZNdaB0xhHiaUxRwlO59mwGiqrZ5te1s+6WDN",
+	"BMpSm3mzGkK3KUmDCu6b4wveLhfny07uyaEClMwokfPOb0LTchjUFJs61TnrvUB7JC1o4AwXm5VukqHl",
+	"gylEtzNT8j1PIDnN3U55B6fP/TR0HMPjSbbUJQAh71jLK5Pz0Ha7DFKvp1bFXviAWpY5dpMkdRIfUaFk",
+	"Tj+iU5QtUKudWgDUqA0vj0FSCUtcApPmydOi//TJebyjKqS41aRuQEgLlDCFJzjhjjZaCAtAQJk6uAGc",
+	"cwBBjLDCozuAwKHwQw9RGnrOhxKTqaRMyxxaQAU03KUOZ/DTQB8buPcBRX5DGWKM8re//rm2rqB87QBb",
+	"MIX46WUoLbjC/VrghOIO86mJVaBq1/jAU1lEgpgKQwUvqCadbm6Dqungd0dllY6IMFQkRMoLXtI/NjRT",
+	"dRPFWo5cMCgV+CiQSpJVXpJnSFwxIQz1va8m8xtFX+kQkltj6S/L96IYxfSGWGSjbQ6VqJZW1HJryygr",
+	"q/lKj6bRnx4N52yAkocHiYC+ZWBDURyoXkmJIIxlNa8GPVXjD7bXI20UyR7lC2P7OhNHe+BvI/37owCv",
+	"cMAttJWBERxjBQtMe71qZBB3eFKF9nLCTaywn5YqqEYWqgwbds+XXYfdqE6Pp73zaV+50+LtFHnGbPSu",
+	"jXEMvfJK9bw8DrKoQOheQceXRkW2slKQyS9l7re//xWIIIUE5UJKWUkHTrAzGW1JTGLYkVXajUAiPDAP",
+	"U7hPFx7UmdP8zDV/+J4aJVqJY3livNHZxXduVJ4jNSM+Q9XPb6bqpwTt41IZesiIpjIbnPAGRZeBwY9u",
+	"ZKRFMGlC1gpJmFY2s53NYEYC8cGi7jIvWfe1MKOazOAys4bb02rGYTfEsB6xGUPayrsxKJYqflh2cK1s",
+	"PHeX12+sVI7/vOPO9Zi9xtbzoeer7WYfGU/RxuG0q13pa0tmyvXd9sNV+uktQ9iZCy03ss6t3HTjcNXs",
+	"7vCE2wzsqaLXd2gBXmxWvG8791vX/45gwC3V58zp+KwcJDbCQ3jsxia7vpzuV8R71OQgWdsNBc420k2p",
+	"TG9P6ZHhJnXIXVpmC6P70yjnMDlNjV0yynqfSAPprW1eX3/3eOcDD/bLD05oICsc2S9Al1DwwO2A7jcN",
+	"ZGAygJ1ecahfmg5NgNHe+07RjoNbWOKWMNfT7fWSqyuehlKzu8m6FnhLM9b17iit+2nrFI9U33X2id7T",
+	"gAe3ExvuPZeeywOt52IT/e5Gz7viWe9sJLsA8IKXtJMHWfioI373fN94UR2Pdchr3dWnrnw6AR92zZOd",
+	"87/2OcGBXtXfXTV4NE+9ZFbfepy/fS2+vlzLAW1wodf9vahaOPmdnXRH72EHwJ/48CltGAIfPvHdkXyq",
+	"U3+e5mDNN2ogB33mJn3pQ33rJnbQV3b4dHb09lH+xGIuRn6uV3uwl32yx35BV3tDV2i4tyrkp3H45XdJ",
+	"Bnj6R3j9F2XYdnwBiIILhlBZ9m0HGHlHJXJdN2aW54APxGoqx2bYR09AE2/UNG/ZZYGlh2+nt3aqh3wb",
+	"CHDoJ3CxZ1Zwll7u92PwJ2S5d4IOpzq+x4JNJ2AvaGkxCIB7R4NXRj4GGGrOl4DkNnl8woDFBISZ127X",
+	"p0UeiIXCJmdYhXoZKIXm93pVyHN9+HNZOGwi+H5FZ4LIR4BlkCP4RwYtaIZEgoYXpyRqyHqSaHWgxmXP",
+	"N4fAJGYXhodolnJjt3JFaHahN2vYZG/hN4gBOIU6d4hxN3vt14hc+Igl9CJzMAe1dVu5lSODcolPdoYW",
+	"d0h0MEPBOIxvgFs++IZcplVagkB2MlgvkS1jxYdLuFgMZHQL6IPppGoPaH2LUogciItXqIjCRne9WIIl",
+	"9ERykAdEUAYNoz2Dh4n+F4P3mI9uqGWPZ0smpRQNk1LL93zltCf0GEXpZJBwwBnVp4es6I1upotxllZu",
+	"sVaBCIWSAZFARWOGaC8UZEG5CIJayIsJN0J415D3CCD80mrC54KZuIy4EgWLUo8vmUvPdINXB4cEGTgT",
+	"EQYCAgJKAZM/A042qINbB0wNeWFzoDOHBWIYhYQbJXqxOEv3Vjf55pE/8SICspMx+Re7xU0mdSI8YZQx",
+	"xpNK2XijyElOmZMOmT4vclM+U5WfJ2/6VIG1tpUA9TSzuB1oWQZimZS26EbsmIjbt4jwuJLw1ZJyaQSr",
+	"VIbJWJOGF4M4CUWSeS6g6HHhxlumQ2ptiTUJxUsL6RNP+XU5Y5edh5eqBHokhnb1ppWzYXqAKYjbITHr",
+	"Q1DtI1JuKYdwWT6paXlS+W6uKQKuGJt8SXp+6ZukGZg+oZtlWVKBI5oICSUKaWpNNJzpVAa0w3LaJ3fV",
+	"Y1Vs5VeguSdzhThMqQOkKJxyeWHfWYQXiZIwJyflGZShCU8gkCyN5mnZCWYM+Z6q6TBTaZUUuIR9GVS9",
+	"CS5U55/AiVTbKaCWR6ASCJtKaGLMqaB0hEv9iRXguFruCUWpZkPY5VEfKjzWWDxd9SVgNSZiVaDtuJh/",
+	"qJFxxVbcY5aBAz52cp3qGaEi+nUEsZvn6RO+5VzzcwbChT8xZFwZ4qP1eGEExJrYEUsnahQiuY6TYoWK",
+	"KZ67yGsjaHcsmXtVUSeMp186smTISHzKeJmbSAd1V6YNJpA5+J90aIpfZ45BqIoRWISe95p6yVGwyE+y",
+	"WIFdiYHbMaZXcZjf1YHqF54YmZJe6ojyKF+I2hG9B3FnikPBR23793TG96bKByXU+HHjpIAjZ4eCqW55",
+	"CoGbZ5HrV3AZ6X1zZqiK9WOKumda2qgfCKuQGkFf2oWpIqY/Rn8NOomZynT7WJn92KagOoDF2pkDuZ6n",
+	"SXnkSJeqmodD+Gp5mYR7iaAZipu1Wie32mu5Op+8yoiRGo9huiqVWgZsqBTQdqxtkKb8Z5mf+mPv+mxL",
+	"OapZ96A8SK2pdq2pyKp7OE99ipwT+IqyyYTNeVC36ZXtOq6Maq7ch66+KqnrWkLtmq9IdoyUqab2enh1",
+	"x7EBiYNAuZ7tOY4Be3LnSJFE6KqOSp+ACH7gah62qo5UmKWIqKt+OHdb6Jjxh3ftKonGKG0fW6/Lyox1",
+	"94k+GYqQpLJ3KrBCuIovO0/JeaGjN6gQe7NXmrM3Vq6vWrGNeXsZS6k/1lyqVbQSd7SeKrJnu0Agyq+Q",
+	"B7UTKrV62qrzZKJw+x20arPiirO3qLMnea5jS4JlSyO/9VzpIV0xUl38Yxg5EgMem6wgm7S40lzAtbj3",
+	"47hM2rSeCXkpmhLZ2BLbaFglSqV7K46nWq3FJLl2S7Dp2LWB+7U7S7GM+bNk+5jIZhFysCFcVgdyIGOS",
+	"gQZ0QAdwoAMv8AIlwiU/AxQuAJE4AQcuABMz1gcBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/parameters/roundtrip/echo/gen/server.gen.go
+++ b/internal/test/parameters/roundtrip/echo/gen/server.gen.go
@@ -5,7 +5,7 @@ package echoparamsgen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -928,51 +928,92 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3FpNb+M2E/4rAt/3VMiWne1JPQXbbZuim6R1gC0Q5MBI44hbSeSSdDaB4f9ekJQsiZL1YUv56C2xhjPP",
-	"POQzFIfaooAmjKaQSoH8LeIgGE0F6H9WJGEx/JX9pH4JaCohlepPCU/SYzEmqfpPBBEkWP/+zAD5SEhO",
-	"0ge02+1cFIIIOGGS0BT56NwR2q+Tx3Lo/VcIJFKmxo+O/pEqq6cr89DfIsYpAy6JAXcRlqKRVMIDcLRz",
-	"0YU4DxMDKnt4T2kMOFUPC2f/57BGPvqfV+TvZcG9qwIPh28bwiFE/m0+2FWhizh3FbdVjGvChbzECTQQ",
-	"4yJO46YHVlRt5ZZc3WlOSbqmanBMAsgmJ9WB0OeLG+VdEqncoxsQ0lkBfwSOXPQIXJhpWM4X84UypAxS",
-	"zAjy0Yf5Yr5ELmJYRhq/l823yc/bMsxxslNPHkCnq5LFal7VbKBfQX4sD9CuOE5AAhfIv62sH8xYTAI9",
-	"2PsqqLWK2qanujAyNpCvYSM3p0FHRmUuJd/A7s6trvGzxeJQvL2dZwlhp2N6AaX/EGhnQ1vUaKgKgnGS",
-	"EEkelSE8sZiGgPw1jgVkiQW5mzw15JaoWlOeYGlE8OEMuTVN7NxeERU9BwLCyRGzKKGDOcfPfcPiSlgi",
-	"IRG94u9/MdEa8NRgtPE9HYw9LTQXTC9eaAVQv1Jmh65HbKPguIhTyb2aSWAMCg4bMwgoqpOgnjlCYi5J",
-	"+uB8JzJy0k1yr0tlo5elqBBhl267uoSwxptYHlthIN2YpdZYYD6lm+RaFRbRVWGu84cmReXWecTxBkSe",
-	"57cN8OfSCtOuZXSdFdEiY/UE+bfLxcI9Wyzu3B7FoF5yfzTcVGaCOvlqyZKPAIfA28rrb8bi1PIa5W6y",
-	"5P+eXZeGTFpoW0LPPmW14UVKbx3IubJuBvFihfgAqlcux3VUpjY1kzVFdT6E4N0V6XoimaM8IQvg0YeO",
-	"lKaz31dXl3mRcZ17uklDBwtHRuBw/N0xWJzMx2GBYiFmNxGnm4fomB3F9ricrTLr2Rcio9llbv1iu0yM",
-	"7yHO1q7Wl7ed64r6Q+ur/h/2sHohblJPn7f0cfTtIiGf9RlIZ4jGfPcvc5afjoaSduiQNAZrfcT/Uvzs",
-	"t7ThFJU34glY6rGkJqbokjYJr5uf6rgWdsrbxn9Ievv8q+IbQFyn+k5h7k3Ir6a7bnb66O0UXl5VcAmW",
-	"nDxZeiNhezX6XBt0TCki4eRCM9lNR9heaIMYO36P66BsmMKmJqcktZ8G8XPSBtdB0QCxTcZPbX8jYQ9y",
-	"Rtjd3rPi6pvbMNZO2Nreh+qqcutBzWn72pvWGcNCZMfRPhc014V56/XMgJP2q1y+6IblzwCsuHs7lHLJ",
-	"qqNVGAKw9t6P1ScNjeujNWO1TYqFEhaYxz7uZ8zFShEQthH3Z9WygzzBcABOmJs7rZ09i0cx1hVLwaCG",
-	"U4Bv6M0SdixcNj5chaaEdmyl/EJ50jnV2qhjlnt1k+3bhPHpUkPRwG6yherFQPXrKtucTX/HZ0UcI+A+",
-	"1a6LDzvbaa602yQ8WkCrY2zHab8wfOX+uwX2uDtSy8nAK9ITKpv5jqh6wOjRYFzVhr3dzrVJEU3GWuXL",
-	"ngG0vZ3e9dQMlc4a3W/Xq8aRr968nowj+3jfl6F3076enrn+39atmga+iQb2ZCwdIb4W1b1bma305tmf",
-	"g1X+RjIGAbXvVqdMN3vN+EJkZC7Cve2yR9a1YRP2NpYTNzcUw/pzXYN7w2Pko0hK5nte9q2uBCHnIQBL",
-	"MJtjgnZ3u38DAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FDGk4FU8T8CKRbkWjpw3POU8vbg2CRmdPH3GNHmmjJyiSJPMCUKmTUzAPXWIEPPmTccwMvsgjRt27EgS",
+	"Ec34HPGCoEGEJ+e8oGkTp2rOc4tqFhExTp00Ef/q2CICtufEfxMvbvy4y2zfdAXaxWt4r1qBZnADdRKm",
+	"TWSBdHZG/hl0KGLalq+LyB5YMlChboiWrX07t0PedzuKQBpdzvTqPY2XjWnmzUg2aYyhkEhruYGfT00k",
+	"QcV3T9Ehn2RUSEQHCFMYZodh84lwoX1QySRZDC7AEOJ3zBkIRxo+zRCiCzFkCEcYdKDxnAillXQSci/s",
+	"8aIc1fUxUmHJicAcj08h5JdPR5RBR1sL3SjXbyLsiJ9J9r0nEEFNLjRSGHC4FCCMHb6gxhxRrcUaWp+F",
+	"NlqNpyW0kGpnuvZCWxyVAdeTZO3nYZQwopGhgdb5JGUbGbKHWxm6BVVHGX10gZRWIfElkAwwwJBmGaJJ",
+	"RpppFKX2AqRcSfSCRnV+tFVFPRlVVo1vrJGGeECONCSYRuomQpJLVuZqT0gNqqRham0hkFI0NVXknnZt",
+	"lMZTF2Zop0tvKOWQGWGwYRFSj0lGUKuv/nmgZHBkGGdOa/UnB050iTDYDDJkSN52g5VR2GFHDbuUsR0K",
+	"KpRjzPIqwrNsRBuZomVgu+e2u3obqGRlhIvUuCOZi65gC7HrrnYUE4ZhvUndm4ZT+TKMB7RKkQFCGHLw",
+	"mIezIwcsrQ4EG+wTwt0iBeh2ZeT08Fk4jbTsTTNKDGPGFiP1bsbybmw0xpKhrLJsLNhb7MfH+uR0GCsj",
+	"BbDA01Z7rboH61qzCDdbLS7P5Ar0cxtBv3Hu0JKt2+7S5YGtMb10b3f1yhwTyxTVIf/bssAmf9UZSloP",
+	"/nLMYM8str9lM+zfzq2lLQJomK7JKWpvrob2a3hCLfXfIJcpZOiJkxwZtdYW3Li2jyu83eRmVX5ppiJs",
+	"6hbnDHleOeiHi05SlkFy6eUYtLohJpkeCgTxWpjjrnubno6rGp1vISfbbH7jazqnHeHhFeqvk8Qt5N+S",
+	"hNjo3u95M1V0oPxUeiDcsSwaILhRRxtiYCgz7OeTnU9i0BDKoWktRzNPd9IjG0fRBiShmpFSqFUHNgQp",
+	"eprbnZt6BypUqYZUVzFVpLY3mxcoZH8zitVaZnWsI0mmCPprAxRQVp0C8olH1qFSsNgHONPNEIe/kkP9",
+	"7geCE7YBBHao1qJsmC0R2MYwWSNb+ow4wxj9sDpns91ajPieGFSKBZSCgQOFli65Xaxu8ZpXAx8FQQ+O",
+	"hFI0GEn3eui+N4AASybRkqpKaJMwKOUwa1GhQFjYIRfeSklIyNkfXUTDHALLSh2bWumQta9lpaFZqXPZ",
+	"6rzmuib2cZE2Sx8WWgCFSvYriweEjtsmFreKzW08TLNb0uilGR5OUl/KOmUmuQYzOSzqfyL4pP+kuDAR",
+	"jLKUubxkGVpQBMUhCpU9K9cq4Wa3osESjU1SY988dkuRqc5ke2OZ6hzCOE8qcpiRM2YLgpAyrDHTmcGp",
+	"XSrVZRK2RWyaZXTlGeGVTaVdU2/t5FstI0m6qjUtoOLUZNdaB0xhHiaUxRwlO59mwGiqrZ5te1s+6WDN",
+	"BMpSm3mzGkK3KUmDCu6b4wveLhfny07uyaEClMwokfPOb0LTchjUFJs61TnrvUB7JC1o4AwXm5VukqHl",
+	"gylEtzNT8j1PIDnN3U55B6fP/TR0HMPjSbbUJQAh71jLK5Pz0Ha7DFKvp1bFXviAWpY5dpMkdRIfUaFk",
+	"Tj+iU5QtUKudWgDUqA0vj0FSCUtcApPmydOi//TJebyjKqS41aRuQEgLlDCFJzjhjjZaCAtAQJk6uAGc",
+	"cwBBjLDCozuAwKHwQw9RGnrOhxKTqaRMyxxaQAU03KUOZ/DTQB8buPcBRX5DGWKM8re//rm2rqB87QBb",
+	"MIX46WUoLbjC/VrghOIO86mJVaBq1/jAU1lEgpgKQwUvqCadbm6Dqungd0dllY6IMFQkRMoLXtI/NjRT",
+	"dRPFWo5cMCgV+CiQSpJVXpJnSFwxIQz1va8m8xtFX+kQkltj6S/L96IYxfSGWGSjbQ6VqJZW1HJryygr",
+	"q/lKj6bRnx4N52yAkocHiYC+ZWBDURyoXkmJIIxlNa8GPVXjD7bXI20UyR7lC2P7OhNHe+BvI/37owCv",
+	"cMAttJWBERxjBQtMe71qZBB3eFKF9nLCTaywn5YqqEYWqgwbds+XXYfdqE6Pp73zaV+50+LtFHnGbPSu",
+	"jXEMvfJK9bw8DrKoQOheQceXRkW2slKQyS9l7re//xWIIIUE5UJKWUkHTrAzGW1JTGLYkVXajUAiPDAP",
+	"U7hPFx7UmdP8zDV/+J4aJVqJY3livNHZxXduVJ4jNSM+Q9XPb6bqpwTt41IZesiIpjIbnPAGRZeBwY9u",
+	"ZKRFMGlC1gpJmFY2s53NYEYC8cGi7jIvWfe1MKOazOAys4bb02rGYTfEsB6xGUPayrsxKJYqflh2cK1s",
+	"PHeX12+sVI7/vOPO9Zi9xtbzoeer7WYfGU/RxuG0q13pa0tmyvXd9sNV+uktQ9iZCy03ss6t3HTjcNXs",
+	"7vCE2wzsqaLXd2gBXmxWvG8791vX/45gwC3V58zp+KwcJDbCQ3jsxia7vpzuV8R71OQgWdsNBc420k2p",
+	"TG9P6ZHhJnXIXVpmC6P70yjnMDlNjV0yynqfSAPprW1eX3/3eOcDD/bLD05oICsc2S9Al1DwwO2A7jcN",
+	"ZGAygJ1ecahfmg5NgNHe+07RjoNbWOKWMNfT7fWSqyuehlKzu8m6FnhLM9b17iit+2nrFI9U33X2id7T",
+	"gAe3ExvuPZeeywOt52IT/e5Gz7viWe9sJLsA8IKXtJMHWfioI373fN94UR2Pdchr3dWnrnw6AR92zZOd",
+	"87/2OcGBXtXfXTV4NE+9ZFbfepy/fS2+vlzLAW1wodf9vahaOPmdnXRH72EHwJ/48CltGAIfPvHdkXyq",
+	"U3+e5mDNN2ogB33mJn3pQ33rJnbQV3b4dHb09lH+xGIuRn6uV3uwl32yx35BV3tDV2i4tyrkp3H45XdJ",
+	"Bnj6R3j9F2XYdnwBiIILhlBZ9m0HGHlHJXJdN2aW54APxGoqx2bYR09AE2/UNG/ZZYGlh2+nt3aqh3wb",
+	"CHDoJ3CxZ1Zwll7u92PwJ2S5d4IOpzq+x4JNJ2AvaGkxCIB7R4NXRj4GGGrOl4DkNnl8woDFBISZ127X",
+	"p0UeiIXCJmdYhXoZKIXm93pVyHN9+HNZOGwi+H5FZ4LIR4BlkCP4RwYtaIZEgoYXpyRqyHqSaHWgxmXP",
+	"N4fAJGYXhodolnJjt3JFaHahN2vYZG/hN4gBOIU6d4hxN3vt14hc+Igl9CJzMAe1dVu5lSODcolPdoYW",
+	"d0h0MEPBOIxvgFs++IZcplVagkB2MlgvkS1jxYdLuFgMZHQL6IPppGoPaH2LUogciItXqIjCRne9WIIl",
+	"9ERykAdEUAYNoz2Dh4n+F4P3mI9uqGWPZ0smpRQNk1LL93zltCf0GEXpZJBwwBnVp4es6I1upotxllZu",
+	"sVaBCIWSAZFARWOGaC8UZEG5CIJayIsJN0J415D3CCD80mrC54KZuIy4EgWLUo8vmUvPdINXB4cEGTgT",
+	"EQYCAgJKAZM/A042qINbB0wNeWFzoDOHBWIYhYQbJXqxOEv3Vjf55pE/8SICspMx+Re7xU0mdSI8YZQx",
+	"xpNK2XijyElOmZMOmT4vclM+U5WfJ2/6VIG1tpUA9TSzuB1oWQZimZS26EbsmIjbt4jwuJLw1ZJyaQSr",
+	"VIbJWJOGF4M4CUWSeS6g6HHhxlumQ2ptiTUJxUsL6RNP+XU5Y5edh5eqBHokhnb1ppWzYXqAKYjbITHr",
+	"Q1DtI1JuKYdwWT6paXlS+W6uKQKuGJt8SXp+6ZukGZg+oZtlWVKBI5oICSUKaWpNNJzpVAa0w3LaJ3fV",
+	"Y1Vs5VeguSdzhThMqQOkKJxyeWHfWYQXiZIwJyflGZShCU8gkCyN5mnZCWYM+Z6q6TBTaZUUuIR9GVS9",
+	"CS5U55/AiVTbKaCWR6ASCJtKaGLMqaB0hEv9iRXguFruCUWpZkPY5VEfKjzWWDxd9SVgNSZiVaDtuJh/",
+	"qJFxxVbcY5aBAz52cp3qGaEi+nUEsZvn6RO+5VzzcwbChT8xZFwZ4qP1eGEExJrYEUsnahQiuY6TYoWK",
+	"KZ67yGsjaHcsmXtVUSeMp186smTISHzKeJmbSAd1V6YNJpA5+J90aIpfZ45BqIoRWISe95p6yVGwyE+y",
+	"WIFdiYHbMaZXcZjf1YHqF54YmZJe6ojyKF+I2hG9B3FnikPBR23793TG96bKByXU+HHjpIAjZ4eCqW55",
+	"CoGbZ5HrV3AZ6X1zZqiK9WOKumda2qgfCKuQGkFf2oWpIqY/Rn8NOomZynT7WJn92KagOoDF2pkDuZ6n",
+	"SXnkSJeqmodD+Gp5mYR7iaAZipu1Wie32mu5Op+8yoiRGo9huiqVWgZsqBTQdqxtkKb8Z5mf+mPv+mxL",
+	"OapZ96A8SK2pdq2pyKp7OE99ipwT+IqyyYTNeVC36ZXtOq6Maq7ch66+KqnrWkLtmq9IdoyUqab2enh1",
+	"x7EBiYNAuZ7tOY4Be3LnSJFE6KqOSp+ACH7gah62qo5UmKWIqKt+OHdb6Jjxh3ftKonGKG0fW6/Lyox1",
+	"94k+GYqQpLJ3KrBCuIovO0/JeaGjN6gQe7NXmrM3Vq6vWrGNeXsZS6k/1lyqVbQSd7SeKrJnu0Agyq+Q",
+	"B7UTKrV62qrzZKJw+x20arPiirO3qLMnea5jS4JlSyO/9VzpIV0xUl38Yxg5EgMem6wgm7S40lzAtbj3",
+	"47hM2rSeCXkpmhLZ2BLbaFglSqV7K46nWq3FJLl2S7Dp2LWB+7U7S7GM+bNk+5jIZhFysCFcVgdyIGOS",
+	"gQZ0QAdwoAMv8AIlwiU/AxQuAJE4AQcuABMz1gcBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/parameters/roundtrip/echov5/gen/server.gen.go
+++ b/internal/test/parameters/roundtrip/echov5/gen/server.gen.go
@@ -5,7 +5,7 @@ package echov5paramsgen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -928,51 +928,92 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3FpNb+M2E/4rAt/3VMiWne1JPQXbbZuim6R1gC0Q5MBI44hbSeSSdDaB4f9ekJQsiZL1YUv56C2xhjPP",
-	"POQzFIfaooAmjKaQSoH8LeIgGE0F6H9WJGEx/JX9pH4JaCohlepPCU/SYzEmqfpPBBEkWP/+zAD5SEhO",
-	"0ge02+1cFIIIOGGS0BT56NwR2q+Tx3Lo/VcIJFKmxo+O/pEqq6cr89DfIsYpAy6JAXcRlqKRVMIDcLRz",
-	"0YU4DxMDKnt4T2kMOFUPC2f/57BGPvqfV+TvZcG9qwIPh28bwiFE/m0+2FWhizh3FbdVjGvChbzECTQQ",
-	"4yJO46YHVlRt5ZZc3WlOSbqmanBMAsgmJ9WB0OeLG+VdEqncoxsQ0lkBfwSOXPQIXJhpWM4X84UypAxS",
-	"zAjy0Yf5Yr5ELmJYRhq/l823yc/bMsxxslNPHkCnq5LFal7VbKBfQX4sD9CuOE5AAhfIv62sH8xYTAI9",
-	"2PsqqLWK2qanujAyNpCvYSM3p0FHRmUuJd/A7s6trvGzxeJQvL2dZwlhp2N6AaX/EGhnQ1vUaKgKgnGS",
-	"EEkelSE8sZiGgPw1jgVkiQW5mzw15JaoWlOeYGlE8OEMuTVN7NxeERU9BwLCyRGzKKGDOcfPfcPiSlgi",
-	"IRG94u9/MdEa8NRgtPE9HYw9LTQXTC9eaAVQv1Jmh65HbKPguIhTyb2aSWAMCg4bMwgoqpOgnjlCYi5J",
-	"+uB8JzJy0k1yr0tlo5elqBBhl267uoSwxptYHlthIN2YpdZYYD6lm+RaFRbRVWGu84cmReXWecTxBkSe",
-	"57cN8OfSCtOuZXSdFdEiY/UE+bfLxcI9Wyzu3B7FoF5yfzTcVGaCOvlqyZKPAIfA28rrb8bi1PIa5W6y",
-	"5P+eXZeGTFpoW0LPPmW14UVKbx3IubJuBvFihfgAqlcux3VUpjY1kzVFdT6E4N0V6XoimaM8IQvg0YeO",
-	"lKaz31dXl3mRcZ17uklDBwtHRuBw/N0xWJzMx2GBYiFmNxGnm4fomB3F9ricrTLr2Rcio9llbv1iu0yM",
-	"7yHO1q7Wl7ed64r6Q+ur/h/2sHohblJPn7f0cfTtIiGf9RlIZ4jGfPcvc5afjoaSduiQNAZrfcT/Uvzs",
-	"t7ThFJU34glY6rGkJqbokjYJr5uf6rgWdsrbxn9Ievv8q+IbQFyn+k5h7k3Ir6a7bnb66O0UXl5VcAmW",
-	"nDxZeiNhezX6XBt0TCki4eRCM9lNR9heaIMYO36P66BsmMKmJqcktZ8G8XPSBtdB0QCxTcZPbX8jYQ9y",
-	"Rtjd3rPi6pvbMNZO2Nreh+qqcutBzWn72pvWGcNCZMfRPhc014V56/XMgJP2q1y+6IblzwCsuHs7lHLJ",
-	"qqNVGAKw9t6P1ScNjeujNWO1TYqFEhaYxz7uZ8zFShEQthH3Z9WygzzBcABOmJs7rZ09i0cx1hVLwaCG",
-	"U4Bv6M0SdixcNj5chaaEdmyl/EJ50jnV2qhjlnt1k+3bhPHpUkPRwG6yherFQPXrKtucTX/HZ0UcI+A+",
-	"1a6LDzvbaa602yQ8WkCrY2zHab8wfOX+uwX2uDtSy8nAK9ITKpv5jqh6wOjRYFzVhr3dzrVJEU3GWuXL",
-	"ngG0vZ3e9dQMlc4a3W/Xq8aRr968nowj+3jfl6F3076enrn+39atmga+iQb2ZCwdIb4W1b1bma305tmf",
-	"g1X+RjIGAbXvVqdMN3vN+EJkZC7Cve2yR9a1YRP2NpYTNzcUw/pzXYN7w2Pko0hK5nte9q2uBCHnIQBL",
-	"MJtjgnZ3u38DAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FDGk4FU8T8CKRbkWjpw3POU8vbg2CRmdPH3GNHmmjJyiSJPMCUKmTUzAPXWIEPPmTccwMvsgjRt27EgS",
+	"Ec34HPGCoEGEJ+e8oGkTp2rOc4tqFhExTp00Ef/q2CICtufEfxMvbvy4y2zfdAXaxWt4r1qBZnADdRKm",
+	"TWSBdHZG/hl0KGLalq+LyB5YMlChboiWrX07t0PedzuKQBpdzvTqPY2XjWnmzUg2aYyhkEhruYGfT00k",
+	"QcV3T9Ehn2RUSEQHCFMYZodh84lwoX1QySRZDC7AEOJ3zBkIRxo+zRCiCzFkCEcYdKDxnAillXQSci/s",
+	"8aIc1fUxUmHJicAcj08h5JdPR5RBR1sL3SjXbyLsiJ9J9r0nEEFNLjRSGHC4FCCMHb6gxhxRrcUaWp+F",
+	"NlqNpyW0kGpnuvZCWxyVAdeTZO3nYZQwopGhgdb5JGUbGbKHWxm6BVVHGX10gZRWIfElkAwwwJBmGaJJ",
+	"RpppFKX2AqRcSfSCRnV+tFVFPRlVVo1vrJGGeECONCSYRuomQpJLVuZqT0gNqqRham0hkFI0NVXknnZt",
+	"lMZTF2Zop0tvKOWQGWGwYRFSj0lGUKuv/nmgZHBkGGdOa/UnB050iTDYDDJkSN52g5VR2GFHDbuUsR0K",
+	"KpRjzPIqwrNsRBuZomVgu+e2u3obqGRlhIvUuCOZi65gC7HrrnYUE4ZhvUndm4ZT+TKMB7RKkQFCGHLw",
+	"mIezIwcsrQ4EG+wTwt0iBeh2ZeT08Fk4jbTsTTNKDGPGFiP1bsbybmw0xpKhrLJsLNhb7MfH+uR0GCsj",
+	"BbDA01Z7rboH61qzCDdbLS7P5Ar0cxtBv3Hu0JKt2+7S5YGtMb10b3f1yhwTyxTVIf/bssAmf9UZSloP",
+	"/nLMYM8str9lM+zfzq2lLQJomK7JKWpvrob2a3hCLfXfIJcpZOiJkxwZtdYW3Li2jyu83eRmVX5ppiJs",
+	"6hbnDHleOeiHi05SlkFy6eUYtLohJpkeCgTxWpjjrnubno6rGp1vISfbbH7jazqnHeHhFeqvk8Qt5N+S",
+	"hNjo3u95M1V0oPxUeiDcsSwaILhRRxtiYCgz7OeTnU9i0BDKoWktRzNPd9IjG0fRBiShmpFSqFUHNgQp",
+	"eprbnZt6BypUqYZUVzFVpLY3mxcoZH8zitVaZnWsI0mmCPprAxRQVp0C8olH1qFSsNgHONPNEIe/kkP9",
+	"7geCE7YBBHao1qJsmC0R2MYwWSNb+ow4wxj9sDpns91ajPieGFSKBZSCgQOFli65Xaxu8ZpXAx8FQQ+O",
+	"hFI0GEn3eui+N4AASybRkqpKaJMwKOUwa1GhQFjYIRfeSklIyNkfXUTDHALLSh2bWumQta9lpaFZqXPZ",
+	"6rzmuib2cZE2Sx8WWgCFSvYriweEjtsmFreKzW08TLNb0uilGR5OUl/KOmUmuQYzOSzqfyL4pP+kuDAR",
+	"jLKUubxkGVpQBMUhCpU9K9cq4Wa3osESjU1SY988dkuRqc5ke2OZ6hzCOE8qcpiRM2YLgpAyrDHTmcGp",
+	"XSrVZRK2RWyaZXTlGeGVTaVdU2/t5FstI0m6qjUtoOLUZNdaB0xhHiaUxRwlO59mwGiqrZ5te1s+6WDN",
+	"BMpSm3mzGkK3KUmDCu6b4wveLhfny07uyaEClMwokfPOb0LTchjUFJs61TnrvUB7JC1o4AwXm5VukqHl",
+	"gylEtzNT8j1PIDnN3U55B6fP/TR0HMPjSbbUJQAh71jLK5Pz0Ha7DFKvp1bFXviAWpY5dpMkdRIfUaFk",
+	"Tj+iU5QtUKudWgDUqA0vj0FSCUtcApPmydOi//TJebyjKqS41aRuQEgLlDCFJzjhjjZaCAtAQJk6uAGc",
+	"cwBBjLDCozuAwKHwQw9RGnrOhxKTqaRMyxxaQAU03KUOZ/DTQB8buPcBRX5DGWKM8re//rm2rqB87QBb",
+	"MIX46WUoLbjC/VrghOIO86mJVaBq1/jAU1lEgpgKQwUvqCadbm6Dqungd0dllY6IMFQkRMoLXtI/NjRT",
+	"dRPFWo5cMCgV+CiQSpJVXpJnSFwxIQz1va8m8xtFX+kQkltj6S/L96IYxfSGWGSjbQ6VqJZW1HJryygr",
+	"q/lKj6bRnx4N52yAkocHiYC+ZWBDURyoXkmJIIxlNa8GPVXjD7bXI20UyR7lC2P7OhNHe+BvI/37owCv",
+	"cMAttJWBERxjBQtMe71qZBB3eFKF9nLCTaywn5YqqEYWqgwbds+XXYfdqE6Pp73zaV+50+LtFHnGbPSu",
+	"jXEMvfJK9bw8DrKoQOheQceXRkW2slKQyS9l7re//xWIIIUE5UJKWUkHTrAzGW1JTGLYkVXajUAiPDAP",
+	"U7hPFx7UmdP8zDV/+J4aJVqJY3livNHZxXduVJ4jNSM+Q9XPb6bqpwTt41IZesiIpjIbnPAGRZeBwY9u",
+	"ZKRFMGlC1gpJmFY2s53NYEYC8cGi7jIvWfe1MKOazOAys4bb02rGYTfEsB6xGUPayrsxKJYqflh2cK1s",
+	"PHeX12+sVI7/vOPO9Zi9xtbzoeer7WYfGU/RxuG0q13pa0tmyvXd9sNV+uktQ9iZCy03ss6t3HTjcNXs",
+	"7vCE2wzsqaLXd2gBXmxWvG8791vX/45gwC3V58zp+KwcJDbCQ3jsxia7vpzuV8R71OQgWdsNBc420k2p",
+	"TG9P6ZHhJnXIXVpmC6P70yjnMDlNjV0yynqfSAPprW1eX3/3eOcDD/bLD05oICsc2S9Al1DwwO2A7jcN",
+	"ZGAygJ1ecahfmg5NgNHe+07RjoNbWOKWMNfT7fWSqyuehlKzu8m6FnhLM9b17iit+2nrFI9U33X2id7T",
+	"gAe3ExvuPZeeywOt52IT/e5Gz7viWe9sJLsA8IKXtJMHWfioI373fN94UR2Pdchr3dWnrnw6AR92zZOd",
+	"87/2OcGBXtXfXTV4NE+9ZFbfepy/fS2+vlzLAW1wodf9vahaOPmdnXRH72EHwJ/48CltGAIfPvHdkXyq",
+	"U3+e5mDNN2ogB33mJn3pQ33rJnbQV3b4dHb09lH+xGIuRn6uV3uwl32yx35BV3tDV2i4tyrkp3H45XdJ",
+	"Bnj6R3j9F2XYdnwBiIILhlBZ9m0HGHlHJXJdN2aW54APxGoqx2bYR09AE2/UNG/ZZYGlh2+nt3aqh3wb",
+	"CHDoJ3CxZ1Zwll7u92PwJ2S5d4IOpzq+x4JNJ2AvaGkxCIB7R4NXRj4GGGrOl4DkNnl8woDFBISZ127X",
+	"p0UeiIXCJmdYhXoZKIXm93pVyHN9+HNZOGwi+H5FZ4LIR4BlkCP4RwYtaIZEgoYXpyRqyHqSaHWgxmXP",
+	"N4fAJGYXhodolnJjt3JFaHahN2vYZG/hN4gBOIU6d4hxN3vt14hc+Igl9CJzMAe1dVu5lSODcolPdoYW",
+	"d0h0MEPBOIxvgFs++IZcplVagkB2MlgvkS1jxYdLuFgMZHQL6IPppGoPaH2LUogciItXqIjCRne9WIIl",
+	"9ERykAdEUAYNoz2Dh4n+F4P3mI9uqGWPZ0smpRQNk1LL93zltCf0GEXpZJBwwBnVp4es6I1upotxllZu",
+	"sVaBCIWSAZFARWOGaC8UZEG5CIJayIsJN0J415D3CCD80mrC54KZuIy4EgWLUo8vmUvPdINXB4cEGTgT",
+	"EQYCAgJKAZM/A042qINbB0wNeWFzoDOHBWIYhYQbJXqxOEv3Vjf55pE/8SICspMx+Re7xU0mdSI8YZQx",
+	"xpNK2XijyElOmZMOmT4vclM+U5WfJ2/6VIG1tpUA9TSzuB1oWQZimZS26EbsmIjbt4jwuJLw1ZJyaQSr",
+	"VIbJWJOGF4M4CUWSeS6g6HHhxlumQ2ptiTUJxUsL6RNP+XU5Y5edh5eqBHokhnb1ppWzYXqAKYjbITHr",
+	"Q1DtI1JuKYdwWT6paXlS+W6uKQKuGJt8SXp+6ZukGZg+oZtlWVKBI5oICSUKaWpNNJzpVAa0w3LaJ3fV",
+	"Y1Vs5VeguSdzhThMqQOkKJxyeWHfWYQXiZIwJyflGZShCU8gkCyN5mnZCWYM+Z6q6TBTaZUUuIR9GVS9",
+	"CS5U55/AiVTbKaCWR6ASCJtKaGLMqaB0hEv9iRXguFruCUWpZkPY5VEfKjzWWDxd9SVgNSZiVaDtuJh/",
+	"qJFxxVbcY5aBAz52cp3qGaEi+nUEsZvn6RO+5VzzcwbChT8xZFwZ4qP1eGEExJrYEUsnahQiuY6TYoWK",
+	"KZ67yGsjaHcsmXtVUSeMp186smTISHzKeJmbSAd1V6YNJpA5+J90aIpfZ45BqIoRWISe95p6yVGwyE+y",
+	"WIFdiYHbMaZXcZjf1YHqF54YmZJe6ojyKF+I2hG9B3FnikPBR23793TG96bKByXU+HHjpIAjZ4eCqW55",
+	"CoGbZ5HrV3AZ6X1zZqiK9WOKumda2qgfCKuQGkFf2oWpIqY/Rn8NOomZynT7WJn92KagOoDF2pkDuZ6n",
+	"SXnkSJeqmodD+Gp5mYR7iaAZipu1Wie32mu5Op+8yoiRGo9huiqVWgZsqBTQdqxtkKb8Z5mf+mPv+mxL",
+	"OapZ96A8SK2pdq2pyKp7OE99ipwT+IqyyYTNeVC36ZXtOq6Maq7ch66+KqnrWkLtmq9IdoyUqab2enh1",
+	"x7EBiYNAuZ7tOY4Be3LnSJFE6KqOSp+ACH7gah62qo5UmKWIqKt+OHdb6Jjxh3ftKonGKG0fW6/Lyox1",
+	"94k+GYqQpLJ3KrBCuIovO0/JeaGjN6gQe7NXmrM3Vq6vWrGNeXsZS6k/1lyqVbQSd7SeKrJnu0Agyq+Q",
+	"B7UTKrV62qrzZKJw+x20arPiirO3qLMnea5jS4JlSyO/9VzpIV0xUl38Yxg5EgMem6wgm7S40lzAtbj3",
+	"47hM2rSeCXkpmhLZ2BLbaFglSqV7K46nWq3FJLl2S7Dp2LWB+7U7S7GM+bNk+5jIZhFysCFcVgdyIGOS",
+	"gQZ0QAdwoAMv8AIlwiU/AxQuAJE4AQcuABMz1gcBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/parameters/roundtrip/fiber/gen/server.gen.go
+++ b/internal/test/parameters/roundtrip/fiber/gen/server.gen.go
@@ -5,7 +5,7 @@ package fiberparamsgen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -1378,51 +1378,92 @@ func RegisterHandlersWithOptions(router fiber.Router, si ServerInterface, option
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3FpNb+M2E/4rAt/3VMiWne1JPQXbbZuim6R1gC0Q5MBI44hbSeSSdDaB4f9ekJQsiZL1YUv56C2xhjPP",
-	"POQzFIfaooAmjKaQSoH8LeIgGE0F6H9WJGEx/JX9pH4JaCohlepPCU/SYzEmqfpPBBEkWP/+zAD5SEhO",
-	"0ge02+1cFIIIOGGS0BT56NwR2q+Tx3Lo/VcIJFKmxo+O/pEqq6cr89DfIsYpAy6JAXcRlqKRVMIDcLRz",
-	"0YU4DxMDKnt4T2kMOFUPC2f/57BGPvqfV+TvZcG9qwIPh28bwiFE/m0+2FWhizh3FbdVjGvChbzECTQQ",
-	"4yJO46YHVlRt5ZZc3WlOSbqmanBMAsgmJ9WB0OeLG+VdEqncoxsQ0lkBfwSOXPQIXJhpWM4X84UypAxS",
-	"zAjy0Yf5Yr5ELmJYRhq/l823yc/bMsxxslNPHkCnq5LFal7VbKBfQX4sD9CuOE5AAhfIv62sH8xYTAI9",
-	"2PsqqLWK2qanujAyNpCvYSM3p0FHRmUuJd/A7s6trvGzxeJQvL2dZwlhp2N6AaX/EGhnQ1vUaKgKgnGS",
-	"EEkelSE8sZiGgPw1jgVkiQW5mzw15JaoWlOeYGlE8OEMuTVN7NxeERU9BwLCyRGzKKGDOcfPfcPiSlgi",
-	"IRG94u9/MdEa8NRgtPE9HYw9LTQXTC9eaAVQv1Jmh65HbKPguIhTyb2aSWAMCg4bMwgoqpOgnjlCYi5J",
-	"+uB8JzJy0k1yr0tlo5elqBBhl267uoSwxptYHlthIN2YpdZYYD6lm+RaFRbRVWGu84cmReXWecTxBkSe",
-	"57cN8OfSCtOuZXSdFdEiY/UE+bfLxcI9Wyzu3B7FoF5yfzTcVGaCOvlqyZKPAIfA28rrb8bi1PIa5W6y",
-	"5P+eXZeGTFpoW0LPPmW14UVKbx3IubJuBvFihfgAqlcux3VUpjY1kzVFdT6E4N0V6XoimaM8IQvg0YeO",
-	"lKaz31dXl3mRcZ17uklDBwtHRuBw/N0xWJzMx2GBYiFmNxGnm4fomB3F9ricrTLr2Rcio9llbv1iu0yM",
-	"7yHO1q7Wl7ed64r6Q+ur/h/2sHohblJPn7f0cfTtIiGf9RlIZ4jGfPcvc5afjoaSduiQNAZrfcT/Uvzs",
-	"t7ThFJU34glY6rGkJqbokjYJr5uf6rgWdsrbxn9Ievv8q+IbQFyn+k5h7k3Ir6a7bnb66O0UXl5VcAmW",
-	"nDxZeiNhezX6XBt0TCki4eRCM9lNR9heaIMYO36P66BsmMKmJqcktZ8G8XPSBtdB0QCxTcZPbX8jYQ9y",
-	"Rtjd3rPi6pvbMNZO2Nreh+qqcutBzWn72pvWGcNCZMfRPhc014V56/XMgJP2q1y+6IblzwCsuHs7lHLJ",
-	"qqNVGAKw9t6P1ScNjeujNWO1TYqFEhaYxz7uZ8zFShEQthH3Z9WygzzBcABOmJs7rZ09i0cx1hVLwaCG",
-	"U4Bv6M0SdixcNj5chaaEdmyl/EJ50jnV2qhjlnt1k+3bhPHpUkPRwG6yherFQPXrKtucTX/HZ0UcI+A+",
-	"1a6LDzvbaa602yQ8WkCrY2zHab8wfOX+uwX2uDtSy8nAK9ITKpv5jqh6wOjRYFzVhr3dzrVJEU3GWuXL",
-	"ngG0vZ3e9dQMlc4a3W/Xq8aRr968nowj+3jfl6F3076enrn+39atmga+iQb2ZCwdIb4W1b1bma305tmf",
-	"g1X+RjIGAbXvVqdMN3vN+EJkZC7Cve2yR9a1YRP2NpYTNzcUw/pzXYN7w2Pko0hK5nte9q2uBCHnIQBL",
-	"MJtjgnZ3u38DAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FDGk4FU8T8CKRbkWjpw3POU8vbg2CRmdPH3GNHmmjJyiSJPMCUKmTUzAPXWIEPPmTccwMvsgjRt27EgS",
+	"Ec34HPGCoEGEJ+e8oGkTp2rOc4tqFhExTp00Ef/q2CICtufEfxMvbvy4y2zfdAXaxWt4r1qBZnADdRKm",
+	"TWSBdHZG/hl0KGLalq+LyB5YMlChboiWrX07t0PedzuKQBpdzvTqPY2XjWnmzUg2aYyhkEhruYGfT00k",
+	"QcV3T9Ehn2RUSEQHCFMYZodh84lwoX1QySRZDC7AEOJ3zBkIRxo+zRCiCzFkCEcYdKDxnAillXQSci/s",
+	"8aIc1fUxUmHJicAcj08h5JdPR5RBR1sL3SjXbyLsiJ9J9r0nEEFNLjRSGHC4FCCMHb6gxhxRrcUaWp+F",
+	"NlqNpyW0kGpnuvZCWxyVAdeTZO3nYZQwopGhgdb5JGUbGbKHWxm6BVVHGX10gZRWIfElkAwwwJBmGaJJ",
+	"RpppFKX2AqRcSfSCRnV+tFVFPRlVVo1vrJGGeECONCSYRuomQpJLVuZqT0gNqqRham0hkFI0NVXknnZt",
+	"lMZTF2Zop0tvKOWQGWGwYRFSj0lGUKuv/nmgZHBkGGdOa/UnB050iTDYDDJkSN52g5VR2GFHDbuUsR0K",
+	"KpRjzPIqwrNsRBuZomVgu+e2u3obqGRlhIvUuCOZi65gC7HrrnYUE4ZhvUndm4ZT+TKMB7RKkQFCGHLw",
+	"mIezIwcsrQ4EG+wTwt0iBeh2ZeT08Fk4jbTsTTNKDGPGFiP1bsbybmw0xpKhrLJsLNhb7MfH+uR0GCsj",
+	"BbDA01Z7rboH61qzCDdbLS7P5Ar0cxtBv3Hu0JKt2+7S5YGtMb10b3f1yhwTyxTVIf/bssAmf9UZSloP",
+	"/nLMYM8str9lM+zfzq2lLQJomK7JKWpvrob2a3hCLfXfIJcpZOiJkxwZtdYW3Li2jyu83eRmVX5ppiJs",
+	"6hbnDHleOeiHi05SlkFy6eUYtLohJpkeCgTxWpjjrnubno6rGp1vISfbbH7jazqnHeHhFeqvk8Qt5N+S",
+	"hNjo3u95M1V0oPxUeiDcsSwaILhRRxtiYCgz7OeTnU9i0BDKoWktRzNPd9IjG0fRBiShmpFSqFUHNgQp",
+	"eprbnZt6BypUqYZUVzFVpLY3mxcoZH8zitVaZnWsI0mmCPprAxRQVp0C8olH1qFSsNgHONPNEIe/kkP9",
+	"7geCE7YBBHao1qJsmC0R2MYwWSNb+ow4wxj9sDpns91ajPieGFSKBZSCgQOFli65Xaxu8ZpXAx8FQQ+O",
+	"hFI0GEn3eui+N4AASybRkqpKaJMwKOUwa1GhQFjYIRfeSklIyNkfXUTDHALLSh2bWumQta9lpaFZqXPZ",
+	"6rzmuib2cZE2Sx8WWgCFSvYriweEjtsmFreKzW08TLNb0uilGR5OUl/KOmUmuQYzOSzqfyL4pP+kuDAR",
+	"jLKUubxkGVpQBMUhCpU9K9cq4Wa3osESjU1SY988dkuRqc5ke2OZ6hzCOE8qcpiRM2YLgpAyrDHTmcGp",
+	"XSrVZRK2RWyaZXTlGeGVTaVdU2/t5FstI0m6qjUtoOLUZNdaB0xhHiaUxRwlO59mwGiqrZ5te1s+6WDN",
+	"BMpSm3mzGkK3KUmDCu6b4wveLhfny07uyaEClMwokfPOb0LTchjUFJs61TnrvUB7JC1o4AwXm5VukqHl",
+	"gylEtzNT8j1PIDnN3U55B6fP/TR0HMPjSbbUJQAh71jLK5Pz0Ha7DFKvp1bFXviAWpY5dpMkdRIfUaFk",
+	"Tj+iU5QtUKudWgDUqA0vj0FSCUtcApPmydOi//TJebyjKqS41aRuQEgLlDCFJzjhjjZaCAtAQJk6uAGc",
+	"cwBBjLDCozuAwKHwQw9RGnrOhxKTqaRMyxxaQAU03KUOZ/DTQB8buPcBRX5DGWKM8re//rm2rqB87QBb",
+	"MIX46WUoLbjC/VrghOIO86mJVaBq1/jAU1lEgpgKQwUvqCadbm6Dqungd0dllY6IMFQkRMoLXtI/NjRT",
+	"dRPFWo5cMCgV+CiQSpJVXpJnSFwxIQz1va8m8xtFX+kQkltj6S/L96IYxfSGWGSjbQ6VqJZW1HJryygr",
+	"q/lKj6bRnx4N52yAkocHiYC+ZWBDURyoXkmJIIxlNa8GPVXjD7bXI20UyR7lC2P7OhNHe+BvI/37owCv",
+	"cMAttJWBERxjBQtMe71qZBB3eFKF9nLCTaywn5YqqEYWqgwbds+XXYfdqE6Pp73zaV+50+LtFHnGbPSu",
+	"jXEMvfJK9bw8DrKoQOheQceXRkW2slKQyS9l7re//xWIIIUE5UJKWUkHTrAzGW1JTGLYkVXajUAiPDAP",
+	"U7hPFx7UmdP8zDV/+J4aJVqJY3livNHZxXduVJ4jNSM+Q9XPb6bqpwTt41IZesiIpjIbnPAGRZeBwY9u",
+	"ZKRFMGlC1gpJmFY2s53NYEYC8cGi7jIvWfe1MKOazOAys4bb02rGYTfEsB6xGUPayrsxKJYqflh2cK1s",
+	"PHeX12+sVI7/vOPO9Zi9xtbzoeer7WYfGU/RxuG0q13pa0tmyvXd9sNV+uktQ9iZCy03ss6t3HTjcNXs",
+	"7vCE2wzsqaLXd2gBXmxWvG8791vX/45gwC3V58zp+KwcJDbCQ3jsxia7vpzuV8R71OQgWdsNBc420k2p",
+	"TG9P6ZHhJnXIXVpmC6P70yjnMDlNjV0yynqfSAPprW1eX3/3eOcDD/bLD05oICsc2S9Al1DwwO2A7jcN",
+	"ZGAygJ1ecahfmg5NgNHe+07RjoNbWOKWMNfT7fWSqyuehlKzu8m6FnhLM9b17iit+2nrFI9U33X2id7T",
+	"gAe3ExvuPZeeywOt52IT/e5Gz7viWe9sJLsA8IKXtJMHWfioI373fN94UR2Pdchr3dWnrnw6AR92zZOd",
+	"87/2OcGBXtXfXTV4NE+9ZFbfepy/fS2+vlzLAW1wodf9vahaOPmdnXRH72EHwJ/48CltGAIfPvHdkXyq",
+	"U3+e5mDNN2ogB33mJn3pQ33rJnbQV3b4dHb09lH+xGIuRn6uV3uwl32yx35BV3tDV2i4tyrkp3H45XdJ",
+	"Bnj6R3j9F2XYdnwBiIILhlBZ9m0HGHlHJXJdN2aW54APxGoqx2bYR09AE2/UNG/ZZYGlh2+nt3aqh3wb",
+	"CHDoJ3CxZ1Zwll7u92PwJ2S5d4IOpzq+x4JNJ2AvaGkxCIB7R4NXRj4GGGrOl4DkNnl8woDFBISZ127X",
+	"p0UeiIXCJmdYhXoZKIXm93pVyHN9+HNZOGwi+H5FZ4LIR4BlkCP4RwYtaIZEgoYXpyRqyHqSaHWgxmXP",
+	"N4fAJGYXhodolnJjt3JFaHahN2vYZG/hN4gBOIU6d4hxN3vt14hc+Igl9CJzMAe1dVu5lSODcolPdoYW",
+	"d0h0MEPBOIxvgFs++IZcplVagkB2MlgvkS1jxYdLuFgMZHQL6IPppGoPaH2LUogciItXqIjCRne9WIIl",
+	"9ERykAdEUAYNoz2Dh4n+F4P3mI9uqGWPZ0smpRQNk1LL93zltCf0GEXpZJBwwBnVp4es6I1upotxllZu",
+	"sVaBCIWSAZFARWOGaC8UZEG5CIJayIsJN0J415D3CCD80mrC54KZuIy4EgWLUo8vmUvPdINXB4cEGTgT",
+	"EQYCAgJKAZM/A042qINbB0wNeWFzoDOHBWIYhYQbJXqxOEv3Vjf55pE/8SICspMx+Re7xU0mdSI8YZQx",
+	"xpNK2XijyElOmZMOmT4vclM+U5WfJ2/6VIG1tpUA9TSzuB1oWQZimZS26EbsmIjbt4jwuJLw1ZJyaQSr",
+	"VIbJWJOGF4M4CUWSeS6g6HHhxlumQ2ptiTUJxUsL6RNP+XU5Y5edh5eqBHokhnb1ppWzYXqAKYjbITHr",
+	"Q1DtI1JuKYdwWT6paXlS+W6uKQKuGJt8SXp+6ZukGZg+oZtlWVKBI5oICSUKaWpNNJzpVAa0w3LaJ3fV",
+	"Y1Vs5VeguSdzhThMqQOkKJxyeWHfWYQXiZIwJyflGZShCU8gkCyN5mnZCWYM+Z6q6TBTaZUUuIR9GVS9",
+	"CS5U55/AiVTbKaCWR6ASCJtKaGLMqaB0hEv9iRXguFruCUWpZkPY5VEfKjzWWDxd9SVgNSZiVaDtuJh/",
+	"qJFxxVbcY5aBAz52cp3qGaEi+nUEsZvn6RO+5VzzcwbChT8xZFwZ4qP1eGEExJrYEUsnahQiuY6TYoWK",
+	"KZ67yGsjaHcsmXtVUSeMp186smTISHzKeJmbSAd1V6YNJpA5+J90aIpfZ45BqIoRWISe95p6yVGwyE+y",
+	"WIFdiYHbMaZXcZjf1YHqF54YmZJe6ojyKF+I2hG9B3FnikPBR23793TG96bKByXU+HHjpIAjZ4eCqW55",
+	"CoGbZ5HrV3AZ6X1zZqiK9WOKumda2qgfCKuQGkFf2oWpIqY/Rn8NOomZynT7WJn92KagOoDF2pkDuZ6n",
+	"SXnkSJeqmodD+Gp5mYR7iaAZipu1Wie32mu5Op+8yoiRGo9huiqVWgZsqBTQdqxtkKb8Z5mf+mPv+mxL",
+	"OapZ96A8SK2pdq2pyKp7OE99ipwT+IqyyYTNeVC36ZXtOq6Maq7ch66+KqnrWkLtmq9IdoyUqab2enh1",
+	"x7EBiYNAuZ7tOY4Be3LnSJFE6KqOSp+ACH7gah62qo5UmKWIqKt+OHdb6Jjxh3ftKonGKG0fW6/Lyox1",
+	"94k+GYqQpLJ3KrBCuIovO0/JeaGjN6gQe7NXmrM3Vq6vWrGNeXsZS6k/1lyqVbQSd7SeKrJnu0Agyq+Q",
+	"B7UTKrV62qrzZKJw+x20arPiirO3qLMnea5jS4JlSyO/9VzpIV0xUl38Yxg5EgMem6wgm7S40lzAtbj3",
+	"47hM2rSeCXkpmhLZ2BLbaFglSqV7K46nWq3FJLl2S7Dp2LWB+7U7S7GM+bNk+5jIZhFysCFcVgdyIGOS",
+	"gQZ0QAdwoAMv8AIlwiU/AxQuAJE4AQcuABMz1gcBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/parameters/roundtrip/fiberv3/gen/server.gen.go
+++ b/internal/test/parameters/roundtrip/fiberv3/gen/server.gen.go
@@ -5,7 +5,7 @@ package fiberv3paramsgen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -1378,51 +1378,92 @@ func RegisterHandlersWithOptions(router fiber.Router, si ServerInterface, option
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3FpNb+M2E/4rAt/3VMiWne1JPQXbbZuim6R1gC0Q5MBI44hbSeSSdDaB4f9ekJQsiZL1YUv56C2xhjPP",
-	"POQzFIfaooAmjKaQSoH8LeIgGE0F6H9WJGEx/JX9pH4JaCohlepPCU/SYzEmqfpPBBEkWP/+zAD5SEhO",
-	"0ge02+1cFIIIOGGS0BT56NwR2q+Tx3Lo/VcIJFKmxo+O/pEqq6cr89DfIsYpAy6JAXcRlqKRVMIDcLRz",
-	"0YU4DxMDKnt4T2kMOFUPC2f/57BGPvqfV+TvZcG9qwIPh28bwiFE/m0+2FWhizh3FbdVjGvChbzECTQQ",
-	"4yJO46YHVlRt5ZZc3WlOSbqmanBMAsgmJ9WB0OeLG+VdEqncoxsQ0lkBfwSOXPQIXJhpWM4X84UypAxS",
-	"zAjy0Yf5Yr5ELmJYRhq/l823yc/bMsxxslNPHkCnq5LFal7VbKBfQX4sD9CuOE5AAhfIv62sH8xYTAI9",
-	"2PsqqLWK2qanujAyNpCvYSM3p0FHRmUuJd/A7s6trvGzxeJQvL2dZwlhp2N6AaX/EGhnQ1vUaKgKgnGS",
-	"EEkelSE8sZiGgPw1jgVkiQW5mzw15JaoWlOeYGlE8OEMuTVN7NxeERU9BwLCyRGzKKGDOcfPfcPiSlgi",
-	"IRG94u9/MdEa8NRgtPE9HYw9LTQXTC9eaAVQv1Jmh65HbKPguIhTyb2aSWAMCg4bMwgoqpOgnjlCYi5J",
-	"+uB8JzJy0k1yr0tlo5elqBBhl267uoSwxptYHlthIN2YpdZYYD6lm+RaFRbRVWGu84cmReXWecTxBkSe",
-	"57cN8OfSCtOuZXSdFdEiY/UE+bfLxcI9Wyzu3B7FoF5yfzTcVGaCOvlqyZKPAIfA28rrb8bi1PIa5W6y",
-	"5P+eXZeGTFpoW0LPPmW14UVKbx3IubJuBvFihfgAqlcux3VUpjY1kzVFdT6E4N0V6XoimaM8IQvg0YeO",
-	"lKaz31dXl3mRcZ17uklDBwtHRuBw/N0xWJzMx2GBYiFmNxGnm4fomB3F9ricrTLr2Rcio9llbv1iu0yM",
-	"7yHO1q7Wl7ed64r6Q+ur/h/2sHohblJPn7f0cfTtIiGf9RlIZ4jGfPcvc5afjoaSduiQNAZrfcT/Uvzs",
-	"t7ThFJU34glY6rGkJqbokjYJr5uf6rgWdsrbxn9Ievv8q+IbQFyn+k5h7k3Ir6a7bnb66O0UXl5VcAmW",
-	"nDxZeiNhezX6XBt0TCki4eRCM9lNR9heaIMYO36P66BsmMKmJqcktZ8G8XPSBtdB0QCxTcZPbX8jYQ9y",
-	"Rtjd3rPi6pvbMNZO2Nreh+qqcutBzWn72pvWGcNCZMfRPhc014V56/XMgJP2q1y+6IblzwCsuHs7lHLJ",
-	"qqNVGAKw9t6P1ScNjeujNWO1TYqFEhaYxz7uZ8zFShEQthH3Z9WygzzBcABOmJs7rZ09i0cx1hVLwaCG",
-	"U4Bv6M0SdixcNj5chaaEdmyl/EJ50jnV2qhjlnt1k+3bhPHpUkPRwG6yherFQPXrKtucTX/HZ0UcI+A+",
-	"1a6LDzvbaa602yQ8WkCrY2zHab8wfOX+uwX2uDtSy8nAK9ITKpv5jqh6wOjRYFzVhr3dzrVJEU3GWuXL",
-	"ngG0vZ3e9dQMlc4a3W/Xq8aRr968nowj+3jfl6F3076enrn+39atmga+iQb2ZCwdIb4W1b1bma305tmf",
-	"g1X+RjIGAbXvVqdMN3vN+EJkZC7Cve2yR9a1YRP2NpYTNzcUw/pzXYN7w2Pko0hK5nte9q2uBCHnIQBL",
-	"MJtjgnZ3u38DAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FDGk4FU8T8CKRbkWjpw3POU8vbg2CRmdPH3GNHmmjJyiSJPMCUKmTUzAPXWIEPPmTccwMvsgjRt27EgS",
+	"Ec34HPGCoEGEJ+e8oGkTp2rOc4tqFhExTp00Ef/q2CICtufEfxMvbvy4y2zfdAXaxWt4r1qBZnADdRKm",
+	"TWSBdHZG/hl0KGLalq+LyB5YMlChboiWrX07t0PedzuKQBpdzvTqPY2XjWnmzUg2aYyhkEhruYGfT00k",
+	"QcV3T9Ehn2RUSEQHCFMYZodh84lwoX1QySRZDC7AEOJ3zBkIRxo+zRCiCzFkCEcYdKDxnAillXQSci/s",
+	"8aIc1fUxUmHJicAcj08h5JdPR5RBR1sL3SjXbyLsiJ9J9r0nEEFNLjRSGHC4FCCMHb6gxhxRrcUaWp+F",
+	"NlqNpyW0kGpnuvZCWxyVAdeTZO3nYZQwopGhgdb5JGUbGbKHWxm6BVVHGX10gZRWIfElkAwwwJBmGaJJ",
+	"RpppFKX2AqRcSfSCRnV+tFVFPRlVVo1vrJGGeECONCSYRuomQpJLVuZqT0gNqqRham0hkFI0NVXknnZt",
+	"lMZTF2Zop0tvKOWQGWGwYRFSj0lGUKuv/nmgZHBkGGdOa/UnB050iTDYDDJkSN52g5VR2GFHDbuUsR0K",
+	"KpRjzPIqwrNsRBuZomVgu+e2u3obqGRlhIvUuCOZi65gC7HrrnYUE4ZhvUndm4ZT+TKMB7RKkQFCGHLw",
+	"mIezIwcsrQ4EG+wTwt0iBeh2ZeT08Fk4jbTsTTNKDGPGFiP1bsbybmw0xpKhrLJsLNhb7MfH+uR0GCsj",
+	"BbDA01Z7rboH61qzCDdbLS7P5Ar0cxtBv3Hu0JKt2+7S5YGtMb10b3f1yhwTyxTVIf/bssAmf9UZSloP",
+	"/nLMYM8str9lM+zfzq2lLQJomK7JKWpvrob2a3hCLfXfIJcpZOiJkxwZtdYW3Li2jyu83eRmVX5ppiJs",
+	"6hbnDHleOeiHi05SlkFy6eUYtLohJpkeCgTxWpjjrnubno6rGp1vISfbbH7jazqnHeHhFeqvk8Qt5N+S",
+	"hNjo3u95M1V0oPxUeiDcsSwaILhRRxtiYCgz7OeTnU9i0BDKoWktRzNPd9IjG0fRBiShmpFSqFUHNgQp",
+	"eprbnZt6BypUqYZUVzFVpLY3mxcoZH8zitVaZnWsI0mmCPprAxRQVp0C8olH1qFSsNgHONPNEIe/kkP9",
+	"7geCE7YBBHao1qJsmC0R2MYwWSNb+ow4wxj9sDpns91ajPieGFSKBZSCgQOFli65Xaxu8ZpXAx8FQQ+O",
+	"hFI0GEn3eui+N4AASybRkqpKaJMwKOUwa1GhQFjYIRfeSklIyNkfXUTDHALLSh2bWumQta9lpaFZqXPZ",
+	"6rzmuib2cZE2Sx8WWgCFSvYriweEjtsmFreKzW08TLNb0uilGR5OUl/KOmUmuQYzOSzqfyL4pP+kuDAR",
+	"jLKUubxkGVpQBMUhCpU9K9cq4Wa3osESjU1SY988dkuRqc5ke2OZ6hzCOE8qcpiRM2YLgpAyrDHTmcGp",
+	"XSrVZRK2RWyaZXTlGeGVTaVdU2/t5FstI0m6qjUtoOLUZNdaB0xhHiaUxRwlO59mwGiqrZ5te1s+6WDN",
+	"BMpSm3mzGkK3KUmDCu6b4wveLhfny07uyaEClMwokfPOb0LTchjUFJs61TnrvUB7JC1o4AwXm5VukqHl",
+	"gylEtzNT8j1PIDnN3U55B6fP/TR0HMPjSbbUJQAh71jLK5Pz0Ha7DFKvp1bFXviAWpY5dpMkdRIfUaFk",
+	"Tj+iU5QtUKudWgDUqA0vj0FSCUtcApPmydOi//TJebyjKqS41aRuQEgLlDCFJzjhjjZaCAtAQJk6uAGc",
+	"cwBBjLDCozuAwKHwQw9RGnrOhxKTqaRMyxxaQAU03KUOZ/DTQB8buPcBRX5DGWKM8re//rm2rqB87QBb",
+	"MIX46WUoLbjC/VrghOIO86mJVaBq1/jAU1lEgpgKQwUvqCadbm6Dqungd0dllY6IMFQkRMoLXtI/NjRT",
+	"dRPFWo5cMCgV+CiQSpJVXpJnSFwxIQz1va8m8xtFX+kQkltj6S/L96IYxfSGWGSjbQ6VqJZW1HJryygr",
+	"q/lKj6bRnx4N52yAkocHiYC+ZWBDURyoXkmJIIxlNa8GPVXjD7bXI20UyR7lC2P7OhNHe+BvI/37owCv",
+	"cMAttJWBERxjBQtMe71qZBB3eFKF9nLCTaywn5YqqEYWqgwbds+XXYfdqE6Pp73zaV+50+LtFHnGbPSu",
+	"jXEMvfJK9bw8DrKoQOheQceXRkW2slKQyS9l7re//xWIIIUE5UJKWUkHTrAzGW1JTGLYkVXajUAiPDAP",
+	"U7hPFx7UmdP8zDV/+J4aJVqJY3livNHZxXduVJ4jNSM+Q9XPb6bqpwTt41IZesiIpjIbnPAGRZeBwY9u",
+	"ZKRFMGlC1gpJmFY2s53NYEYC8cGi7jIvWfe1MKOazOAys4bb02rGYTfEsB6xGUPayrsxKJYqflh2cK1s",
+	"PHeX12+sVI7/vOPO9Zi9xtbzoeer7WYfGU/RxuG0q13pa0tmyvXd9sNV+uktQ9iZCy03ss6t3HTjcNXs",
+	"7vCE2wzsqaLXd2gBXmxWvG8791vX/45gwC3V58zp+KwcJDbCQ3jsxia7vpzuV8R71OQgWdsNBc420k2p",
+	"TG9P6ZHhJnXIXVpmC6P70yjnMDlNjV0yynqfSAPprW1eX3/3eOcDD/bLD05oICsc2S9Al1DwwO2A7jcN",
+	"ZGAygJ1ecahfmg5NgNHe+07RjoNbWOKWMNfT7fWSqyuehlKzu8m6FnhLM9b17iit+2nrFI9U33X2id7T",
+	"gAe3ExvuPZeeywOt52IT/e5Gz7viWe9sJLsA8IKXtJMHWfioI373fN94UR2Pdchr3dWnrnw6AR92zZOd",
+	"87/2OcGBXtXfXTV4NE+9ZFbfepy/fS2+vlzLAW1wodf9vahaOPmdnXRH72EHwJ/48CltGAIfPvHdkXyq",
+	"U3+e5mDNN2ogB33mJn3pQ33rJnbQV3b4dHb09lH+xGIuRn6uV3uwl32yx35BV3tDV2i4tyrkp3H45XdJ",
+	"Bnj6R3j9F2XYdnwBiIILhlBZ9m0HGHlHJXJdN2aW54APxGoqx2bYR09AE2/UNG/ZZYGlh2+nt3aqh3wb",
+	"CHDoJ3CxZ1Zwll7u92PwJ2S5d4IOpzq+x4JNJ2AvaGkxCIB7R4NXRj4GGGrOl4DkNnl8woDFBISZ127X",
+	"p0UeiIXCJmdYhXoZKIXm93pVyHN9+HNZOGwi+H5FZ4LIR4BlkCP4RwYtaIZEgoYXpyRqyHqSaHWgxmXP",
+	"N4fAJGYXhodolnJjt3JFaHahN2vYZG/hN4gBOIU6d4hxN3vt14hc+Igl9CJzMAe1dVu5lSODcolPdoYW",
+	"d0h0MEPBOIxvgFs++IZcplVagkB2MlgvkS1jxYdLuFgMZHQL6IPppGoPaH2LUogciItXqIjCRne9WIIl",
+	"9ERykAdEUAYNoz2Dh4n+F4P3mI9uqGWPZ0smpRQNk1LL93zltCf0GEXpZJBwwBnVp4es6I1upotxllZu",
+	"sVaBCIWSAZFARWOGaC8UZEG5CIJayIsJN0J415D3CCD80mrC54KZuIy4EgWLUo8vmUvPdINXB4cEGTgT",
+	"EQYCAgJKAZM/A042qINbB0wNeWFzoDOHBWIYhYQbJXqxOEv3Vjf55pE/8SICspMx+Re7xU0mdSI8YZQx",
+	"xpNK2XijyElOmZMOmT4vclM+U5WfJ2/6VIG1tpUA9TSzuB1oWQZimZS26EbsmIjbt4jwuJLw1ZJyaQSr",
+	"VIbJWJOGF4M4CUWSeS6g6HHhxlumQ2ptiTUJxUsL6RNP+XU5Y5edh5eqBHokhnb1ppWzYXqAKYjbITHr",
+	"Q1DtI1JuKYdwWT6paXlS+W6uKQKuGJt8SXp+6ZukGZg+oZtlWVKBI5oICSUKaWpNNJzpVAa0w3LaJ3fV",
+	"Y1Vs5VeguSdzhThMqQOkKJxyeWHfWYQXiZIwJyflGZShCU8gkCyN5mnZCWYM+Z6q6TBTaZUUuIR9GVS9",
+	"CS5U55/AiVTbKaCWR6ASCJtKaGLMqaB0hEv9iRXguFruCUWpZkPY5VEfKjzWWDxd9SVgNSZiVaDtuJh/",
+	"qJFxxVbcY5aBAz52cp3qGaEi+nUEsZvn6RO+5VzzcwbChT8xZFwZ4qP1eGEExJrYEUsnahQiuY6TYoWK",
+	"KZ67yGsjaHcsmXtVUSeMp186smTISHzKeJmbSAd1V6YNJpA5+J90aIpfZ45BqIoRWISe95p6yVGwyE+y",
+	"WIFdiYHbMaZXcZjf1YHqF54YmZJe6ojyKF+I2hG9B3FnikPBR23793TG96bKByXU+HHjpIAjZ4eCqW55",
+	"CoGbZ5HrV3AZ6X1zZqiK9WOKumda2qgfCKuQGkFf2oWpIqY/Rn8NOomZynT7WJn92KagOoDF2pkDuZ6n",
+	"SXnkSJeqmodD+Gp5mYR7iaAZipu1Wie32mu5Op+8yoiRGo9huiqVWgZsqBTQdqxtkKb8Z5mf+mPv+mxL",
+	"OapZ96A8SK2pdq2pyKp7OE99ipwT+IqyyYTNeVC36ZXtOq6Maq7ch66+KqnrWkLtmq9IdoyUqab2enh1",
+	"x7EBiYNAuZ7tOY4Be3LnSJFE6KqOSp+ACH7gah62qo5UmKWIqKt+OHdb6Jjxh3ftKonGKG0fW6/Lyox1",
+	"94k+GYqQpLJ3KrBCuIovO0/JeaGjN6gQe7NXmrM3Vq6vWrGNeXsZS6k/1lyqVbQSd7SeKrJnu0Agyq+Q",
+	"B7UTKrV62qrzZKJw+x20arPiirO3qLMnea5jS4JlSyO/9VzpIV0xUl38Yxg5EgMem6wgm7S40lzAtbj3",
+	"47hM2rSeCXkpmhLZ2BLbaFglSqV7K46nWq3FJLl2S7Dp2LWB+7U7S7GM+bNk+5jIZhFysCFcVgdyIGOS",
+	"gQZ0QAdwoAMv8AIlwiU/AxQuAJE4AQcuABMz1gcBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/parameters/roundtrip/gin/gen/server.gen.go
+++ b/internal/test/parameters/roundtrip/gin/gen/server.gen.go
@@ -5,7 +5,7 @@ package ginparamsgen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -1237,51 +1237,92 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/enums", wrapper.EnumParams)
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3FpNb+M2E/4rAt/3VMiWne1JPQXbbZuim6R1gC0Q5MBI44hbSeSSdDaB4f9ekJQsiZL1YUv56C2xhjPP",
-	"POQzFIfaooAmjKaQSoH8LeIgGE0F6H9WJGEx/JX9pH4JaCohlepPCU/SYzEmqfpPBBEkWP/+zAD5SEhO",
-	"0ge02+1cFIIIOGGS0BT56NwR2q+Tx3Lo/VcIJFKmxo+O/pEqq6cr89DfIsYpAy6JAXcRlqKRVMIDcLRz",
-	"0YU4DxMDKnt4T2kMOFUPC2f/57BGPvqfV+TvZcG9qwIPh28bwiFE/m0+2FWhizh3FbdVjGvChbzECTQQ",
-	"4yJO46YHVlRt5ZZc3WlOSbqmanBMAsgmJ9WB0OeLG+VdEqncoxsQ0lkBfwSOXPQIXJhpWM4X84UypAxS",
-	"zAjy0Yf5Yr5ELmJYRhq/l823yc/bMsxxslNPHkCnq5LFal7VbKBfQX4sD9CuOE5AAhfIv62sH8xYTAI9",
-	"2PsqqLWK2qanujAyNpCvYSM3p0FHRmUuJd/A7s6trvGzxeJQvL2dZwlhp2N6AaX/EGhnQ1vUaKgKgnGS",
-	"EEkelSE8sZiGgPw1jgVkiQW5mzw15JaoWlOeYGlE8OEMuTVN7NxeERU9BwLCyRGzKKGDOcfPfcPiSlgi",
-	"IRG94u9/MdEa8NRgtPE9HYw9LTQXTC9eaAVQv1Jmh65HbKPguIhTyb2aSWAMCg4bMwgoqpOgnjlCYi5J",
-	"+uB8JzJy0k1yr0tlo5elqBBhl267uoSwxptYHlthIN2YpdZYYD6lm+RaFRbRVWGu84cmReXWecTxBkSe",
-	"57cN8OfSCtOuZXSdFdEiY/UE+bfLxcI9Wyzu3B7FoF5yfzTcVGaCOvlqyZKPAIfA28rrb8bi1PIa5W6y",
-	"5P+eXZeGTFpoW0LPPmW14UVKbx3IubJuBvFihfgAqlcux3VUpjY1kzVFdT6E4N0V6XoimaM8IQvg0YeO",
-	"lKaz31dXl3mRcZ17uklDBwtHRuBw/N0xWJzMx2GBYiFmNxGnm4fomB3F9ricrTLr2Rcio9llbv1iu0yM",
-	"7yHO1q7Wl7ed64r6Q+ur/h/2sHohblJPn7f0cfTtIiGf9RlIZ4jGfPcvc5afjoaSduiQNAZrfcT/Uvzs",
-	"t7ThFJU34glY6rGkJqbokjYJr5uf6rgWdsrbxn9Ievv8q+IbQFyn+k5h7k3Ir6a7bnb66O0UXl5VcAmW",
-	"nDxZeiNhezX6XBt0TCki4eRCM9lNR9heaIMYO36P66BsmMKmJqcktZ8G8XPSBtdB0QCxTcZPbX8jYQ9y",
-	"Rtjd3rPi6pvbMNZO2Nreh+qqcutBzWn72pvWGcNCZMfRPhc014V56/XMgJP2q1y+6IblzwCsuHs7lHLJ",
-	"qqNVGAKw9t6P1ScNjeujNWO1TYqFEhaYxz7uZ8zFShEQthH3Z9WygzzBcABOmJs7rZ09i0cx1hVLwaCG",
-	"U4Bv6M0SdixcNj5chaaEdmyl/EJ50jnV2qhjlnt1k+3bhPHpUkPRwG6yherFQPXrKtucTX/HZ0UcI+A+",
-	"1a6LDzvbaa602yQ8WkCrY2zHab8wfOX+uwX2uDtSy8nAK9ITKpv5jqh6wOjRYFzVhr3dzrVJEU3GWuXL",
-	"ngG0vZ3e9dQMlc4a3W/Xq8aRr968nowj+3jfl6F3076enrn+39atmga+iQb2ZCwdIb4W1b1bma305tmf",
-	"g1X+RjIGAbXvVqdMN3vN+EJkZC7Cve2yR9a1YRP2NpYTNzcUw/pzXYN7w2Pko0hK5nte9q2uBCHnIQBL",
-	"MJtjgnZ3u38DAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FDGk4FU8T8CKRbkWjpw3POU8vbg2CRmdPH3GNHmmjJyiSJPMCUKmTUzAPXWIEPPmTccwMvsgjRt27EgS",
+	"Ec34HPGCoEGEJ+e8oGkTp2rOc4tqFhExTp00Ef/q2CICtufEfxMvbvy4y2zfdAXaxWt4r1qBZnADdRKm",
+	"TWSBdHZG/hl0KGLalq+LyB5YMlChboiWrX07t0PedzuKQBpdzvTqPY2XjWnmzUg2aYyhkEhruYGfT00k",
+	"QcV3T9Ehn2RUSEQHCFMYZodh84lwoX1QySRZDC7AEOJ3zBkIRxo+zRCiCzFkCEcYdKDxnAillXQSci/s",
+	"8aIc1fUxUmHJicAcj08h5JdPR5RBR1sL3SjXbyLsiJ9J9r0nEEFNLjRSGHC4FCCMHb6gxhxRrcUaWp+F",
+	"NlqNpyW0kGpnuvZCWxyVAdeTZO3nYZQwopGhgdb5JGUbGbKHWxm6BVVHGX10gZRWIfElkAwwwJBmGaJJ",
+	"RpppFKX2AqRcSfSCRnV+tFVFPRlVVo1vrJGGeECONCSYRuomQpJLVuZqT0gNqqRham0hkFI0NVXknnZt",
+	"lMZTF2Zop0tvKOWQGWGwYRFSj0lGUKuv/nmgZHBkGGdOa/UnB050iTDYDDJkSN52g5VR2GFHDbuUsR0K",
+	"KpRjzPIqwrNsRBuZomVgu+e2u3obqGRlhIvUuCOZi65gC7HrrnYUE4ZhvUndm4ZT+TKMB7RKkQFCGHLw",
+	"mIezIwcsrQ4EG+wTwt0iBeh2ZeT08Fk4jbTsTTNKDGPGFiP1bsbybmw0xpKhrLJsLNhb7MfH+uR0GCsj",
+	"BbDA01Z7rboH61qzCDdbLS7P5Ar0cxtBv3Hu0JKt2+7S5YGtMb10b3f1yhwTyxTVIf/bssAmf9UZSloP",
+	"/nLMYM8str9lM+zfzq2lLQJomK7JKWpvrob2a3hCLfXfIJcpZOiJkxwZtdYW3Li2jyu83eRmVX5ppiJs",
+	"6hbnDHleOeiHi05SlkFy6eUYtLohJpkeCgTxWpjjrnubno6rGp1vISfbbH7jazqnHeHhFeqvk8Qt5N+S",
+	"hNjo3u95M1V0oPxUeiDcsSwaILhRRxtiYCgz7OeTnU9i0BDKoWktRzNPd9IjG0fRBiShmpFSqFUHNgQp",
+	"eprbnZt6BypUqYZUVzFVpLY3mxcoZH8zitVaZnWsI0mmCPprAxRQVp0C8olH1qFSsNgHONPNEIe/kkP9",
+	"7geCE7YBBHao1qJsmC0R2MYwWSNb+ow4wxj9sDpns91ajPieGFSKBZSCgQOFli65Xaxu8ZpXAx8FQQ+O",
+	"hFI0GEn3eui+N4AASybRkqpKaJMwKOUwa1GhQFjYIRfeSklIyNkfXUTDHALLSh2bWumQta9lpaFZqXPZ",
+	"6rzmuib2cZE2Sx8WWgCFSvYriweEjtsmFreKzW08TLNb0uilGR5OUl/KOmUmuQYzOSzqfyL4pP+kuDAR",
+	"jLKUubxkGVpQBMUhCpU9K9cq4Wa3osESjU1SY988dkuRqc5ke2OZ6hzCOE8qcpiRM2YLgpAyrDHTmcGp",
+	"XSrVZRK2RWyaZXTlGeGVTaVdU2/t5FstI0m6qjUtoOLUZNdaB0xhHiaUxRwlO59mwGiqrZ5te1s+6WDN",
+	"BMpSm3mzGkK3KUmDCu6b4wveLhfny07uyaEClMwokfPOb0LTchjUFJs61TnrvUB7JC1o4AwXm5VukqHl",
+	"gylEtzNT8j1PIDnN3U55B6fP/TR0HMPjSbbUJQAh71jLK5Pz0Ha7DFKvp1bFXviAWpY5dpMkdRIfUaFk",
+	"Tj+iU5QtUKudWgDUqA0vj0FSCUtcApPmydOi//TJebyjKqS41aRuQEgLlDCFJzjhjjZaCAtAQJk6uAGc",
+	"cwBBjLDCozuAwKHwQw9RGnrOhxKTqaRMyxxaQAU03KUOZ/DTQB8buPcBRX5DGWKM8re//rm2rqB87QBb",
+	"MIX46WUoLbjC/VrghOIO86mJVaBq1/jAU1lEgpgKQwUvqCadbm6Dqungd0dllY6IMFQkRMoLXtI/NjRT",
+	"dRPFWo5cMCgV+CiQSpJVXpJnSFwxIQz1va8m8xtFX+kQkltj6S/L96IYxfSGWGSjbQ6VqJZW1HJryygr",
+	"q/lKj6bRnx4N52yAkocHiYC+ZWBDURyoXkmJIIxlNa8GPVXjD7bXI20UyR7lC2P7OhNHe+BvI/37owCv",
+	"cMAttJWBERxjBQtMe71qZBB3eFKF9nLCTaywn5YqqEYWqgwbds+XXYfdqE6Pp73zaV+50+LtFHnGbPSu",
+	"jXEMvfJK9bw8DrKoQOheQceXRkW2slKQyS9l7re//xWIIIUE5UJKWUkHTrAzGW1JTGLYkVXajUAiPDAP",
+	"U7hPFx7UmdP8zDV/+J4aJVqJY3livNHZxXduVJ4jNSM+Q9XPb6bqpwTt41IZesiIpjIbnPAGRZeBwY9u",
+	"ZKRFMGlC1gpJmFY2s53NYEYC8cGi7jIvWfe1MKOazOAys4bb02rGYTfEsB6xGUPayrsxKJYqflh2cK1s",
+	"PHeX12+sVI7/vOPO9Zi9xtbzoeer7WYfGU/RxuG0q13pa0tmyvXd9sNV+uktQ9iZCy03ss6t3HTjcNXs",
+	"7vCE2wzsqaLXd2gBXmxWvG8791vX/45gwC3V58zp+KwcJDbCQ3jsxia7vpzuV8R71OQgWdsNBc420k2p",
+	"TG9P6ZHhJnXIXVpmC6P70yjnMDlNjV0yynqfSAPprW1eX3/3eOcDD/bLD05oICsc2S9Al1DwwO2A7jcN",
+	"ZGAygJ1ecahfmg5NgNHe+07RjoNbWOKWMNfT7fWSqyuehlKzu8m6FnhLM9b17iit+2nrFI9U33X2id7T",
+	"gAe3ExvuPZeeywOt52IT/e5Gz7viWe9sJLsA8IKXtJMHWfioI373fN94UR2Pdchr3dWnrnw6AR92zZOd",
+	"87/2OcGBXtXfXTV4NE+9ZFbfepy/fS2+vlzLAW1wodf9vahaOPmdnXRH72EHwJ/48CltGAIfPvHdkXyq",
+	"U3+e5mDNN2ogB33mJn3pQ33rJnbQV3b4dHb09lH+xGIuRn6uV3uwl32yx35BV3tDV2i4tyrkp3H45XdJ",
+	"Bnj6R3j9F2XYdnwBiIILhlBZ9m0HGHlHJXJdN2aW54APxGoqx2bYR09AE2/UNG/ZZYGlh2+nt3aqh3wb",
+	"CHDoJ3CxZ1Zwll7u92PwJ2S5d4IOpzq+x4JNJ2AvaGkxCIB7R4NXRj4GGGrOl4DkNnl8woDFBISZ127X",
+	"p0UeiIXCJmdYhXoZKIXm93pVyHN9+HNZOGwi+H5FZ4LIR4BlkCP4RwYtaIZEgoYXpyRqyHqSaHWgxmXP",
+	"N4fAJGYXhodolnJjt3JFaHahN2vYZG/hN4gBOIU6d4hxN3vt14hc+Igl9CJzMAe1dVu5lSODcolPdoYW",
+	"d0h0MEPBOIxvgFs++IZcplVagkB2MlgvkS1jxYdLuFgMZHQL6IPppGoPaH2LUogciItXqIjCRne9WIIl",
+	"9ERykAdEUAYNoz2Dh4n+F4P3mI9uqGWPZ0smpRQNk1LL93zltCf0GEXpZJBwwBnVp4es6I1upotxllZu",
+	"sVaBCIWSAZFARWOGaC8UZEG5CIJayIsJN0J415D3CCD80mrC54KZuIy4EgWLUo8vmUvPdINXB4cEGTgT",
+	"EQYCAgJKAZM/A042qINbB0wNeWFzoDOHBWIYhYQbJXqxOEv3Vjf55pE/8SICspMx+Re7xU0mdSI8YZQx",
+	"xpNK2XijyElOmZMOmT4vclM+U5WfJ2/6VIG1tpUA9TSzuB1oWQZimZS26EbsmIjbt4jwuJLw1ZJyaQSr",
+	"VIbJWJOGF4M4CUWSeS6g6HHhxlumQ2ptiTUJxUsL6RNP+XU5Y5edh5eqBHokhnb1ppWzYXqAKYjbITHr",
+	"Q1DtI1JuKYdwWT6paXlS+W6uKQKuGJt8SXp+6ZukGZg+oZtlWVKBI5oICSUKaWpNNJzpVAa0w3LaJ3fV",
+	"Y1Vs5VeguSdzhThMqQOkKJxyeWHfWYQXiZIwJyflGZShCU8gkCyN5mnZCWYM+Z6q6TBTaZUUuIR9GVS9",
+	"CS5U55/AiVTbKaCWR6ASCJtKaGLMqaB0hEv9iRXguFruCUWpZkPY5VEfKjzWWDxd9SVgNSZiVaDtuJh/",
+	"qJFxxVbcY5aBAz52cp3qGaEi+nUEsZvn6RO+5VzzcwbChT8xZFwZ4qP1eGEExJrYEUsnahQiuY6TYoWK",
+	"KZ67yGsjaHcsmXtVUSeMp186smTISHzKeJmbSAd1V6YNJpA5+J90aIpfZ45BqIoRWISe95p6yVGwyE+y",
+	"WIFdiYHbMaZXcZjf1YHqF54YmZJe6ojyKF+I2hG9B3FnikPBR23793TG96bKByXU+HHjpIAjZ4eCqW55",
+	"CoGbZ5HrV3AZ6X1zZqiK9WOKumda2qgfCKuQGkFf2oWpIqY/Rn8NOomZynT7WJn92KagOoDF2pkDuZ6n",
+	"SXnkSJeqmodD+Gp5mYR7iaAZipu1Wie32mu5Op+8yoiRGo9huiqVWgZsqBTQdqxtkKb8Z5mf+mPv+mxL",
+	"OapZ96A8SK2pdq2pyKp7OE99ipwT+IqyyYTNeVC36ZXtOq6Maq7ch66+KqnrWkLtmq9IdoyUqab2enh1",
+	"x7EBiYNAuZ7tOY4Be3LnSJFE6KqOSp+ACH7gah62qo5UmKWIqKt+OHdb6Jjxh3ftKonGKG0fW6/Lyox1",
+	"94k+GYqQpLJ3KrBCuIovO0/JeaGjN6gQe7NXmrM3Vq6vWrGNeXsZS6k/1lyqVbQSd7SeKrJnu0Agyq+Q",
+	"B7UTKrV62qrzZKJw+x20arPiirO3qLMnea5jS4JlSyO/9VzpIV0xUl38Yxg5EgMem6wgm7S40lzAtbj3",
+	"47hM2rSeCXkpmhLZ2BLbaFglSqV7K46nWq3FJLl2S7Dp2LWB+7U7S7GM+bNk+5jIZhFysCFcVgdyIGOS",
+	"gQZ0QAdwoAMv8AIlwiU/AxQuAJE4AQcuABMz1gcBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/parameters/roundtrip/gorilla/gen/server.gen.go
+++ b/internal/test/parameters/roundtrip/gorilla/gen/server.gen.go
@@ -5,7 +5,7 @@ package gorillaparamsgen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -1443,51 +1443,92 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 	return r
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3FpNb+M2E/4rAt/3VMiWne1JPQXbbZuim6R1gC0Q5MBI44hbSeSSdDaB4f9ekJQsiZL1YUv56C2xhjPP",
-	"POQzFIfaooAmjKaQSoH8LeIgGE0F6H9WJGEx/JX9pH4JaCohlepPCU/SYzEmqfpPBBEkWP/+zAD5SEhO",
-	"0ge02+1cFIIIOGGS0BT56NwR2q+Tx3Lo/VcIJFKmxo+O/pEqq6cr89DfIsYpAy6JAXcRlqKRVMIDcLRz",
-	"0YU4DxMDKnt4T2kMOFUPC2f/57BGPvqfV+TvZcG9qwIPh28bwiFE/m0+2FWhizh3FbdVjGvChbzECTQQ",
-	"4yJO46YHVlRt5ZZc3WlOSbqmanBMAsgmJ9WB0OeLG+VdEqncoxsQ0lkBfwSOXPQIXJhpWM4X84UypAxS",
-	"zAjy0Yf5Yr5ELmJYRhq/l823yc/bMsxxslNPHkCnq5LFal7VbKBfQX4sD9CuOE5AAhfIv62sH8xYTAI9",
-	"2PsqqLWK2qanujAyNpCvYSM3p0FHRmUuJd/A7s6trvGzxeJQvL2dZwlhp2N6AaX/EGhnQ1vUaKgKgnGS",
-	"EEkelSE8sZiGgPw1jgVkiQW5mzw15JaoWlOeYGlE8OEMuTVN7NxeERU9BwLCyRGzKKGDOcfPfcPiSlgi",
-	"IRG94u9/MdEa8NRgtPE9HYw9LTQXTC9eaAVQv1Jmh65HbKPguIhTyb2aSWAMCg4bMwgoqpOgnjlCYi5J",
-	"+uB8JzJy0k1yr0tlo5elqBBhl267uoSwxptYHlthIN2YpdZYYD6lm+RaFRbRVWGu84cmReXWecTxBkSe",
-	"57cN8OfSCtOuZXSdFdEiY/UE+bfLxcI9Wyzu3B7FoF5yfzTcVGaCOvlqyZKPAIfA28rrb8bi1PIa5W6y",
-	"5P+eXZeGTFpoW0LPPmW14UVKbx3IubJuBvFihfgAqlcux3VUpjY1kzVFdT6E4N0V6XoimaM8IQvg0YeO",
-	"lKaz31dXl3mRcZ17uklDBwtHRuBw/N0xWJzMx2GBYiFmNxGnm4fomB3F9ricrTLr2Rcio9llbv1iu0yM",
-	"7yHO1q7Wl7ed64r6Q+ur/h/2sHohblJPn7f0cfTtIiGf9RlIZ4jGfPcvc5afjoaSduiQNAZrfcT/Uvzs",
-	"t7ThFJU34glY6rGkJqbokjYJr5uf6rgWdsrbxn9Ievv8q+IbQFyn+k5h7k3Ir6a7bnb66O0UXl5VcAmW",
-	"nDxZeiNhezX6XBt0TCki4eRCM9lNR9heaIMYO36P66BsmMKmJqcktZ8G8XPSBtdB0QCxTcZPbX8jYQ9y",
-	"Rtjd3rPi6pvbMNZO2Nreh+qqcutBzWn72pvWGcNCZMfRPhc014V56/XMgJP2q1y+6IblzwCsuHs7lHLJ",
-	"qqNVGAKw9t6P1ScNjeujNWO1TYqFEhaYxz7uZ8zFShEQthH3Z9WygzzBcABOmJs7rZ09i0cx1hVLwaCG",
-	"U4Bv6M0SdixcNj5chaaEdmyl/EJ50jnV2qhjlnt1k+3bhPHpUkPRwG6yherFQPXrKtucTX/HZ0UcI+A+",
-	"1a6LDzvbaa602yQ8WkCrY2zHab8wfOX+uwX2uDtSy8nAK9ITKpv5jqh6wOjRYFzVhr3dzrVJEU3GWuXL",
-	"ngG0vZ3e9dQMlc4a3W/Xq8aRr968nowj+3jfl6F3076enrn+39atmga+iQb2ZCwdIb4W1b1bma305tmf",
-	"g1X+RjIGAbXvVqdMN3vN+EJkZC7Cve2yR9a1YRP2NpYTNzcUw/pzXYN7w2Pko0hK5nte9q2uBCHnIQBL",
-	"MJtjgnZ3u38DAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FDGk4FU8T8CKRbkWjpw3POU8vbg2CRmdPH3GNHmmjJyiSJPMCUKmTUzAPXWIEPPmTccwMvsgjRt27EgS",
+	"Ec34HPGCoEGEJ+e8oGkTp2rOc4tqFhExTp00Ef/q2CICtufEfxMvbvy4y2zfdAXaxWt4r1qBZnADdRKm",
+	"TWSBdHZG/hl0KGLalq+LyB5YMlChboiWrX07t0PedzuKQBpdzvTqPY2XjWnmzUg2aYyhkEhruYGfT00k",
+	"QcV3T9Ehn2RUSEQHCFMYZodh84lwoX1QySRZDC7AEOJ3zBkIRxo+zRCiCzFkCEcYdKDxnAillXQSci/s",
+	"8aIc1fUxUmHJicAcj08h5JdPR5RBR1sL3SjXbyLsiJ9J9r0nEEFNLjRSGHC4FCCMHb6gxhxRrcUaWp+F",
+	"NlqNpyW0kGpnuvZCWxyVAdeTZO3nYZQwopGhgdb5JGUbGbKHWxm6BVVHGX10gZRWIfElkAwwwJBmGaJJ",
+	"RpppFKX2AqRcSfSCRnV+tFVFPRlVVo1vrJGGeECONCSYRuomQpJLVuZqT0gNqqRham0hkFI0NVXknnZt",
+	"lMZTF2Zop0tvKOWQGWGwYRFSj0lGUKuv/nmgZHBkGGdOa/UnB050iTDYDDJkSN52g5VR2GFHDbuUsR0K",
+	"KpRjzPIqwrNsRBuZomVgu+e2u3obqGRlhIvUuCOZi65gC7HrrnYUE4ZhvUndm4ZT+TKMB7RKkQFCGHLw",
+	"mIezIwcsrQ4EG+wTwt0iBeh2ZeT08Fk4jbTsTTNKDGPGFiP1bsbybmw0xpKhrLJsLNhb7MfH+uR0GCsj",
+	"BbDA01Z7rboH61qzCDdbLS7P5Ar0cxtBv3Hu0JKt2+7S5YGtMb10b3f1yhwTyxTVIf/bssAmf9UZSloP",
+	"/nLMYM8str9lM+zfzq2lLQJomK7JKWpvrob2a3hCLfXfIJcpZOiJkxwZtdYW3Li2jyu83eRmVX5ppiJs",
+	"6hbnDHleOeiHi05SlkFy6eUYtLohJpkeCgTxWpjjrnubno6rGp1vISfbbH7jazqnHeHhFeqvk8Qt5N+S",
+	"hNjo3u95M1V0oPxUeiDcsSwaILhRRxtiYCgz7OeTnU9i0BDKoWktRzNPd9IjG0fRBiShmpFSqFUHNgQp",
+	"eprbnZt6BypUqYZUVzFVpLY3mxcoZH8zitVaZnWsI0mmCPprAxRQVp0C8olH1qFSsNgHONPNEIe/kkP9",
+	"7geCE7YBBHao1qJsmC0R2MYwWSNb+ow4wxj9sDpns91ajPieGFSKBZSCgQOFli65Xaxu8ZpXAx8FQQ+O",
+	"hFI0GEn3eui+N4AASybRkqpKaJMwKOUwa1GhQFjYIRfeSklIyNkfXUTDHALLSh2bWumQta9lpaFZqXPZ",
+	"6rzmuib2cZE2Sx8WWgCFSvYriweEjtsmFreKzW08TLNb0uilGR5OUl/KOmUmuQYzOSzqfyL4pP+kuDAR",
+	"jLKUubxkGVpQBMUhCpU9K9cq4Wa3osESjU1SY988dkuRqc5ke2OZ6hzCOE8qcpiRM2YLgpAyrDHTmcGp",
+	"XSrVZRK2RWyaZXTlGeGVTaVdU2/t5FstI0m6qjUtoOLUZNdaB0xhHiaUxRwlO59mwGiqrZ5te1s+6WDN",
+	"BMpSm3mzGkK3KUmDCu6b4wveLhfny07uyaEClMwokfPOb0LTchjUFJs61TnrvUB7JC1o4AwXm5VukqHl",
+	"gylEtzNT8j1PIDnN3U55B6fP/TR0HMPjSbbUJQAh71jLK5Pz0Ha7DFKvp1bFXviAWpY5dpMkdRIfUaFk",
+	"Tj+iU5QtUKudWgDUqA0vj0FSCUtcApPmydOi//TJebyjKqS41aRuQEgLlDCFJzjhjjZaCAtAQJk6uAGc",
+	"cwBBjLDCozuAwKHwQw9RGnrOhxKTqaRMyxxaQAU03KUOZ/DTQB8buPcBRX5DGWKM8re//rm2rqB87QBb",
+	"MIX46WUoLbjC/VrghOIO86mJVaBq1/jAU1lEgpgKQwUvqCadbm6Dqungd0dllY6IMFQkRMoLXtI/NjRT",
+	"dRPFWo5cMCgV+CiQSpJVXpJnSFwxIQz1va8m8xtFX+kQkltj6S/L96IYxfSGWGSjbQ6VqJZW1HJryygr",
+	"q/lKj6bRnx4N52yAkocHiYC+ZWBDURyoXkmJIIxlNa8GPVXjD7bXI20UyR7lC2P7OhNHe+BvI/37owCv",
+	"cMAttJWBERxjBQtMe71qZBB3eFKF9nLCTaywn5YqqEYWqgwbds+XXYfdqE6Pp73zaV+50+LtFHnGbPSu",
+	"jXEMvfJK9bw8DrKoQOheQceXRkW2slKQyS9l7re//xWIIIUE5UJKWUkHTrAzGW1JTGLYkVXajUAiPDAP",
+	"U7hPFx7UmdP8zDV/+J4aJVqJY3livNHZxXduVJ4jNSM+Q9XPb6bqpwTt41IZesiIpjIbnPAGRZeBwY9u",
+	"ZKRFMGlC1gpJmFY2s53NYEYC8cGi7jIvWfe1MKOazOAys4bb02rGYTfEsB6xGUPayrsxKJYqflh2cK1s",
+	"PHeX12+sVI7/vOPO9Zi9xtbzoeer7WYfGU/RxuG0q13pa0tmyvXd9sNV+uktQ9iZCy03ss6t3HTjcNXs",
+	"7vCE2wzsqaLXd2gBXmxWvG8791vX/45gwC3V58zp+KwcJDbCQ3jsxia7vpzuV8R71OQgWdsNBc420k2p",
+	"TG9P6ZHhJnXIXVpmC6P70yjnMDlNjV0yynqfSAPprW1eX3/3eOcDD/bLD05oICsc2S9Al1DwwO2A7jcN",
+	"ZGAygJ1ecahfmg5NgNHe+07RjoNbWOKWMNfT7fWSqyuehlKzu8m6FnhLM9b17iit+2nrFI9U33X2id7T",
+	"gAe3ExvuPZeeywOt52IT/e5Gz7viWe9sJLsA8IKXtJMHWfioI373fN94UR2Pdchr3dWnrnw6AR92zZOd",
+	"87/2OcGBXtXfXTV4NE+9ZFbfepy/fS2+vlzLAW1wodf9vahaOPmdnXRH72EHwJ/48CltGAIfPvHdkXyq",
+	"U3+e5mDNN2ogB33mJn3pQ33rJnbQV3b4dHb09lH+xGIuRn6uV3uwl32yx35BV3tDV2i4tyrkp3H45XdJ",
+	"Bnj6R3j9F2XYdnwBiIILhlBZ9m0HGHlHJXJdN2aW54APxGoqx2bYR09AE2/UNG/ZZYGlh2+nt3aqh3wb",
+	"CHDoJ3CxZ1Zwll7u92PwJ2S5d4IOpzq+x4JNJ2AvaGkxCIB7R4NXRj4GGGrOl4DkNnl8woDFBISZ127X",
+	"p0UeiIXCJmdYhXoZKIXm93pVyHN9+HNZOGwi+H5FZ4LIR4BlkCP4RwYtaIZEgoYXpyRqyHqSaHWgxmXP",
+	"N4fAJGYXhodolnJjt3JFaHahN2vYZG/hN4gBOIU6d4hxN3vt14hc+Igl9CJzMAe1dVu5lSODcolPdoYW",
+	"d0h0MEPBOIxvgFs++IZcplVagkB2MlgvkS1jxYdLuFgMZHQL6IPppGoPaH2LUogciItXqIjCRne9WIIl",
+	"9ERykAdEUAYNoz2Dh4n+F4P3mI9uqGWPZ0smpRQNk1LL93zltCf0GEXpZJBwwBnVp4es6I1upotxllZu",
+	"sVaBCIWSAZFARWOGaC8UZEG5CIJayIsJN0J415D3CCD80mrC54KZuIy4EgWLUo8vmUvPdINXB4cEGTgT",
+	"EQYCAgJKAZM/A042qINbB0wNeWFzoDOHBWIYhYQbJXqxOEv3Vjf55pE/8SICspMx+Re7xU0mdSI8YZQx",
+	"xpNK2XijyElOmZMOmT4vclM+U5WfJ2/6VIG1tpUA9TSzuB1oWQZimZS26EbsmIjbt4jwuJLw1ZJyaQSr",
+	"VIbJWJOGF4M4CUWSeS6g6HHhxlumQ2ptiTUJxUsL6RNP+XU5Y5edh5eqBHokhnb1ppWzYXqAKYjbITHr",
+	"Q1DtI1JuKYdwWT6paXlS+W6uKQKuGJt8SXp+6ZukGZg+oZtlWVKBI5oICSUKaWpNNJzpVAa0w3LaJ3fV",
+	"Y1Vs5VeguSdzhThMqQOkKJxyeWHfWYQXiZIwJyflGZShCU8gkCyN5mnZCWYM+Z6q6TBTaZUUuIR9GVS9",
+	"CS5U55/AiVTbKaCWR6ASCJtKaGLMqaB0hEv9iRXguFruCUWpZkPY5VEfKjzWWDxd9SVgNSZiVaDtuJh/",
+	"qJFxxVbcY5aBAz52cp3qGaEi+nUEsZvn6RO+5VzzcwbChT8xZFwZ4qP1eGEExJrYEUsnahQiuY6TYoWK",
+	"KZ67yGsjaHcsmXtVUSeMp186smTISHzKeJmbSAd1V6YNJpA5+J90aIpfZ45BqIoRWISe95p6yVGwyE+y",
+	"WIFdiYHbMaZXcZjf1YHqF54YmZJe6ojyKF+I2hG9B3FnikPBR23793TG96bKByXU+HHjpIAjZ4eCqW55",
+	"CoGbZ5HrV3AZ6X1zZqiK9WOKumda2qgfCKuQGkFf2oWpIqY/Rn8NOomZynT7WJn92KagOoDF2pkDuZ6n",
+	"SXnkSJeqmodD+Gp5mYR7iaAZipu1Wie32mu5Op+8yoiRGo9huiqVWgZsqBTQdqxtkKb8Z5mf+mPv+mxL",
+	"OapZ96A8SK2pdq2pyKp7OE99ipwT+IqyyYTNeVC36ZXtOq6Maq7ch66+KqnrWkLtmq9IdoyUqab2enh1",
+	"x7EBiYNAuZ7tOY4Be3LnSJFE6KqOSp+ACH7gah62qo5UmKWIqKt+OHdb6Jjxh3ftKonGKG0fW6/Lyox1",
+	"94k+GYqQpLJ3KrBCuIovO0/JeaGjN6gQe7NXmrM3Vq6vWrGNeXsZS6k/1lyqVbQSd7SeKrJnu0Agyq+Q",
+	"B7UTKrV62qrzZKJw+x20arPiirO3qLMnea5jS4JlSyO/9VzpIV0xUl38Yxg5EgMem6wgm7S40lzAtbj3",
+	"47hM2rSeCXkpmhLZ2BLbaFglSqV7K46nWq3FJLl2S7Dp2LWB+7U7S7GM+bNk+5jIZhFysCFcVgdyIGOS",
+	"gQZ0QAdwoAMv8AIlwiU/AxQuAJE4AQcuABMz1gcBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/parameters/roundtrip/iris/gen/server.gen.go
+++ b/internal/test/parameters/roundtrip/iris/gen/server.gen.go
@@ -5,7 +5,7 @@ package irisparamsgen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -1073,51 +1073,92 @@ func RegisterHandlersWithOptions(router *iris.Application, si ServerInterface, o
 	router.Build()
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3FpNb+M2E/4rAt/3VMiWne1JPQXbbZuim6R1gC0Q5MBI44hbSeSSdDaB4f9ekJQsiZL1YUv56C2xhjPP",
-	"POQzFIfaooAmjKaQSoH8LeIgGE0F6H9WJGEx/JX9pH4JaCohlepPCU/SYzEmqfpPBBEkWP/+zAD5SEhO",
-	"0ge02+1cFIIIOGGS0BT56NwR2q+Tx3Lo/VcIJFKmxo+O/pEqq6cr89DfIsYpAy6JAXcRlqKRVMIDcLRz",
-	"0YU4DxMDKnt4T2kMOFUPC2f/57BGPvqfV+TvZcG9qwIPh28bwiFE/m0+2FWhizh3FbdVjGvChbzECTQQ",
-	"4yJO46YHVlRt5ZZc3WlOSbqmanBMAsgmJ9WB0OeLG+VdEqncoxsQ0lkBfwSOXPQIXJhpWM4X84UypAxS",
-	"zAjy0Yf5Yr5ELmJYRhq/l823yc/bMsxxslNPHkCnq5LFal7VbKBfQX4sD9CuOE5AAhfIv62sH8xYTAI9",
-	"2PsqqLWK2qanujAyNpCvYSM3p0FHRmUuJd/A7s6trvGzxeJQvL2dZwlhp2N6AaX/EGhnQ1vUaKgKgnGS",
-	"EEkelSE8sZiGgPw1jgVkiQW5mzw15JaoWlOeYGlE8OEMuTVN7NxeERU9BwLCyRGzKKGDOcfPfcPiSlgi",
-	"IRG94u9/MdEa8NRgtPE9HYw9LTQXTC9eaAVQv1Jmh65HbKPguIhTyb2aSWAMCg4bMwgoqpOgnjlCYi5J",
-	"+uB8JzJy0k1yr0tlo5elqBBhl267uoSwxptYHlthIN2YpdZYYD6lm+RaFRbRVWGu84cmReXWecTxBkSe",
-	"57cN8OfSCtOuZXSdFdEiY/UE+bfLxcI9Wyzu3B7FoF5yfzTcVGaCOvlqyZKPAIfA28rrb8bi1PIa5W6y",
-	"5P+eXZeGTFpoW0LPPmW14UVKbx3IubJuBvFihfgAqlcux3VUpjY1kzVFdT6E4N0V6XoimaM8IQvg0YeO",
-	"lKaz31dXl3mRcZ17uklDBwtHRuBw/N0xWJzMx2GBYiFmNxGnm4fomB3F9ricrTLr2Rcio9llbv1iu0yM",
-	"7yHO1q7Wl7ed64r6Q+ur/h/2sHohblJPn7f0cfTtIiGf9RlIZ4jGfPcvc5afjoaSduiQNAZrfcT/Uvzs",
-	"t7ThFJU34glY6rGkJqbokjYJr5uf6rgWdsrbxn9Ievv8q+IbQFyn+k5h7k3Ir6a7bnb66O0UXl5VcAmW",
-	"nDxZeiNhezX6XBt0TCki4eRCM9lNR9heaIMYO36P66BsmMKmJqcktZ8G8XPSBtdB0QCxTcZPbX8jYQ9y",
-	"Rtjd3rPi6pvbMNZO2Nreh+qqcutBzWn72pvWGcNCZMfRPhc014V56/XMgJP2q1y+6IblzwCsuHs7lHLJ",
-	"qqNVGAKw9t6P1ScNjeujNWO1TYqFEhaYxz7uZ8zFShEQthH3Z9WygzzBcABOmJs7rZ09i0cx1hVLwaCG",
-	"U4Bv6M0SdixcNj5chaaEdmyl/EJ50jnV2qhjlnt1k+3bhPHpUkPRwG6yherFQPXrKtucTX/HZ0UcI+A+",
-	"1a6LDzvbaa602yQ8WkCrY2zHab8wfOX+uwX2uDtSy8nAK9ITKpv5jqh6wOjRYFzVhr3dzrVJEU3GWuXL",
-	"ngG0vZ3e9dQMlc4a3W/Xq8aRr968nowj+3jfl6F3076enrn+39atmga+iQb2ZCwdIb4W1b1bma305tmf",
-	"g1X+RjIGAbXvVqdMN3vN+EJkZC7Cve2yR9a1YRP2NpYTNzcUw/pzXYN7w2Pko0hK5nte9q2uBCHnIQBL",
-	"MJtjgnZ3u38DAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FDGk4FU8T8CKRbkWjpw3POU8vbg2CRmdPH3GNHmmjJyiSJPMCUKmTUzAPXWIEPPmTccwMvsgjRt27EgS",
+	"Ec34HPGCoEGEJ+e8oGkTp2rOc4tqFhExTp00Ef/q2CICtufEfxMvbvy4y2zfdAXaxWt4r1qBZnADdRKm",
+	"TWSBdHZG/hl0KGLalq+LyB5YMlChboiWrX07t0PedzuKQBpdzvTqPY2XjWnmzUg2aYyhkEhruYGfT00k",
+	"QcV3T9Ehn2RUSEQHCFMYZodh84lwoX1QySRZDC7AEOJ3zBkIRxo+zRCiCzFkCEcYdKDxnAillXQSci/s",
+	"8aIc1fUxUmHJicAcj08h5JdPR5RBR1sL3SjXbyLsiJ9J9r0nEEFNLjRSGHC4FCCMHb6gxhxRrcUaWp+F",
+	"NlqNpyW0kGpnuvZCWxyVAdeTZO3nYZQwopGhgdb5JGUbGbKHWxm6BVVHGX10gZRWIfElkAwwwJBmGaJJ",
+	"RpppFKX2AqRcSfSCRnV+tFVFPRlVVo1vrJGGeECONCSYRuomQpJLVuZqT0gNqqRham0hkFI0NVXknnZt",
+	"lMZTF2Zop0tvKOWQGWGwYRFSj0lGUKuv/nmgZHBkGGdOa/UnB050iTDYDDJkSN52g5VR2GFHDbuUsR0K",
+	"KpRjzPIqwrNsRBuZomVgu+e2u3obqGRlhIvUuCOZi65gC7HrrnYUE4ZhvUndm4ZT+TKMB7RKkQFCGHLw",
+	"mIezIwcsrQ4EG+wTwt0iBeh2ZeT08Fk4jbTsTTNKDGPGFiP1bsbybmw0xpKhrLJsLNhb7MfH+uR0GCsj",
+	"BbDA01Z7rboH61qzCDdbLS7P5Ar0cxtBv3Hu0JKt2+7S5YGtMb10b3f1yhwTyxTVIf/bssAmf9UZSloP",
+	"/nLMYM8str9lM+zfzq2lLQJomK7JKWpvrob2a3hCLfXfIJcpZOiJkxwZtdYW3Li2jyu83eRmVX5ppiJs",
+	"6hbnDHleOeiHi05SlkFy6eUYtLohJpkeCgTxWpjjrnubno6rGp1vISfbbH7jazqnHeHhFeqvk8Qt5N+S",
+	"hNjo3u95M1V0oPxUeiDcsSwaILhRRxtiYCgz7OeTnU9i0BDKoWktRzNPd9IjG0fRBiShmpFSqFUHNgQp",
+	"eprbnZt6BypUqYZUVzFVpLY3mxcoZH8zitVaZnWsI0mmCPprAxRQVp0C8olH1qFSsNgHONPNEIe/kkP9",
+	"7geCE7YBBHao1qJsmC0R2MYwWSNb+ow4wxj9sDpns91ajPieGFSKBZSCgQOFli65Xaxu8ZpXAx8FQQ+O",
+	"hFI0GEn3eui+N4AASybRkqpKaJMwKOUwa1GhQFjYIRfeSklIyNkfXUTDHALLSh2bWumQta9lpaFZqXPZ",
+	"6rzmuib2cZE2Sx8WWgCFSvYriweEjtsmFreKzW08TLNb0uilGR5OUl/KOmUmuQYzOSzqfyL4pP+kuDAR",
+	"jLKUubxkGVpQBMUhCpU9K9cq4Wa3osESjU1SY988dkuRqc5ke2OZ6hzCOE8qcpiRM2YLgpAyrDHTmcGp",
+	"XSrVZRK2RWyaZXTlGeGVTaVdU2/t5FstI0m6qjUtoOLUZNdaB0xhHiaUxRwlO59mwGiqrZ5te1s+6WDN",
+	"BMpSm3mzGkK3KUmDCu6b4wveLhfny07uyaEClMwokfPOb0LTchjUFJs61TnrvUB7JC1o4AwXm5VukqHl",
+	"gylEtzNT8j1PIDnN3U55B6fP/TR0HMPjSbbUJQAh71jLK5Pz0Ha7DFKvp1bFXviAWpY5dpMkdRIfUaFk",
+	"Tj+iU5QtUKudWgDUqA0vj0FSCUtcApPmydOi//TJebyjKqS41aRuQEgLlDCFJzjhjjZaCAtAQJk6uAGc",
+	"cwBBjLDCozuAwKHwQw9RGnrOhxKTqaRMyxxaQAU03KUOZ/DTQB8buPcBRX5DGWKM8re//rm2rqB87QBb",
+	"MIX46WUoLbjC/VrghOIO86mJVaBq1/jAU1lEgpgKQwUvqCadbm6Dqungd0dllY6IMFQkRMoLXtI/NjRT",
+	"dRPFWo5cMCgV+CiQSpJVXpJnSFwxIQz1va8m8xtFX+kQkltj6S/L96IYxfSGWGSjbQ6VqJZW1HJryygr",
+	"q/lKj6bRnx4N52yAkocHiYC+ZWBDURyoXkmJIIxlNa8GPVXjD7bXI20UyR7lC2P7OhNHe+BvI/37owCv",
+	"cMAttJWBERxjBQtMe71qZBB3eFKF9nLCTaywn5YqqEYWqgwbds+XXYfdqE6Pp73zaV+50+LtFHnGbPSu",
+	"jXEMvfJK9bw8DrKoQOheQceXRkW2slKQyS9l7re//xWIIIUE5UJKWUkHTrAzGW1JTGLYkVXajUAiPDAP",
+	"U7hPFx7UmdP8zDV/+J4aJVqJY3livNHZxXduVJ4jNSM+Q9XPb6bqpwTt41IZesiIpjIbnPAGRZeBwY9u",
+	"ZKRFMGlC1gpJmFY2s53NYEYC8cGi7jIvWfe1MKOazOAys4bb02rGYTfEsB6xGUPayrsxKJYqflh2cK1s",
+	"PHeX12+sVI7/vOPO9Zi9xtbzoeer7WYfGU/RxuG0q13pa0tmyvXd9sNV+uktQ9iZCy03ss6t3HTjcNXs",
+	"7vCE2wzsqaLXd2gBXmxWvG8791vX/45gwC3V58zp+KwcJDbCQ3jsxia7vpzuV8R71OQgWdsNBc420k2p",
+	"TG9P6ZHhJnXIXVpmC6P70yjnMDlNjV0yynqfSAPprW1eX3/3eOcDD/bLD05oICsc2S9Al1DwwO2A7jcN",
+	"ZGAygJ1ecahfmg5NgNHe+07RjoNbWOKWMNfT7fWSqyuehlKzu8m6FnhLM9b17iit+2nrFI9U33X2id7T",
+	"gAe3ExvuPZeeywOt52IT/e5Gz7viWe9sJLsA8IKXtJMHWfioI373fN94UR2Pdchr3dWnrnw6AR92zZOd",
+	"87/2OcGBXtXfXTV4NE+9ZFbfepy/fS2+vlzLAW1wodf9vahaOPmdnXRH72EHwJ/48CltGAIfPvHdkXyq",
+	"U3+e5mDNN2ogB33mJn3pQ33rJnbQV3b4dHb09lH+xGIuRn6uV3uwl32yx35BV3tDV2i4tyrkp3H45XdJ",
+	"Bnj6R3j9F2XYdnwBiIILhlBZ9m0HGHlHJXJdN2aW54APxGoqx2bYR09AE2/UNG/ZZYGlh2+nt3aqh3wb",
+	"CHDoJ3CxZ1Zwll7u92PwJ2S5d4IOpzq+x4JNJ2AvaGkxCIB7R4NXRj4GGGrOl4DkNnl8woDFBISZ127X",
+	"p0UeiIXCJmdYhXoZKIXm93pVyHN9+HNZOGwi+H5FZ4LIR4BlkCP4RwYtaIZEgoYXpyRqyHqSaHWgxmXP",
+	"N4fAJGYXhodolnJjt3JFaHahN2vYZG/hN4gBOIU6d4hxN3vt14hc+Igl9CJzMAe1dVu5lSODcolPdoYW",
+	"d0h0MEPBOIxvgFs++IZcplVagkB2MlgvkS1jxYdLuFgMZHQL6IPppGoPaH2LUogciItXqIjCRne9WIIl",
+	"9ERykAdEUAYNoz2Dh4n+F4P3mI9uqGWPZ0smpRQNk1LL93zltCf0GEXpZJBwwBnVp4es6I1upotxllZu",
+	"sVaBCIWSAZFARWOGaC8UZEG5CIJayIsJN0J415D3CCD80mrC54KZuIy4EgWLUo8vmUvPdINXB4cEGTgT",
+	"EQYCAgJKAZM/A042qINbB0wNeWFzoDOHBWIYhYQbJXqxOEv3Vjf55pE/8SICspMx+Re7xU0mdSI8YZQx",
+	"xpNK2XijyElOmZMOmT4vclM+U5WfJ2/6VIG1tpUA9TSzuB1oWQZimZS26EbsmIjbt4jwuJLw1ZJyaQSr",
+	"VIbJWJOGF4M4CUWSeS6g6HHhxlumQ2ptiTUJxUsL6RNP+XU5Y5edh5eqBHokhnb1ppWzYXqAKYjbITHr",
+	"Q1DtI1JuKYdwWT6paXlS+W6uKQKuGJt8SXp+6ZukGZg+oZtlWVKBI5oICSUKaWpNNJzpVAa0w3LaJ3fV",
+	"Y1Vs5VeguSdzhThMqQOkKJxyeWHfWYQXiZIwJyflGZShCU8gkCyN5mnZCWYM+Z6q6TBTaZUUuIR9GVS9",
+	"CS5U55/AiVTbKaCWR6ASCJtKaGLMqaB0hEv9iRXguFruCUWpZkPY5VEfKjzWWDxd9SVgNSZiVaDtuJh/",
+	"qJFxxVbcY5aBAz52cp3qGaEi+nUEsZvn6RO+5VzzcwbChT8xZFwZ4qP1eGEExJrYEUsnahQiuY6TYoWK",
+	"KZ67yGsjaHcsmXtVUSeMp186smTISHzKeJmbSAd1V6YNJpA5+J90aIpfZ45BqIoRWISe95p6yVGwyE+y",
+	"WIFdiYHbMaZXcZjf1YHqF54YmZJe6ojyKF+I2hG9B3FnikPBR23793TG96bKByXU+HHjpIAjZ4eCqW55",
+	"CoGbZ5HrV3AZ6X1zZqiK9WOKumda2qgfCKuQGkFf2oWpIqY/Rn8NOomZynT7WJn92KagOoDF2pkDuZ6n",
+	"SXnkSJeqmodD+Gp5mYR7iaAZipu1Wie32mu5Op+8yoiRGo9huiqVWgZsqBTQdqxtkKb8Z5mf+mPv+mxL",
+	"OapZ96A8SK2pdq2pyKp7OE99ipwT+IqyyYTNeVC36ZXtOq6Maq7ch66+KqnrWkLtmq9IdoyUqab2enh1",
+	"x7EBiYNAuZ7tOY4Be3LnSJFE6KqOSp+ACH7gah62qo5UmKWIqKt+OHdb6Jjxh3ftKonGKG0fW6/Lyox1",
+	"94k+GYqQpLJ3KrBCuIovO0/JeaGjN6gQe7NXmrM3Vq6vWrGNeXsZS6k/1lyqVbQSd7SeKrJnu0Agyq+Q",
+	"B7UTKrV62qrzZKJw+x20arPiirO3qLMnea5jS4JlSyO/9VzpIV0xUl38Yxg5EgMem6wgm7S40lzAtbj3",
+	"47hM2rSeCXkpmhLZ2BLbaFglSqV7K46nWq3FJLl2S7Dp2LWB+7U7S7GM+bNk+5jIZhFysCFcVgdyIGOS",
+	"gQZ0QAdwoAMv8AIlwiU/AxQuAJE4AQcuABMz1gcBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/parameters/roundtrip/stdhttp/gen/server.gen.go
+++ b/internal/test/parameters/roundtrip/stdhttp/gen/server.gen.go
@@ -7,7 +7,7 @@ package stdhttpparamsgen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -1423,51 +1423,92 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	return m
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3FpNb+M2E/4rAt/3VMiWne1JPQXbbZuim6R1gC0Q5MBI44hbSeSSdDaB4f9ekJQsiZL1YUv56C2xhjPP",
-	"POQzFIfaooAmjKaQSoH8LeIgGE0F6H9WJGEx/JX9pH4JaCohlepPCU/SYzEmqfpPBBEkWP/+zAD5SEhO",
-	"0ge02+1cFIIIOGGS0BT56NwR2q+Tx3Lo/VcIJFKmxo+O/pEqq6cr89DfIsYpAy6JAXcRlqKRVMIDcLRz",
-	"0YU4DxMDKnt4T2kMOFUPC2f/57BGPvqfV+TvZcG9qwIPh28bwiFE/m0+2FWhizh3FbdVjGvChbzECTQQ",
-	"4yJO46YHVlRt5ZZc3WlOSbqmanBMAsgmJ9WB0OeLG+VdEqncoxsQ0lkBfwSOXPQIXJhpWM4X84UypAxS",
-	"zAjy0Yf5Yr5ELmJYRhq/l823yc/bMsxxslNPHkCnq5LFal7VbKBfQX4sD9CuOE5AAhfIv62sH8xYTAI9",
-	"2PsqqLWK2qanujAyNpCvYSM3p0FHRmUuJd/A7s6trvGzxeJQvL2dZwlhp2N6AaX/EGhnQ1vUaKgKgnGS",
-	"EEkelSE8sZiGgPw1jgVkiQW5mzw15JaoWlOeYGlE8OEMuTVN7NxeERU9BwLCyRGzKKGDOcfPfcPiSlgi",
-	"IRG94u9/MdEa8NRgtPE9HYw9LTQXTC9eaAVQv1Jmh65HbKPguIhTyb2aSWAMCg4bMwgoqpOgnjlCYi5J",
-	"+uB8JzJy0k1yr0tlo5elqBBhl267uoSwxptYHlthIN2YpdZYYD6lm+RaFRbRVWGu84cmReXWecTxBkSe",
-	"57cN8OfSCtOuZXSdFdEiY/UE+bfLxcI9Wyzu3B7FoF5yfzTcVGaCOvlqyZKPAIfA28rrb8bi1PIa5W6y",
-	"5P+eXZeGTFpoW0LPPmW14UVKbx3IubJuBvFihfgAqlcux3VUpjY1kzVFdT6E4N0V6XoimaM8IQvg0YeO",
-	"lKaz31dXl3mRcZ17uklDBwtHRuBw/N0xWJzMx2GBYiFmNxGnm4fomB3F9ricrTLr2Rcio9llbv1iu0yM",
-	"7yHO1q7Wl7ed64r6Q+ur/h/2sHohblJPn7f0cfTtIiGf9RlIZ4jGfPcvc5afjoaSduiQNAZrfcT/Uvzs",
-	"t7ThFJU34glY6rGkJqbokjYJr5uf6rgWdsrbxn9Ievv8q+IbQFyn+k5h7k3Ir6a7bnb66O0UXl5VcAmW",
-	"nDxZeiNhezX6XBt0TCki4eRCM9lNR9heaIMYO36P66BsmMKmJqcktZ8G8XPSBtdB0QCxTcZPbX8jYQ9y",
-	"Rtjd3rPi6pvbMNZO2Nreh+qqcutBzWn72pvWGcNCZMfRPhc014V56/XMgJP2q1y+6IblzwCsuHs7lHLJ",
-	"qqNVGAKw9t6P1ScNjeujNWO1TYqFEhaYxz7uZ8zFShEQthH3Z9WygzzBcABOmJs7rZ09i0cx1hVLwaCG",
-	"U4Bv6M0SdixcNj5chaaEdmyl/EJ50jnV2qhjlnt1k+3bhPHpUkPRwG6yherFQPXrKtucTX/HZ0UcI+A+",
-	"1a6LDzvbaa602yQ8WkCrY2zHab8wfOX+uwX2uDtSy8nAK9ITKpv5jqh6wOjRYFzVhr3dzrVJEU3GWuXL",
-	"ngG0vZ3e9dQMlc4a3W/Xq8aRr968nowj+3jfl6F3076enrn+39atmga+iQb2ZCwdIb4W1b1bma305tmf",
-	"g1X+RjIGAbXvVqdMN3vN+EJkZC7Cve2yR9a1YRP2NpYTNzcUw/pzXYN7w2Pko0hK5nte9q2uBCHnIQBL",
-	"MJtjgnZ3u38DAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FDGk4FU8T8CKRbkWjpw3POU8vbg2CRmdPH3GNHmmjJyiSJPMCUKmTUzAPXWIEPPmTccwMvsgjRt27EgS",
+	"Ec34HPGCoEGEJ+e8oGkTp2rOc4tqFhExTp00Ef/q2CICtufEfxMvbvy4y2zfdAXaxWt4r1qBZnADdRKm",
+	"TWSBdHZG/hl0KGLalq+LyB5YMlChboiWrX07t0PedzuKQBpdzvTqPY2XjWnmzUg2aYyhkEhruYGfT00k",
+	"QcV3T9Ehn2RUSEQHCFMYZodh84lwoX1QySRZDC7AEOJ3zBkIRxo+zRCiCzFkCEcYdKDxnAillXQSci/s",
+	"8aIc1fUxUmHJicAcj08h5JdPR5RBR1sL3SjXbyLsiJ9J9r0nEEFNLjRSGHC4FCCMHb6gxhxRrcUaWp+F",
+	"NlqNpyW0kGpnuvZCWxyVAdeTZO3nYZQwopGhgdb5JGUbGbKHWxm6BVVHGX10gZRWIfElkAwwwJBmGaJJ",
+	"RpppFKX2AqRcSfSCRnV+tFVFPRlVVo1vrJGGeECONCSYRuomQpJLVuZqT0gNqqRham0hkFI0NVXknnZt",
+	"lMZTF2Zop0tvKOWQGWGwYRFSj0lGUKuv/nmgZHBkGGdOa/UnB050iTDYDDJkSN52g5VR2GFHDbuUsR0K",
+	"KpRjzPIqwrNsRBuZomVgu+e2u3obqGRlhIvUuCOZi65gC7HrrnYUE4ZhvUndm4ZT+TKMB7RKkQFCGHLw",
+	"mIezIwcsrQ4EG+wTwt0iBeh2ZeT08Fk4jbTsTTNKDGPGFiP1bsbybmw0xpKhrLJsLNhb7MfH+uR0GCsj",
+	"BbDA01Z7rboH61qzCDdbLS7P5Ar0cxtBv3Hu0JKt2+7S5YGtMb10b3f1yhwTyxTVIf/bssAmf9UZSloP",
+	"/nLMYM8str9lM+zfzq2lLQJomK7JKWpvrob2a3hCLfXfIJcpZOiJkxwZtdYW3Li2jyu83eRmVX5ppiJs",
+	"6hbnDHleOeiHi05SlkFy6eUYtLohJpkeCgTxWpjjrnubno6rGp1vISfbbH7jazqnHeHhFeqvk8Qt5N+S",
+	"hNjo3u95M1V0oPxUeiDcsSwaILhRRxtiYCgz7OeTnU9i0BDKoWktRzNPd9IjG0fRBiShmpFSqFUHNgQp",
+	"eprbnZt6BypUqYZUVzFVpLY3mxcoZH8zitVaZnWsI0mmCPprAxRQVp0C8olH1qFSsNgHONPNEIe/kkP9",
+	"7geCE7YBBHao1qJsmC0R2MYwWSNb+ow4wxj9sDpns91ajPieGFSKBZSCgQOFli65Xaxu8ZpXAx8FQQ+O",
+	"hFI0GEn3eui+N4AASybRkqpKaJMwKOUwa1GhQFjYIRfeSklIyNkfXUTDHALLSh2bWumQta9lpaFZqXPZ",
+	"6rzmuib2cZE2Sx8WWgCFSvYriweEjtsmFreKzW08TLNb0uilGR5OUl/KOmUmuQYzOSzqfyL4pP+kuDAR",
+	"jLKUubxkGVpQBMUhCpU9K9cq4Wa3osESjU1SY988dkuRqc5ke2OZ6hzCOE8qcpiRM2YLgpAyrDHTmcGp",
+	"XSrVZRK2RWyaZXTlGeGVTaVdU2/t5FstI0m6qjUtoOLUZNdaB0xhHiaUxRwlO59mwGiqrZ5te1s+6WDN",
+	"BMpSm3mzGkK3KUmDCu6b4wveLhfny07uyaEClMwokfPOb0LTchjUFJs61TnrvUB7JC1o4AwXm5VukqHl",
+	"gylEtzNT8j1PIDnN3U55B6fP/TR0HMPjSbbUJQAh71jLK5Pz0Ha7DFKvp1bFXviAWpY5dpMkdRIfUaFk",
+	"Tj+iU5QtUKudWgDUqA0vj0FSCUtcApPmydOi//TJebyjKqS41aRuQEgLlDCFJzjhjjZaCAtAQJk6uAGc",
+	"cwBBjLDCozuAwKHwQw9RGnrOhxKTqaRMyxxaQAU03KUOZ/DTQB8buPcBRX5DGWKM8re//rm2rqB87QBb",
+	"MIX46WUoLbjC/VrghOIO86mJVaBq1/jAU1lEgpgKQwUvqCadbm6Dqungd0dllY6IMFQkRMoLXtI/NjRT",
+	"dRPFWo5cMCgV+CiQSpJVXpJnSFwxIQz1va8m8xtFX+kQkltj6S/L96IYxfSGWGSjbQ6VqJZW1HJryygr",
+	"q/lKj6bRnx4N52yAkocHiYC+ZWBDURyoXkmJIIxlNa8GPVXjD7bXI20UyR7lC2P7OhNHe+BvI/37owCv",
+	"cMAttJWBERxjBQtMe71qZBB3eFKF9nLCTaywn5YqqEYWqgwbds+XXYfdqE6Pp73zaV+50+LtFHnGbPSu",
+	"jXEMvfJK9bw8DrKoQOheQceXRkW2slKQyS9l7re//xWIIIUE5UJKWUkHTrAzGW1JTGLYkVXajUAiPDAP",
+	"U7hPFx7UmdP8zDV/+J4aJVqJY3livNHZxXduVJ4jNSM+Q9XPb6bqpwTt41IZesiIpjIbnPAGRZeBwY9u",
+	"ZKRFMGlC1gpJmFY2s53NYEYC8cGi7jIvWfe1MKOazOAys4bb02rGYTfEsB6xGUPayrsxKJYqflh2cK1s",
+	"PHeX12+sVI7/vOPO9Zi9xtbzoeer7WYfGU/RxuG0q13pa0tmyvXd9sNV+uktQ9iZCy03ss6t3HTjcNXs",
+	"7vCE2wzsqaLXd2gBXmxWvG8791vX/45gwC3V58zp+KwcJDbCQ3jsxia7vpzuV8R71OQgWdsNBc420k2p",
+	"TG9P6ZHhJnXIXVpmC6P70yjnMDlNjV0yynqfSAPprW1eX3/3eOcDD/bLD05oICsc2S9Al1DwwO2A7jcN",
+	"ZGAygJ1ecahfmg5NgNHe+07RjoNbWOKWMNfT7fWSqyuehlKzu8m6FnhLM9b17iit+2nrFI9U33X2id7T",
+	"gAe3ExvuPZeeywOt52IT/e5Gz7viWe9sJLsA8IKXtJMHWfioI373fN94UR2Pdchr3dWnrnw6AR92zZOd",
+	"87/2OcGBXtXfXTV4NE+9ZFbfepy/fS2+vlzLAW1wodf9vahaOPmdnXRH72EHwJ/48CltGAIfPvHdkXyq",
+	"U3+e5mDNN2ogB33mJn3pQ33rJnbQV3b4dHb09lH+xGIuRn6uV3uwl32yx35BV3tDV2i4tyrkp3H45XdJ",
+	"Bnj6R3j9F2XYdnwBiIILhlBZ9m0HGHlHJXJdN2aW54APxGoqx2bYR09AE2/UNG/ZZYGlh2+nt3aqh3wb",
+	"CHDoJ3CxZ1Zwll7u92PwJ2S5d4IOpzq+x4JNJ2AvaGkxCIB7R4NXRj4GGGrOl4DkNnl8woDFBISZ127X",
+	"p0UeiIXCJmdYhXoZKIXm93pVyHN9+HNZOGwi+H5FZ4LIR4BlkCP4RwYtaIZEgoYXpyRqyHqSaHWgxmXP",
+	"N4fAJGYXhodolnJjt3JFaHahN2vYZG/hN4gBOIU6d4hxN3vt14hc+Igl9CJzMAe1dVu5lSODcolPdoYW",
+	"d0h0MEPBOIxvgFs++IZcplVagkB2MlgvkS1jxYdLuFgMZHQL6IPppGoPaH2LUogciItXqIjCRne9WIIl",
+	"9ERykAdEUAYNoz2Dh4n+F4P3mI9uqGWPZ0smpRQNk1LL93zltCf0GEXpZJBwwBnVp4es6I1upotxllZu",
+	"sVaBCIWSAZFARWOGaC8UZEG5CIJayIsJN0J415D3CCD80mrC54KZuIy4EgWLUo8vmUvPdINXB4cEGTgT",
+	"EQYCAgJKAZM/A042qINbB0wNeWFzoDOHBWIYhYQbJXqxOEv3Vjf55pE/8SICspMx+Re7xU0mdSI8YZQx",
+	"xpNK2XijyElOmZMOmT4vclM+U5WfJ2/6VIG1tpUA9TSzuB1oWQZimZS26EbsmIjbt4jwuJLw1ZJyaQSr",
+	"VIbJWJOGF4M4CUWSeS6g6HHhxlumQ2ptiTUJxUsL6RNP+XU5Y5edh5eqBHokhnb1ppWzYXqAKYjbITHr",
+	"Q1DtI1JuKYdwWT6paXlS+W6uKQKuGJt8SXp+6ZukGZg+oZtlWVKBI5oICSUKaWpNNJzpVAa0w3LaJ3fV",
+	"Y1Vs5VeguSdzhThMqQOkKJxyeWHfWYQXiZIwJyflGZShCU8gkCyN5mnZCWYM+Z6q6TBTaZUUuIR9GVS9",
+	"CS5U55/AiVTbKaCWR6ASCJtKaGLMqaB0hEv9iRXguFruCUWpZkPY5VEfKjzWWDxd9SVgNSZiVaDtuJh/",
+	"qJFxxVbcY5aBAz52cp3qGaEi+nUEsZvn6RO+5VzzcwbChT8xZFwZ4qP1eGEExJrYEUsnahQiuY6TYoWK",
+	"KZ67yGsjaHcsmXtVUSeMp186smTISHzKeJmbSAd1V6YNJpA5+J90aIpfZ45BqIoRWISe95p6yVGwyE+y",
+	"WIFdiYHbMaZXcZjf1YHqF54YmZJe6ojyKF+I2hG9B3FnikPBR23793TG96bKByXU+HHjpIAjZ4eCqW55",
+	"CoGbZ5HrV3AZ6X1zZqiK9WOKumda2qgfCKuQGkFf2oWpIqY/Rn8NOomZynT7WJn92KagOoDF2pkDuZ6n",
+	"SXnkSJeqmodD+Gp5mYR7iaAZipu1Wie32mu5Op+8yoiRGo9huiqVWgZsqBTQdqxtkKb8Z5mf+mPv+mxL",
+	"OapZ96A8SK2pdq2pyKp7OE99ipwT+IqyyYTNeVC36ZXtOq6Maq7ch66+KqnrWkLtmq9IdoyUqab2enh1",
+	"x7EBiYNAuZ7tOY4Be3LnSJFE6KqOSp+ACH7gah62qo5UmKWIqKt+OHdb6Jjxh3ftKonGKG0fW6/Lyox1",
+	"94k+GYqQpLJ3KrBCuIovO0/JeaGjN6gQe7NXmrM3Vq6vWrGNeXsZS6k/1lyqVbQSd7SeKrJnu0Agyq+Q",
+	"B7UTKrV62qrzZKJw+x20arPiirO3qLMnea5jS4JlSyO/9VzpIV0xUl38Yxg5EgMem6wgm7S40lzAtbj3",
+	"47hM2rSeCXkpmhLZ2BLbaFglSqV7K46nWq3FJLl2S7Dp2LWB+7U7S7GM+bNk+5jIZhFysCFcVgdyIGOS",
+	"gQZ0QAdwoAMv8AIlwiU/AxQuAJE4AQcuABMz1gcBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/paths/path_edge_cases/path_edge_cases.gen.go
+++ b/internal/test/paths/path_edge_cases/path_edge_cases.gen.go
@@ -5,7 +5,7 @@ package pathedgecases
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -743,40 +743,47 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"tFXLbhs7DP0VgfcuVY+b7GbXAkURoCiMpO0myUKV6DGDGUmVaCOGMf9eUOP3IynQdDdDUjyHjyOtwIYu",
-	"Bo+eM9QrSJhj8BnLzx11scXbtUksNnhGz/LJ+MxVbA15+ct2hp0p9mVEqCFzIt9A3/caHGabKDIFDzV8",
-	"ULnkVRssFX4+oWWQ0CFPQf+UUkjyEVOImJgGUja4QuUwaQlWxadhGlJnGGogz9dXoDecyDM2mKDX0GHO",
-	"prmYaOPWJ+VoSPhrTgkd1PewBtyEP/YaJsinpL3pzmB9m6ESjwpTxTNUEXn0KmRJ9biN2vSuAH813YB3",
-	"ip4vw+c9/CwEiLHLZ2a5BTUpmeVZZvkMNYkjPw2nDO4iWjKtsiZjVuRVNDxTM+NdS76plQ1t8FtH1ur7",
-	"7ReF2ZpIvhHWCTOmBboHb2cmGcuYdnmiSaZDMWllvFPSEiPI71pcYLvzK4dT8iSu/ODDAlMiJwiSZh0c",
-	"PObRg5fxELdS3uQAQ6FrcCgENCww5aHE96PxaCytCxG9iQQ1XBeThlKTNKWSxleriHzjejE0ww5tCd84",
-	"qOEzsuyWnNvUBfX9CkSAJRfo9Z5ByQT70+E0R/2CSh/1ofSvxuMjvZsYW7KFTvWUw5Hq/084hRr+q3bX",
-	"SbXWciWsz9wDC9OSk50bhD/vOpOWQ51iVQ0t0Cty6JmmhGlU4kqv6nLWcNFUDJlPV+vHOqIsNeijXm68",
-	"k8EpfcLMH4NbvmXVgxz7Q53IJPq/7PZWoK+2/USyl8eQofimZt7ym3VhuMTPwM49Pke0jE7hOmZ/CQ7H",
-	"VwY/vBqTRB0xLbBaFR28qJe7wyN/ph2JeFE7l56X3TWZeVmuiIEyXFLXucZt46qj17f08F/S33sdT/j3",
-	"ff87AAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqekMcimjBSJFC1iHIiQjkI6I03iofMCDpswadyMnDMG",
+	"TZk2YVLmgVPGoYg5dOTEPCOij1EWIshIHCMUDp00CH0GATFno8syICJORGgRxBsxasqMQXn0Z82bYRo+",
+	"FFFEjpw3ckbCectTztOLawkqHamUZtOnUXWwdQsXhN6eSM3AxYlScEw6M2SIQEpnZ0/HC8ucKRO3D9I2",
+	"EueE2cx36V+oMgW3fSsHBOg5oklTtuwTqFA3RMtGjFMnTUQyDreQ3Ps59OieXTyLgFKmscC5b+reVSvQ",
+	"TRjQpf2mcYraJxWbIKyD9moGBB3wPOm4mCyiMs/aQYcWVb679+/gIsQjn/1e8NewYxWFFHN0OHEdXs/R",
+	"xdl0I+lHXVKmbQdYaiJ8h5WD5JmHXnNzrIdUGia18aB7l/0UH24CtkebYGG4FUYe8yFVn29lAKeDcA6K",
+	"0AV/Jf4nFlllxaRYdkxJ2J1gU/A0RhphsGFYWhKBEBMIcIRxHghohOEGGWwMpYNhb7DBlZRuUGklGnOw",
+	"AEIVUjABwlJhwDFUhlpxZkeNXLhRU4thjMXZHGSaeWWVchxokhxpgqAlGV7VZSVqLXR0p5OEGsoZCEqZ",
+	"EROIqM2R5xt3upUGGXNWeV6kZUzqVUId5sneU3R05BMUZ5pZKGiHvknGZk9a1BBSoVYVmAgxuACDsSlG",
+	"p1Ccafg0g7HIImUqmiO1xOELe6SXBBl9jLSZcyIoW+iE2/p0RHMEslcprn8GJ1BMPk3Lnn7xNleujGXw",
+	"RqONQdVRBlI02YSTTv2ZeFtufewoglYhISiCDDDAMBJBmS00UpwupTHGowi9oMYcgQkUMFojkRCRGT6N",
+	"8AJBBiF00hwvjIwTzOkapVxfRXI3rB1NjkplczH+VEcbOMkBo2Dn0vGz0mekcWeZo56UhqacrVeWtQzp",
+	"wHOXZFh52XNvAEXkacNa0XPXJi39a7iOkmujCGZz7TWBa9cnER1CvEHG0QJRbJLFa2Hc5cYTegxyaiKf",
+	"NfBaJpeBsmAqs0zRyzErntYLBBr42nz05WtfjQ71W0bnW1XkMMQS51XSSRfDkTHhqBkeslkC57QWiDc9",
+	"2PjjIkRe0OQLwSzz5TXz6FOLhcJoM1I4k03h1j6n19DNjodRBxvg+s164K4PzrEbsiNOO8mMn5zyyr+7",
+	"HHzltcO8GlycMx+hzhTWkRAeSprEKGesBT3H0EU7GtzO5jW1BS1mVukIFITSBk7dCVvr6tZavjUScX2v",
+	"XEhrjkY4UoYFbsSBiBHBuprTrhu9i0LyQgq9BLMu9szoPjoQHcAsNxLFyIExPnlMZF61IoPJRzlAyYOs",
+	"BFMVDhZFYQzjyukiVjLzQQ59LUvI+pJoOpht8CofKZ1IlidCPrELUe4SAbxYeKZ5HSheXnSh5/YVOjn4",
+	"a4a1q+FirJTDhezQeJgxyWY6A7DKDPEnCexJwmwWEA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/external/path_item_refs/bionicle/bionicle.gen.go
+++ b/internal/test/references/external/path_item_refs/bionicle/bionicle.gen.go
@@ -5,7 +5,7 @@ package bionicle
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -339,34 +339,36 @@ func (sh *strictHandler) GetBionicleName(w http.ResponseWriter, r *http.Request,
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"lJExTzMxDIb/SuXvG6PLFZhu7IJYYGGrOqSpr5eqlwTHRUKn/HfkXI9eKQxksRw7efz6HcCGPgaPnhM0",
-	"A0RDpkdGKtnWBe/sEZ9Nj5LvMFlykV3w0IDcLkK74A4XtjNkLCOBAifFaLgDBb68HIMCwreTI9xBw3RC",
-	"Bcl22Bv5mT+i9CUm5/eQc56KZY7VeY4yIYWIxA5LxZ8n+/5+zlqPXRs1dYXtAS2PFOfbcCvtFRODAnYs",
-	"0Cl9R0pjfVnVVQ1ZQYjoTXTQwH1VV0tQRXgZTU/b04Pws9ztkSWIAiOopx008Ii8mi9aXbmwHuA/YQsN",
-	"/NMXr/SlRV+5lDciPcXg07ihu7qWYINn9IVuYjw6W/j6kETPMHPiJ9jZCv3lQy67e/jj18HjS/urolvI",
-	"Jk/nMwAA//8=",
+	"APeIGPOmDZw3bsq4oTNHhA6BcMLICdOmDJ0ycho+FCEmDcI0Y9iUcUKxjEOBZMrMGSMnDRw6Ht04FEGy",
+	"Iog3ZkDQQVMGxBg0EsOMuShHBAsRaWTqEBFxp1ERbkrOjFrxqZwyceqkuUrGIR05dcocXcmzTZiTIujk",
+	"gWNy6ZyvSc+I6EN37M8yZjUKFBITpEi0cOS8YSsHpkq0VNsKVMt25tuWbuTWFXE169YyXXVsgSq1y1HG",
+	"bUW8EaOmzNC5k5OaeYM25cqWL2POpKKSzlOYdP4upf32qR2Mc2QvjeECRvG5RwcrDAMnzcwZxV3EeNoU",
+	"jV4RLzp+DFnmxZ7EfdCesYhW+USYCJNkFnHEIt/tImuaPBpxYkWiGrcIJHHVzMwRLxBkEEIKMfRCfSXh",
+	"l11f3Mk3l2eUqXSQG3MctpEMMMCAFkELFYgWc3CwAVIY6LnxghpzIIQWWXidtRF/Zfi3FIACTljgHC+w",
+	"mNcL77nhl0l0TUZDhhsidNFCH8IR4oglnpiiUgLp6KJABD4ho34iwCijCDQWZONCOEqJY48/PhjkmXQF",
+	"BA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/external/path_item_refs/common/common.gen.go
+++ b/internal/test/references/external/path_item_refs/common/common.gen.go
@@ -5,7 +5,7 @@ package common
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -190,31 +190,32 @@ type strictHandler struct {
 	options     StrictHTTPServerOptions
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"RMw/TwMxDAXw7/Lm6HQVW3YGFha6IYaQmNboahvHRUJVvjtKT4jJf95P74aqF1MhiY58Q69nupT7+uh+",
-	"9FJZTk/tWeOFJObbXI08mO6oaqM548cIGT2c5YQxEpy+ruzUkF939Zb+lL5/Ug2MyVg+dBY06tXZglWQ",
-	"caQeSAiOjf7Pb/K+54dlXVaMBDWSYoyMh2VdDkiwEueOLNdtG78BAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIorIkUNFTpgxadycSULGyRs6UxTScSgQjpw3cMrIoZOm",
+	"zEWBBMmUYSmCTp6YDkXMoSMn5BkRffqwECGnTJw6aZqScbhl4BudIros9QlUh4g3YtSUGbMyqVIRIc28",
+	"4akzYlE4NBEGpWJz5dY0dNjs9Ep3qIildmTOSSPXawwXMBAjXQpTYRg4aYLOQOwixl8RcMLQQXPRTR02",
+	"bPoEBA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/external/path_item_refs/fooservice/fooservice.gen.go
+++ b/internal/test/references/external/path_item_refs/fooservice/fooservice.gen.go
@@ -5,7 +5,7 @@ package fooservice
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -299,34 +299,36 @@ func (sh *strictHandler) GetBionicleName(w http.ResponseWriter, r *http.Request,
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"lFFBT/MwDP0rk7/vGDUdcOpxF8QFLtymCWWZu2Zak+B4SKjKf0dOV21jA4lenMSvfs/vDWBDH4NHzwma",
-	"AaIh0yMjldvaBe/sHt+mw7PpURobTJZcZBc8NCCvs9DOuMOZ7QwZy0igwEkzGu5AgS9/jkUB4fvBEW6g",
-	"YTqggmQ77I1M5s8ouMTk/BZyzlPzUtDieCiaKUQkdlgg/ijx+6Bz0uWIWqkJFdY7tDzSOd+G6x1fMTEo",
-	"YMdCOl0/kNLYn1d1VUNWECJ6Ex00cF/V1RxUcaBI05N8PQh/lrctshTZwAjV0wYaeERenDuuLnJZDvCf",
-	"sIUG/ulTevoE0bdzyyvxIMXg02jVXV1LscEz+iLDxLh3tgjRuySLDWfZ3GI9hqOvk8nFzYc/cgSPL+2P",
-	"O/7CtsrT9xUAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcMLICdOmDJ0ycho+FCEmDcI0Y9iU+dLxY8gyTiiWcSiQTJk5Y+SkgUPH",
+	"oxuHIlJWBPHGDAg6aMqAGINGYpgxF+WIYCEizU0dIiICXSrCjUqcVitSlVMmTp00XMk4pCOnThmmMIO2",
+	"CcNSBJ08cFZCnUPW6RkRffKiJVpmrUaBJd2AFPlFiM3BciHKeRNXTs2XbbMmdgtXrgi6Mt3c1SuCq1ew",
+	"ZcTq2FL1ahemb+PifCNGTRmkeDk7NfOmrUuYMmnaxEnlJR2qNemI5O2bqh2Mc3ZDjeECRnO8TBkrDAMn",
+	"Dc4ZzV3EoCoVzV8RLwIjfrFHcp+2Zyy2lT6xJsIkokUcsWjYpEidK5lGnFgxqcYtApHAlRk4jfACQQYh",
+	"pBBDL+ynkn/hHXYSSRLed1Ufp3X20kFuzAHZRjLAAENbBC20YFvUwcEGSGG458YLasyBUFtp9cXWRgKW",
+	"QSBUBiLI4YJzvFCjXxHaN1J9gp0UG2c0iEgiQhcthCIcKrLoIowyPiXQkDcKpOATOwIoQo47itBjQT8u",
+	"FCSXQYo3IZKI4dVFXnTWGRA=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/external/response_refs/pkg1/pkg1.gen.go
+++ b/internal/test/references/external/response_refs/pkg1/pkg1.gen.go
@@ -5,7 +5,7 @@ package pkg1
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -385,33 +385,34 @@ func (sh *strictHandler) TestGet(ctx echo.Context) error {
 	return nil
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"fJAxT8MwEIX/ivVgjJK0bN6YUAeWUokBIWScl8a0sS37WoSq/HfktBSxMJ3Pd+/uvneCDWMMnl4y9AmJ",
-	"OQafOSdxt12+rS8/z06GNXsmestS7ZhtclFc8NC4Vz9SFd4/aEV9Ds4OymWViiqxUxJUn8KojA8yMKlo",
-	"7M5siWmaKjjfhzJ27yx9njd4MxIaj6sNpgriZF/SDbOoJ6YjEyocmfL5gkXd1m1pDJHeRAeNu7qtF6gQ",
-	"jQwzUSPMUh5bziFEJlMIVt1l8gMF1V8blm1bwm1iD42b5tex5trX/ONVocuHcTTpC7psVuWKq19n/DwD",
-	"ZeiXEw5pD41BJOqmudAUSd2RcTSxNg7T6/QdAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAuGsOSPjixSJFC1eSUMHzUczZSK6GVMGowgyEsfISQOH",
+	"ThqEDkUEARFxIkKLIN6IUVNmDB0Qd9CkGYMGRJo5PMuglBORDAg6b0CYkVMQRBg3b0qmBAEnzJg1Yc60",
+	"7MOWhYg0bsy8cclmqUKLLt2EadNSh4gmSaiI6OPWJh02fUVQkXh0Sko7KUW4hSxnzk03OWO4gLF5sNs3",
+	"cBSGgZMm54zNLmJIFlG2ZMOHIl7QYexSLR2XoFOGsYkwCZmci+fQOVLmttueIS/ClgEDhksSEc3kHPGC",
+	"oEGEChm+QP5T4guNHD2C7D6y5MmUClkOJixiTp02bcLIyZPT9lXGUX1WXNu2/eOUr20hUB1ysJETGnTQ",
+	"AYcOL7yQm16kzSacCzCVAUd8cLgQRml9dNFHQA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/external/response_refs/pkg2/pkg2.gen.go
+++ b/internal/test/references/external/response_refs/pkg2/pkg2.gen.go
@@ -5,7 +5,7 @@ package pkg2
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -211,32 +211,32 @@ type strictHandler struct {
 	middlewares []StrictMiddlewareFunc
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"NI4xT8MwFIT/inVz5LZi88bIwFIqMSAG41ywIbEtv9cyRP7vKKGMn9777m5FKEstmVkFbkWj1JKFO5zv",
-	"8Jo0njmxMQduh5ESWqqaSobDo/m3TPn4YlDzE1OIJolpm9U4Gi1mamUxPheNbKb68O0/id77gJSnssXO",
-	"KTDL3pD9Qjg8P13QB2jSecMLRc0L240NA25s8rfgZI/2uD2WyuxrgsODPdoTBlSvUeDydZ4HyK4K3NuK",
-	"a5vhEFWrOxzunlLUjmRdfLU+ob/33wAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAqVIpGjxSho6aDSaKRPRzZgyGEWQkThGTho4dNIgdCgi",
+	"CIiIExFaBPFGjJoyY+iAuIMmzRg0INLMuVlmpJyIZEDQeQPCjJyCIMK4eQOSJAg4YcasCXMGZZ+zLESk",
+	"cWPmTUo2RhVaTOkmTBuUOkQ0SUJFRJ+0MemwwSuCikShU0jaISki7WI5c2S6oRnDBQzLftO+gaMwDJw0",
+	"NGdYdhGjsQiwIBvqcFOHDZu0FuU8Vr1FYB05bGiioUMHjo4XLzZ3/kznsIuVZeC08ewiDOg+XfoEBA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/multipackage/externalref.gen.go
+++ b/internal/test/references/multipackage/externalref.gen.go
@@ -5,7 +5,7 @@ package referencesmultipackage
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -30,38 +30,47 @@ type Container struct {
 	Pet     *externalRef1.Pet     `json:"pet,omitempty"`
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"vFXBbtswDP2VgNvRdTts2MG3truvwLZTURiMzNjabEmj6LZB4X8fJMeOY7doNmS9tIooPj++R0pPoGzj",
-	"rCEjHrIn8KqiBuPy2hpBbYjDD8fWEYumGLLrn6Qkx7B+z7SBDN6d74HOdyjnDtUvLOky945U/jVmXUKX",
-	"DADrIwGupgBXEwD1GsB4rkvAkbx23D9gWRKfodP5sHYkXixTzrTxeUVY+LxBL8S5Z5U3qE3O5G3Linxu",
-	"HZmQfUMCXTdjikWhRVuD9c1ET+GWEpCtI8h2xyPdZ8VbeGGwofB/l++FtSlPoHG3pzALHUshIJxO0GsU",
-	"Ki1vl5/XRfhLj9i4miD7kMDGcoMCGWgjnz/BKK42QiVxUGfgPKbBF1v6/dGxiLkzCTyeDZWwbYX4rLEF",
-	"1QHeprtIOtSYxlg6kk/gsan3moEaAqcV66Zv9UOd1ETBtxmCsewuWbh08Y82FbYsNS2NSsBVVuwPrvum",
-	"EGr8sinn+g85U6ORGSdOPTA6R0U/p9EmQWkjdkFesXZhpAMWyaqPrbRZSUWrKBkkQKZtILsFvEdd47oO",
-	"e45M0TPyti7g7pmCBMvDWt7Gte/Yf/0YNboEmH63msPWba/q1Im7k4xPaOeFc/GCPeXQhLpfuFz+olP/",
-	"y/0RqM0FEBzuWFIta9l+C53Qs74iZOLLVqoX2+YwafZUT/IXL9Ehdmy/QGcdt/fSVCKu56fNxkZltMQJ",
-	"hgTuiX0/NPGl6g2ADD6mF+lFaCCUKhTSdX8CAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIoYgpBMmTUI5DgXCkfMGThk5dNKUuSjwjRg1ZcbQ+RIm",
+	"pAgScsqYcShixAuCBhEqZPgi4sSKc17ACTNmTZgzZYJ8mWNyzJcnL2PSCSKiDwsRLmHK/CLGJk6dPH0C",
+	"PZhwYVKjFC0qZeoUqpCpVa9mlSmk69ewWr+MMZtzp46ePwuyHfpWYtykgMcO9irCJB3CaA+rVSzUbVHH",
+	"SIveeQpVToswcNJMHX2mdAvLc+i8yfml8JwvE8OQuY2UzsmpcqxW9Fh75Zs6wVd+KakQtWooZS73mf53",
+	"78zBGHWTSZMSYRg2UEiaRKnyIh05dcp8pZPHJM/I0r8ubfo0Kt6YesVutTmSOfmVNrkRRhtl2MSee4fF",
+	"JodHZ/gFlnVkYWYYYmt1RhRcoc1XVxl3UYUfVvr1NR1lGtbXYV4gatUXRv2NlxKAGAlIoIHtFZjgeQx2",
+	"RZ0Ic7DmmnOrkXbSa9HFNlsZxZlxW267fdHbb3ME52RHbhQ3x3HJ3cacgKl9MUQYvp0xWx78iXfSiyyJ",
+	"kAYZNpWBx4BwsGFjDF+ZMVtFlx3mER020CDCejXytGcZpTkoo40CuQmnnDwR8cYZDQGKII84utHgjgfa",
+	"+KB+f4qARws9CmkaSXX4Zlobb5BRBhuCvuFCqK2d5AJssuXkAqqqsuHCl2GO2SkebbAa44CajgEmob7u",
+	"COuPXS47JK1HJrlkGbrxZpGpwAlHpZVYjqHclkBCl6dIZv6XprG9ykEmRmdNuFlQbV0ImlzOmgZkvUQy",
+	"VCuStuFGbZNPypHtlMTldCVy3mppEpeq8Yqsug6u2eabBjGqQwww1HknmIIu1GenmXYc5kmGEjvxopqS",
+	"8egZKoEc6I0LWuogHGi8IVsVcrCRJncUpRkyzDl+BaywAh3KE802v4Ezq5i+LEIYcsgRBplCB2vTHVLD",
+	"YRKbOpyXnrIc0VFHmqpGtCAc3blxdHQgxAbm2CB4BAIdE7W9b6cK1dGGQ1s8bUdHbIQhBqPyKbSdzF9d",
+	"yQabXUiqqYI5UsYRpDbx3Eaa7aaVGLyMfXYUvT4OeW/opkFLW79MWhsblFIOV6XB3X67MJBUPOXgz09H",
+	"PfWvVmOENWpbO+R1GSN+lVMcdaSRE9d9Gy1fzTfn3FDjIuAO36+gkt4Cqaa2gOuqrb5K+qxF7ntrqqu6",
+	"IC7vRItg9GGW6Zi49qOLmq+Rp+s0bbVTri5wlNoqmHEQJrvmdKl2DWJRudBUOa4JxE5ywJPIPuY4kRGK",
+	"ZJR5n0BwBzmZNW1S1xNa9uzHvSF9T1hqclW9yKevI50vVy5AIPsCZLLDTE5HlJlDTJDDnTxMATQwEogQ",
+	"qJUTOQShVGiQkOYqFK+37HBB7PnhUVYyF/pARSoessoQoXaSI9JtZnSpDxbzssUiejGJGMGQpsRARJJV",
+	"8DBooAMd4IDDr3jETgbijsVE0Ck7nGQOaUAITxwErtTwZAYugEEiO7UUurFkOgEB",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/multipackage/multipart_responses/pkg1/pkg1.gen.go
+++ b/internal/test/references/multipackage/multipart_responses/pkg1/pkg1.gen.go
@@ -5,7 +5,7 @@ package pkg1
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -417,32 +417,33 @@ func (sh *strictHandler) Test(ctx *gin.Context) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"jJExT8MwEIX/y4MxqkPYPDIgsbMjN7mkBufOsq8DqvrfkW1oVKlIzZI72997p3cnjLJGYWLNsCckylE4",
-	"U23i1zJ8KGUtzSisxLVcj0F9dElNouCUpnKYxwOtrmJJIiX1TeQzC7+4VMrHRDMsHszmaRqWTfXau4Rz",
-	"V5FXkbuQWQTn9nW/M2yz75vv9UCzpzANpdLvSLDImjwvqAoXzdvY002sgJ5ngeVjCB0kErvoYfG863c9",
-	"OkSnh6pi/uJcqP6Kg1Mv/DbB4r1cdtdLGPr+vyAu78y2qRbFTwAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAuGsOSPjCx2JdDAORPhxocg2ddjQSQMnjBw6LyKyCfOR",
+	"jMg5Y9CUaRNGJBw5b+CUeZnm4kMRauYgFOJSJImIZhyKGPGCoEGEChm+wKmT55wXGjl+EdO0DwukSt0Y",
+	"efPGKVSpVK1SzPqV684wX8N2NMNWRJ+/gM2KsOvV58aOZOX4BCqUqFGBZoqyISNDJJ08QqXOoSMnjZsz",
+	"fv+e1fuFb9ujP4MOXflYROQyk2NYxlxGM2fPoAML9szXoZuUbM6qdhMGThqpM1zAUC5iNE00DY+++LhZ",
+	"5JkyIY+qlkMzDcIkNnWIoAKyuYiIExFajC5QBgwYbstEFR+34NyFX9FTXA/2sMfyuvUREA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/multipackage/multipart_responses/pkg2/pkg2.gen.go
+++ b/internal/test/references/multipackage/multipart_responses/pkg2/pkg2.gen.go
@@ -5,7 +5,7 @@ package pkg2
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -242,31 +242,32 @@ type strictHandler struct {
 	options     StrictGinServerOptions
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"hI/BTgQhDIbfpXoki6s3jh58D3a2uBimbdruwUzm3Q1gYkwmWS78wP/loxssvAoTkhukDRRNmAzHwdG8",
-	"7wuTI4243ptXyepRsWXHa7+05YZr7kmUBdXr5L+M6T1rj8+KBRI8xT9dnJjFS1bYw2h/MD9qF2bY5wq/",
-	"5iG7TNH/H5SK7fo6ZvkWhATmWukTBlym7IA4HxKdqVQYEt1bC8CClKVCgrfTy+kMAST7zebz/hMAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAulIpINxIEKNCzu2qcOGTho4YeTQeRGRTRiNZDrOGYOm",
+	"TJswHeHIeQOnjMo0Fx+KUDMHoZCUHUlENONQxIgXBA0iVMjwxcyaN+e8EIO0D4uhRd0YefMm6dKmT6NS",
+	"pKr1qs0wWs2QFdGnrl2vItxm7chVTs6dPX8GFWgGKBsyMjrSydOz6Rw6ctK4OUO37le5ZYXq5OnT5GAR",
+	"hcscjqGYcRnHkCVTvotXslyHbkiy+crZTRg4aZrOcAHDBemvKOmgaagjNhs2fQIC",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/multipackage/packageA/externalref.gen.go
+++ b/internal/test/references/multipackage/packageA/externalref.gen.go
@@ -5,7 +5,7 @@ package packagea
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -43,35 +43,39 @@ type StatusPostPayload struct {
 // bearerAuthContextKey is the context key for BearerAuth security scheme
 type bearerAuthContextKey string
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"nFRNq9swEPwv2x4F4V19e4F3fqGhuYRgFHkdq5UldbUuNUb/vUh2PkxccHrTancmszOKB1Cu9c6i5QDF",
-	"AEE12Mp8/LCkVYPV94CUamnMZw3FcYCvhDUU8GVzx24m4MZL9VNecFsGj6rM2CgG8OQ8EmvM1PiHSZa1",
-	"RlOlknuPUEBg0vYCMYrrjTv/QMUQT1HAZz6/p/k5mZUtLrCICV2eU3O95PF3thCTjj1L7sLOBd7J3jhZ",
-	"/a8RI9HhbcEMQhmcXe3Dstq1rsQnhm/O5EG0XQvFEWTVagsCuhTdSTzburTYRwY/kCjWvxEEaDsd1zId",
-	"3uYWz7cKeea1QB8Upu0Jf3WasEoyJ7rTCqOv/4K5Hl0tvjxyZuozti/KzXnco5dEsk91yuNfoc630hU8",
-	"jD8vFwUEVB1p7vdJwih1i5KQ3jtubt+BBDrna7iRNMx+fEba1g4K2xkjwHm00msoAJJx3ISxE/8GAAD/",
-	"/w==",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIoq4kZNGYhkyVeaUkeNQYBg2bJ6YcbhFIAk5ZVbqEDHi",
+	"BUGDCBUyfBFxYsU5L+CEGbMmzJkyQr7MgVNmzJeQI0X0YSEQjpw3TOXQSVPmosAyeOjICfPFDFc2ZEqK",
+	"oJOHqUMRc8SmcXNG6tS1bcu8fSNGTVM6UrvcfdL3bxC1VrGO3NpVrZswbfRiZOt2ZlyOdKWyEMHX7xg6",
+	"X8SofRnzbc2bBxMuBNqTosWgQ4seTbq06RfCnukIsXt3Cp0wdOrMgfImLpQwedi8CZMW48mUMluKIC2T",
+	"ps2CqXWy9vgTNlGjSJUydeobuHArMTRXvZqVsVcRMC0iVEtZMly5mfvcrb+38OfAdwn13Wzi2YbbX7th",
+	"lFh7XL33WGT05fXWZXPVpV+AsYFH23hfSPEGG5J95UYdbbAkAnNtzCXCZsJF1cVm/FmGn4WbCShbeLWR",
+	"91twc2hEoloK/ajDFid+loYdem0211BbISnCi3hVdh9mNIpgo4YF6mjeHOip9ZxKLK2nmFYNqhXXlqPB",
+	"VN1p2OW0Gk/cvXYlgTl+UR6PPpao32YwxVFHGjA1R+SZPD4Jo4QzdfYXgDVmSCeHUJGkIHuLlYlRGs0J",
+	"FOOUFWoG34eNXUoHRe9RZ9p1OKm2U2vdzYkjhx6C6OmmYcgxVh6etijHgyFGaR+F+d3V55+BmojpiiLo",
+	"yquhvvaXm12biTRGHRyxNQV3oQokRBm1jhREHXSgYSa2b4nBLUwkHSolGnTQAQdvSrphxhsOjYjSZoo9",
+	"BkcabyErVLgX2ctGHwEB",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/multipackage/packageB/externalref.gen.go
+++ b/internal/test/references/multipackage/packageB/externalref.gen.go
@@ -5,7 +5,7 @@ package packageb
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -74,32 +74,34 @@ type User struct {
 	Username string  `json:"username"`
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"hFFNS8NAFPwvo8eF4HWPgueCopfSw5q82JX9cvetUMr+d3lrsLG1eMqEmcmbmRwxRp9ioMAF+ogy7smb",
-	"Djev7zTyvcCUY6LMljoRjCd58iERNApnG97QWlN4jK5TFKqH3sJM3gYo1EIZO3VuUXhiw7U8dPnKNrL9",
-	"JCjYsMDr3pc7cRrnNjP09jxr6RpBt5lmaNwMp8LD0nZYpZAWmT6qzTRJlOUDp/uxz4K2awrPUutiHzv9",
-	"sY5Cjm7hmfy/kfqS7eeqydkc5F2WvPYDfie3E1byywKit2GO0KE6pxATBZMsNKCQDO/LN9O+AgAA//8=",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIp6IUVNmDB0hDgXCkfMGThk5dNKUuSjQTZg2ZUKKoJPH",
+	"pEMRc+jISePmjIg+QFmIkPKGTUyMCuu0cbhFRBgybXiKEFpnzkkRXYTStKkDp06ePvsInUInDJ2qRdwo",
+	"lZl0qY6mYTymsRNTKM+4Keli1VrzqNedPX+OLXt2jpUYMsOwYfPEDFORJE2iVMnSq9mqMknIKeO464gX",
+	"BA0iVMjwRcSJFee8IHt5Ttq1QUVsjlMnzWYyTC0X3juz7803GzvS+dlFrIgqVuXIHFnyZMqVMtPgxrjV",
+	"b07AYYWSNFo5DR2KlTVzvvk59MGEC1WfpmjxBVGjgntzdSpHTpg88auedAlTZvWb14H1k3Gz1XZbbtJN",
+	"JYJ+cvAXU1by+QUcRx4NaBxPZrzhkFqLCdWcS3CkcZOCcJiFxkUcstFHQA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/multipackage/parent_child/api/child/child.gen.go
+++ b/internal/test/references/multipackage/parent_child/api/child/child.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -188,34 +188,35 @@ func (sh *strictHandler) GetPets(ctx *gin.Context) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"bFHBbtswDP0VgdvRiL3tph8YdguG3tKgUGU6VmBLLEkXCAL/e0G5QRqgJ5H24+Pje1eIZaaSMauAv4LE",
-	"EedQSwqMWV/2qLXjQsiasP7LYUZ79UIIHkQ55ROsDWg4ffN9bYDxbUmMPfjDNn1sbqjyesaosBos5aEY",
-	"QY8SOZGmksHD05jExTFNvRPC6NJMhVXcXHqcxA1cZqcjuk1yxUADmnQy/joIDbwjy8b3a9eZ2EKYAyXw",
-	"8GfX7TpogIKO9cCWcDPktJ3/qOc/6sJZHKHel8tFFK0MWvtFkN0YxIUYUcRpec5Ql3Iwnn89ePiLurdN",
-	"ZpBQybL5+7vr7IklK+YqIBBNKdbB9iym4haWVT8ZB/Dwo72n2X5G2X7JsVr8eEpwslR9wzK5mwYDGlSQ",
-	"zTTwhyssPIGHdjNzPa4fAQAA//8=",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIuCEkaOQzhcoZeg4FAhHzhs4ZeTQSVPmokA3YdqUGSmC",
+	"Th6UDkXMoSMnjZszIvqwqBkGKEabOHXo5OkTaB+hIjjGqZOGIxmHW0TAlCmiy1CkM5W+EaOmzBiRT6H6",
+	"NPOGJpmWY3rCWYkwJxU0aeaAkJiGDRkQc1COAZHG4BuVetu8ectGrxmTbUDQmQhCI8eFgAWL+JqGDpuw",
+	"A/H63SzCTso5aeoqjeECRtChJxWGgZMm54zWrUlrnOxSxAuUDGmeCekWrly6bnJKCVlHjhu9wEE8LiiZ",
+	"8pw8OylWD0OnehkQdeakBIHGIogwY8a01EvnDZfksFHK4Z7aTZKrSo+EBBl8KMfACInXmwwwuIYRQQt1",
+	"RNNscLCRxhj0IfSCGnOoBpFEFIVBEwkcmZHTCC8QZFhCC83xQkQTVWSiZR19RFxaQ70V0XH15RQGYHWk",
+	"t54ZdbABwn8HPTdTWk8NJZ4cpslx0RYCNcdGTiGKdlUfXfQREA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/multipackage/parent_child/api/parent/parent.gen.go
+++ b/internal/test/references/multipackage/parent_child/api/parent/parent.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -193,34 +193,35 @@ func (sh *strictHandler) GetPets(ctx *gin.Context) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"bFHBrtMwEPwVa+EYNQFu/gHE7Qlxe/TgOpvaVWIvuxtQFeXf0TqtUCVOu7bGM+OZDWJdqBYsKuA3kJhw",
-	"CW19Q7VBXAlZM7bLEha0qXdC8CDKuVxh70DD9T/3eweMv9bMOIJ/P16fuyeqXm4YFXaD5TJVIxhRImfS",
-	"XAt4+JGyOAqMRZ0QRpeCuKWOOIv7k3JMLjC6vFBlxdFd7k4TupjyPDY8dKBZZxM7WKCD38hysH86DWa9",
-	"EpZAGTx8OQ2nATqgoKl9tyc8crkeYby6+466chFHqG7iujRxuYuirUHbeRXkZjvEiCJO688CTZSD8Xwb",
-	"wcNX1DdTsriEapEj7c/DYCPWoubdbxCI5hzbw/4m5uLZmW0fGSfw8KH/V2r/aLS3OlvSr38ITtZmbFpn",
-	"9xQ3oEEF2dIC/77ByjN46B8x7uf9bwAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIqCUoeNQIBw5b+CUkUMnTZmLAt2EaVOmowg6eUQ6FDGH",
+	"jpw0bs6I6MPiZRidGGHK1EHTJk6dfXiKkFMmTp00TMk43CJCJUsRXXoKbUn0jRg1ZcZwTKoUp5k3Lsmc",
+	"HHMTTkmEM6mgSTMHBJwwTBeCmCNyDAg0FkG0eaOWTd07cyWCwFsGRBqDb0iWIQNCTB4QdCaCkJiGDWW+",
+	"YUVoTUOHDVcRd/Ny7Gln5Jw0cInGcAFjZ8+QCsPASTNzBm3aolGHyYxSxAuRDF2e2Zh2bdu3bmZK2VhH",
+	"jpu6yEGYAdkGs+Y5eWpS9D7ce+M6c0b+DRxmzJiTdem84RL9tkg5w2G7SSKV6JGNGiXXE1N8IZRecTLA",
+	"UBtGBC2kEEcY6QYHG2mMkR9CL6gxR2wQSURRGC6RwJQZM43wAkGQJbTQHC9ENFFFLAa4U1I9qRXRc/rN",
+	"FMZedbgHnxl1sAECgQdd1xJZNNI0UmtyXLSFQNWxMdNxjC20Uxd9BAQ=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/multipackage/petstore/petstore.gen.go
+++ b/internal/test/references/multipackage/petstore/petstore.gen.go
@@ -5,7 +5,7 @@ package petstore
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -283,80 +283,142 @@ type UpdateUserJSONRequestBody = User
 // UpdateUserFormdataRequestBody defines body for UpdateUser for application/x-www-form-urlencoded ContentType.
 type UpdateUserFormdataRequestBody = User
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7Fv/b+M2sv9X+NQH9BVwLCfZvr0aOKDZzbbIXbobNLt3PSRBQUtjiV2JVEnKjhvkfz8MScn6astOnLui",
-	"3R92tRLJGc585ivpBy8QaSY4cK286YMn4dcclH4jQgbmxRVo/CcQXAM3jzTLEhZQzQT3f1GC4zsVxJBS",
-	"fPpfCXNv6n3hr9f17Vfl41qPj6PaCvdpsusCjyMvBBVIluEK3hR5JGL2CwSa6JhqwgFCRbQgMyA0DCHE",
-	"Zx0DUVpI8B5H3icF8kxKutppb0xDqrbxiEsjCb3KwJt61FDpYPqSKU3EnOQKpOPeCMetg2TOwlCCMo+Z",
-	"FBlI7ZQSMG04h3uaZgmSuaKJIGeJFl5JWWnJeISsKE011Me/PeseKMHqez3y1elrcrnSWvCuGb+xrD78",
-	"m1enk+P2yLVA3FZHntM8p6mRk9srjjzL2I+gMsEVdOxdhObtXMiUam/qMa5PT9YUGdcQWRWkoBSNzOgW",
-	"4/bFw858fvFFCHOaJ1ZZb6mGSMhVm00W1uRyPKox/P+vOhm2NKriPBeR2kOaQcGXYTJXWqQg20zSNcAG",
-	"YbsAZBPePcoEZH0paZZB6E21zAHZaUpmgn8GiQdNpS2iOcRRvtpHSIVccOgHGXZJCIWQgK5CZSZEApR7",
-	"XVsZtI0M9EVj4jd/ef36ZNDkX3PKddP8X4+GmIOKWXbuPEE5PKQajjRLoc9x5EYOdd9lhEWu7deRBzxP",
-	"vemNlyU0gNAzDl6KhXkMIWELkBB6d6OK0iojdlWbMJrCcS42NTRWMclNWC5Nd289tqEYiihinZLMYqHF",
-	"J5nUba0+rLnRYk5VJg17axlXn8Yy0MR+I4xXYuFaeXRBWUJnCb7LgIeWIyUSo7m2/6TRcL/xkUbe0D08",
-	"jkwSwhAy0xsri6r87rbhI3NZBhLtccs7KHdXdGpqR5k0oEUeUsqSOmZ+ETH/1rwfByLtws6cSaXft8D2",
-	"NxF3huT9wJzQTho0BdWJZ6rUUsg6Ke/45PTV1z3w5zBwLHr56x4Yo1Qrfqcnuvb4v+7woWMwutrdEeUm",
-	"0zNWB0EumV5dI95daM3Yz5/BeCGGnMdAQ0OlCJHu+9oqMvZ3WLn4YIzzZ5rr2MA1EUuL3hTTU2ZT1VzH",
-	"QrLfTLKKXmLqxVpnaur7xQKnY7WkUQRyzIQvcIJfzEKbUoHIwGX9NJziLG9qnslK5JKYFxjAmYbiaypC",
-	"Nl+ZT+hIzDgaBCLnLjMvRIaETuwruNco+ORcBB0q/Y7xkIhck1RIIHSGj9eWbW/k5eXGpr6/3o3BOZ+L",
-	"In2nga6YF8pSA02/rU+o0/0YM0WYIpQoAwWCVcQ1io1cg1yAJDOqICTCussPGfCzqwtyOp4QlUHA5q5O",
-	"GBPyL5GTgHIyb2/llru9EKrJTWsfd//XevXVmFxYkjpmMiRMgzSEsFjA19aVCwkjsoQvF0DUkukgXlc5",
-	"ISgWITdSaWICLQ3i/7nlBZtcLEkMSUYwGKQmDpt5uL1lDDoGSZj+UpHZiqT0M+MRCWLKI1BrCnPGmWGK",
-	"aQXJnAhZfMP8fHzLP2IhtqSrEVkyHRPMMJBfw0CTKOMkAg6SJiNCeUjgPhMKiBIpFJvmsCRzoDqXYID3",
-	"4ez6dHzLb/k1DsoVzPOEJIx/VtNbfkRuPsZVhUrIhGJayJUVOBpJxHScz9DnFsI/ohkrnwsb+qpcTolc",
-	"Bpbhyv7nuPMqsZ0p+LNEzPyUKg3SVzLwU8q4L8HSU77IgNOMjVc0Tb7yRl7CAnCVkfMlZxkNYiAn40nT",
-	"YpbL5Ziar2MhI99NVf7lxdt376/fHZ2MJ+NYp4mJziBT9WGO4GcBdFmdb4b46LOYNs6zAPeV2ws5qhqK",
-	"N/IWIJW1t+PxZHz8Ggm5DXlT73Q8GaOvzqiOjWtA12WiplC67SrOwpBQAwW0gVpNb1a1doK5NQ7F7HBU",
-	"aWisDtvHOFoul0cYhY5ymQBHMwj/862RtxKohorUGtnfOtUy2Re+sIW3UcfJZPJf3/y5zoMAlEL7LyGA",
-	"KHs1+bqNoAu+oAkLCeNZ7totLnR705uHZuS9qca+USVK3j3ejTyVpynFOmMzLm2ifGPS0juM7nkHsj9l",
-	"oVETJ3DPlEaXi0vNVuQibGHbDv4T3m25Add/NJBP+kF+cU5UjoxAaMe+ao/FsMWFJnOR87DXbP6B69kk",
-	"BO4DsK+fy3q6sd+ynMeRiQ4+JllvVusCIYIOe/ohTzTDpM7VvAua5KBM8jEDgtkHCyG0qUkg0pQSBRmV",
-	"VENIbP6vWmaHiSrGuZI4xi1JU9AglRFAQ2c10mVj2vWlA8EVC0FCaFKIOUu0SXjhPktMhxOhOrK1w685",
-	"yNW6dFAF+TWkip7ktFbG71Xao3KeZB+DOgIG560m+RbDecLKLYtS+1hUFU3Phn/ElTIZFPr7Urmb0P/R",
-	"NV82Yx9X2AnyY/JJmWnHI/z7xPx9alNcMJY53mAVhqktNoFj0AAs3MlsNQzx2i7dgYSevn6p9z/B3Atm",
-	"TaODItkprRvHD6YJ/mi5KxrsdWSdm/c2zWmAaktHZS3kVkunK/4x45MdGw6AWJGsl7Yd+2YiUSW0tcPW",
-	"QuJG3WAS87y6sdJUhHYG11G3K/kRdC656ZEwHiXg5tb19D3oK9BvVkZCG63/4hzLeZcjS7P2y8n795Dm",
-	"qRdK85qYKpuVN3doIk8w/7JsOe8qfVxV31PO/JPp+Dsh0x1g1Dztz81a4eFQ1XIg76ltUg1hpxHV3NHG",
-	"Dt7KpZT7ketIG7elfi9YQ1sUOP9UK+BsyoKqISHVdFtI8fMsETS8SN3Jfx/ocNB3zObEg52WlfALwuss",
-	"DE2fkSbkB9DUCaBLvbQcWRm4RdVDegci0KCPlJZA07qDK7czY5zKrhP4x0PW2tVbIoN96TOh1WJMEdPM",
-	"RqB1gdJ2dxlfANfuQHpLlE1phmBzZUYgQttyd2f+DFRX8L0oCTxR2GsEXdUOLQccrdUPyvbWRjUO1eRd",
-	"iMj6BrtfBt0Fk+36VFUgyrsdnW3lq4QGRYvUDG32j+oiN8PtdZHD9N8+lBccnrED17PoLklLscRBrbok",
-	"Mjw3GhajSiw5dXOna6xum0lxD4T8B/NPq25pHGgKSSz1QkhEyxVx1kIuzpWNaCa/J7f5ZHIakOPJZDIm",
-	"Z3ylY8YjQmdiAeYlEZJwwd1snJok7rRM28MokFLItmewCX+B0wEhDhFvRdJKLOxWe9IqJ5OXLI+GpLz2",
-	"jlIj6W2UQyTLZRBTVWy8mbgWOOgpj/bR9F/J16hS8x/U8Jh8MAeurk1YV2/ZbFXjLs9vtji88OpR7hzM",
-	"6fFLKvcQDuM5HNuL1WObwWkLqWHQRBeVq03hzVx0CNDf8WRlrFlwMA2aGEgiogjQT5p7yG2U2fNDd0Hm",
-	"EMHOXpd+3ljXveYuiPikugFhxRHWL203wF324g8qoefYTX9SVkLRnR/n7oaUA5/57xp7fmBGYf1+ydSG",
-	"A3y7miJJ5e6785ERWwC38ZoUFwT7oKgKShcmvO8PzCdd6D9kFnQ4nfedJFZQuydIBqu1D0WJiBivVEl1",
-	"9V/iV+eINp8xxBavBEOYSe/swt1lc3kpcKdGDNIorkCuSaAbDRKgkmi41z0Ey5uTuzRidsVW+yrjRiC1",
-	"6vZBnmLkWvCGw5+O3t1nTII6OptrG47qS5hDXsbJp49vyTIGTrT4DJyAneV1JhQbLqc/jryfjn7E75cs",
-	"ZR24DWiSYMEoSWwuKSaJWEJYxD3n0LqTmM4i10hlY+AvoOSXyFjnATV7uRSRshBlvLgtslIa0s3GIezN",
-	"kT7rELku43R3ONrZsA2jItckyKUErhvpAlGglEVCH9sPhVA2lkxPSlFsKj/UMxinsFuBU3ER/Unw9lbq",
-	"AORsTxzNBegtRU13sB51A+d7MKh5s3rvLtrvJ0BXRNgTZKR4XDs2JgeU7O8j7u5VSjwTLr4Hbe11tlpH",
-	"xi6EdN5Ne5Jx2rb+EOOs4+qwdvlHL2M6rs25cFT/meyzBRJHsKeMMG1guShwYW8w+zRj/uLUQ425CU3C",
-	"7xYg1w2zXNufI1zZ3v0OvzrY/DuD6s+K2uczZuuI1vIKtKnXd+TA8Y/sF03n7RwVamo1FwolKLesE3vt",
-	"Zyt3j/8OAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrEqVNmDh0hb8ikqehQIJQydDoOREhHYciHIsLAgcMmzZgwdNIgfKFm",
+	"DkKRc8agKdMmjEgSEc04FDHiBUGDCE3OeZFzZ8+lH0P26cMi5cqWL2POxNOGDU6dPH2iBFpGqA6iRgse",
+	"TLhwadOwUEGKmEpVBJmKY+SkgaPVzdCoIN6IUVNmDB0QdNDABJGwDJk5iN+AEFMGRBgyd8lERrwThMU3",
+	"EedWrTKnjJwgcuSEySOS4EKTIlWydAlTphuaNv2ifNtTZJqSbRqODTq06NG1SpmCffqCtGnRIujkgVNm",
+	"aJjUq+dOrXo3p16+tocySWMxsBkQdUrLCTy4sNS6vMMIFxgEc8Q580XAkfOGupyYHKE0xm+soVQGHmEY",
+	"xEZ1Z0ERBhuSBcEGHW+IUJV01A1lkV5unAGdRTAxKNCBCbLEoAhDBGFhdNOduGEaHX5IR0RyGYiggifS",
+	"MMMNIDCRBx0U+nVhixrOCKOHdemxl0gk4jhUDjrCEMOKGLpoZIzbsZjhWYIRZtiKXHmFkhsJnngZGfc1",
+	"lGUQcKQhRUVrlSbSfv2ZBmB+BN0lkhmg9XSSCDDSMYMMVBJ5VqBlnPFcXW1UNEcYiopUZZEcIjnklgJN",
+	"etaLWNalqQhdugdmVyKR2WhxI9xlRhh1TKhdVUOEeAZoBQpEp393+kYGkzea6FAMVfEph59DBWoDDYVu",
+	"CehrisoBnakiitCkr2cR8cYZDV1qZaWvanliqF9WFWapZQ6VVaK0djtEehQ26ixKt9q5UX5npukbcPmR",
+	"ZRZaxyXVlnJOyfdCfWg6Ct2n16nGmrikjlnuWfU6ylFVd6i2kmMOzUhRlmnsamOJC/4Kw8gjB9snTMUu",
+	"dGyyJyLaLHTpmQYtryCfaEYZaJxRx8LeUnpkt5+CGxLDYgo081ljsFvQonU9Icdd79rKH67ztqbWgiVJ",
+	"aqgIYrzxxoJh+FVXxzQ7qUMMMJg8LMqHqoystimX9HJd1NGRhMcj9hry2TngcMMNMqhNbNt0rAw34Yku",
+	"WtVEYcckXdnU3iA428sKSujhlSfuLHxo7EVEiHue/CcZIbYQ06mYc2qpCCDSkZ5I3eW1V19DOQ01CFPQ",
+	"AdPrVSlURxsObaEfG2GMgXFVsvFnx/F2ldHS8hHt2kXvepu5kvLMf6o60FsLPWrRIhwN6tNMVxXVnFPL",
+	"G6BA584qR60i6FtcWkixxRDAcL0Qq9zpjo23tNUT2eT+ZKy39Qxxc6vK0fJWs6GQ4Vpn2AjLfIalqsAB",
+	"DW+gUBXkwIb8/IYn+dHelTxENHKd6iwXzOAbNuiVLCEMOzwbF0oqJhuM6UBjZchS616Hkth9h3YoBIln",
+	"dOc6yMCIM5X5TGh654bfBS8ldghDGognhpBZUCEaiVFVbMIG6aVuhAeDlAfx9RPinMU4avHX/eKzFCpA",
+	"6mBbS1h2SjhDi1HHYzikS1UiMpE0RO+JM7MgBjXIwYZM74Cgak+4RCBDoz1MP3LJkhs9BK/0/adqKCEb",
+	"SoQ1uMoZDpEuU1z4HpaprW3Phd1T5NAY2TBHnjA6b8ySc6KmH0vmykA9mSLk9iYCNbwBDW4AQlim6IKj",
+	"THBTYKyLGfxoESeQEoANPIsSfikkRJ6yKppkoNnQNsC4ffJTodxcVYjXzGdOi5dKKFO2rJlMC8pnDncA",
+	"zf/OeaIYyGAGNKjBMVnXTv1gMCG7rOc987nPa4ogZnLI3e7y48PZhecss8QdEXkHzW12k3CD2mc4Yaae",
+	"BVaUWtHZySwLmkxPpdJLq2zkKF+JUO3ApzB10It0prCc9VklDV9YQxngB6Oh7OQyz1HgI1WCU53yDGFt",
+	"WsJOoVM3JZbhC6xKzJ4gdAcPKsglv4lNHRIDmjTooTYIYaFPgQSHOejgBS9oKoUiMgMXwBNSzXKBTF7w",
+	"hqii4QV27aoeqrNFglAnPxG5jA6aOpTAaiYPb4gpCAhLMZmWYbAgEY4I2pCRNJghD4uNLAiOiFjFFo8g",
+	"dViISzFX162igVB6BGBJ5EAmNlhrDAzFyw8fKgIjwEgziT0MZSNima5tFXd3gGtQD8rBsdIBDmdlSnDP",
+	"EFeZQAdGfLLaQop3khHlUkw3LUmCgPBW5ppGrhWqS0PBc5OzUKFzRoRMGDxTMxAAJnegqcwUTAO9ycjH",
+	"MYFxAxJB8ATquCEIUEgCCNoKA89QZ0DLzIptXAACEGQhsSB4iX6X6Qbc/na3lQmDb+nABTdMYbnNssxh",
+	"toAGsia3u819QxdQUOLjnhjE35VJChicBP0mpjKJ8aNmPqiavphnv3UbYnxZAII7lOEEy/PMHX4DFs1Q",
+	"aL/dScMZJszMwySvrjoJQYcfXIcIh40xb7gDCHbCBjigx4gGwd5+ASzgO+zkxuv5zQkgIwbM9mQNR4qw",
+	"YjpUkc3cGASqgtFvbLNZhjjvPKDxc2fyVAYXdPi8iwluHoi85MQgJg2NonRlJLzZNL8hyX9m82b1q6iE",
+	"qIYNRA6bZg50kNJ4Zmk//nNCxHyz3d1n1PwNwhTa2uEOTwHWMTNDq0DQEjeswawdbgEItnDeyrx3rZWJ",
+	"SKt/Q6sVt7isyY1gYuoghmIWRLnClUMLiApu74pbrfFNQbKX3exXx9R4IBB1oN0waISAQFj7fXZ8rU1W",
+	"s6JV22jgtrfbUO5mjbtNBTdNC9AdkRdUUTAveMpqmSKHMURcire5T2IrXhG6+peoLshDgtiQghVhRSFy",
+	"ctgr2VS8zsjABTBYUUyxe+3k3uHmLlBJyxsNmjO84ORuKM1SmJCEIRTBCVMoQgteDgMXlJhUnjJNcJ5g",
+	"hvnKwQ4uOVHN0YriGL/hBasNzguo9Btefjjc7o0stEGg7P4qRNQEXhH05kDbGMDcBTG4AXTqRKY2DYXA",
+	"LricfmCChvyktUa2eoNFYCdbh5ZXBASzDGPKIOYgP/nPTl1RnXpsm7sNhWDn26NEKGIRjJABfq4piWhR",
+	"IhusgPU2NSmvQOJTxrLMr1/2c8tyBHa+LLWeNn15AR5acPM7tICTLZi5Qhj9P9oPx/ZnpB9y/sXGF/S+",
+	"Lr9X8FZaybrd135faKxfcqp/ffE2nry6QVFgSyL5WWf2MEfEPLRXxMc6+NGGeRT9HOJkUxmMTLqqV11W",
+	"MRvaB3u58RUB8323l0a5hz/McX3IcxXAZxvCx33OJxDyE324N367FxfvYX7e4XjpNwV1MAbGgx/CxgaB",
+	"4R+vBx00AAP61EPnB0QiUGNR1BI75gZwsFXdUhpJI1MFsgW2onbxBVWm9UQV80GQxRD0VwaCRVhd0AeH",
+	"NAe/0xPv83mY0X6U936KlkTzdyFi9ER1IwJRaEE8KIMhiH5DUQVwQDrs92UHQh4x0SFcWGcg4HlVsXmv",
+	"53kQ1YYhEnoiUH8VcREZgXokARusJ4EFiBuy130J+HzgJ31qpHsB44Hdkn2vJ3zEd3PH1yfJx0HLlxE2",
+	"NHveB4kLKH7U14HWF0nYp4iZqFIXGD9mxC8MyIGVuIofyB0zSFts6IYZpl9xaBEmwYXx1xmZJ3p99Ec3",
+	"JAcbo3/8lx/+F3MCcoirJxCYGHyxpxuk+IgYOIvhN31rpIoQOICuF3ywWIrdCH20iIrheIvlp4tpSIMk",
+	"aIKOkoIraBotWBcvKI0CMV40aIMP0jF3SASeUQcSiDH6CAPIgoayo4YNIkRukEH3llgV5oIwyHjxSFtW",
+	"EJBuSGgHYjxqqEMwBYTBM4QMAW1GKFU6IDxJWBJLuE6G9ZJkKIVbVIXXUSAi0IshYhnAiAdymGdjCIbY",
+	"IoZyEYV1cXh08AIURgZCkAcKVUQioSgC6I+01QStEhMmMkQLBQI3SHpepl+UsVjK0zH4VWloEGEF0ROe",
+	"UQZwcB0hohmqs0562Bd8WFu3FRVz0JRPSVFtqRqNslrCIYTNk5GPt5eQ0ZV9lhiL0RhOJhlh6Rp0BzX4",
+	"hW/LNCHDxWoQoifLSBHYlH4TYRo8Iz47tE6xqCqs4ioQE0VTpGFWJC1NBDwrCUVSREWt6V9ZREKs8zVe",
+	"xE7cMhWHdB/PKBLRCICIaI2uiI0HuBvoCChkZIoaWIup6I6RhDlyxBq+d5wUeI7cyJwgpIDPyY6UmD+9",
+	"R50wNFqD2ZA0SIX0iILDNpfhkZD8eJ6z9XgAiYNaWURc+SAU0YMjSSAlCUknWYR2hYSOJZOi94SRNZNT",
+	"aJNXeBa2VWGQgZeTgVmjSSVhGJtjaJRVgZRKeVtNOUn5IZUYiZ5VeZV7sSCIIUZfORmVQSdYlxlF9htn",
+	"eRRqWRp9+ZZDVClzwGDOkaJnACw+Gjg+OgMTuR4lYRFH4gKax4J06TF2WWF4+aFh6E5+CRKmEZj9uIuP",
+	"B6KbUZmrNaErgpmimDHMWAadORSfeYVC9Uq6M5R9tZ0fFBxaoywG9UIKox2/CScIIXTC+X/T+BrVSI4T",
+	"OBPZiIBhcS/d6ZzrCI7h+YDTiUjVeYnYuX3gE4txmi/eKIkNSH6PaqfZkVpU+XjqeYJzYI/ueRPwOaLz",
+	"mX71KZBtmp9ssJ8i+YP+uZIm6VQpiQYEqoSMFYhOSAYyGYUL2gZWiJMP+hhpxxAT6qPr1KaBCaAzeZR1",
+	"8wJ7UDd30weMhzXRcqpuUJdE4DxWCog3+pdX+p89dRY/BTUrIj5ElVNL9aaHihIi1JtUkaWEmX6A4aqS",
+	"cRfauiLnOnhStaYnYq27goz2p4w4BK+9sUmi400GBE7MwjR5un97alP7qKoiOBStqhlBhpj8SauPY6sA",
+	"iqsDGpst+Vi9GpNQSJOsw6A4+a3aql7vZ6FDiaFFWRciypCrOhRv4jqsJbN01yEoGpSgwqSd56RHABJR",
+	"0ZR4OHhVCpj/GaqsSpBvcB6WJxkR4bPV9K9tGbArNbAg0bT1d394VKYKKxYCwUmUU0AaFbGbw7LAWbHQ",
+	"6KfsQ40CeI0UWKjKuZ0ZuKiT6IC8x4oRSICvaIHL2bff+LecmovymbGbUoKkaqpGi6pVcbE667g16AY3",
+	"KJBJQJBUeJC7kpALaa8k+niAEZGHwSehFbovBbJBaJxFtVQrWYa3ipIly5IFmrK/GqwsS4XEepNDcax1",
+	"iFmdS7PPmqF0o3gCyK11qZMlERVXIKNG0CcrMq5WKgdY2rgOWYNUa7VCpJiHwZiQ8WRhaZC+WLDLMhRd",
+	"q6sCq75hi75ji7Bm64jxmrYNSzjftDUbtR2ku7Nn4UyN8mOWpxjhWwaOMb6OWRnm+5b+6pkUoaZfOxSB",
+	"RL8LW0p0WlIs0L+Ya5gC/L0EPHkHvBnl64clgb7/mqah+UgVerZzui0/45vOKLci8YIxqMHbu7GjtoPv",
+	"sUX9GbKCyXBPdbsicLIG6qsIyoTCWpO/26A5ScJ9tl5BVoxeGF8xammcBGgw4RNCebw3K60gQa0E2wcv",
+	"YJAQchlJ0BORAi/KKxLM66RsWMZkYFu16Zbkir1Rq6VT28GH8WQLnDVnikKEt66PRLBNmIz4N7+xqLYE",
+	"5DZtKzflY8M0SDD11log0AQgcRlZ3MBo+sAp/EpnMskPYsm644ZaTMFoy5svDLejN4imZ4iAereTehtv",
+	"YBgg0QIb4oSwuY31KwKKPBRiACPA+0X0miVxG3T9R7cj8cqxEcuMqI2m7J1+u6mqyCZuoqfGbJ5SqyGQ",
+	"W4/tObli07oxVas/TIQRkau76pK6e8SG1LsuOxRkXFfI+mWYBil8BUs1KzzIe5RO9QIwsjwLkS4okbOQ",
+	"TFs9G1NBJ3k9YWZVe5/pgZbdsRmMsxCDNjFFi49NOhRJazeaaxLpEsPGPLfxmXrFKaiLqLe6XMEpgRmg",
+	"zAZQYEuYZL9rs8iW08iaA0fK4j2gisfavJ6l2s0W/Z7gTJIi265GFTxJ3LJLjJMF/bPEuNH/rBd9Zocr",
+	"bM/PmnkaKgJMAW10RT601GpTqdMNQjzwtl7uJ0+mgWvyF19L+tMIUZdQINZlYDvDJYilV4jEGah4S6jJ",
+	"edKnjLiaaov5I9dvO7jlmJ2baHzIp3xuwHyGitJ+vYHRGdhcLamEa46Gy7eZCtntKNnqShd1Ucx8ihLD",
+	"+acBuMyVnbd7/cyKmrjSfIuCjc1g3bI8LblsLTaVe5GXe8Oay5E5zIM61M5hXTy/GBhcXaSSR7TO+kRW",
+	"nSVZHV9bDTXUatZycK3ZaqUYu73Tux6bqxmgjWPvM2qOvB6dCxlmCasUAQJcUAcjMwNjAAJoMzIMFgRu",
+	"8COdQ4ca9mmV8d4FlmgRSW9uS95TpIKlZtGVIWqmwR92nIfe7K3gWhKvTaVlArUim81n0bmx1hnSzRmL",
+	"acDISr6Vwa9WasLpt76C/ErSLbajR7ZkypmqDdOdxLaYs7+qTLEfPcPITOGZu90DWZCga5Gjq700KNhg",
+	"lroUybpKXKxDAbNWuljvphiuluF2WLxbrNzzV4YiINBATlvZDasC2d2I8d3hNJAAbmmIid7qDQPs3QMg",
+	"UAPEbebrnd9Nx19wZt59tmRsIOAKQeAg8JFs2Rc7utac19ZICxKCzbToa70SLpg4buELneHgC8IdnsD3",
+	"BhJNpsmA7LXic+Lwm+Lyy+KJfL+e9LD667Z46tGhLRCjXbfKnIinrdeNGIuPDZ2bzRyvfZ2tfhvaucux",
+	"Dp6AuxS1niU4PqrcrILcapHxuei7bZ8W/rmzgZC3/eM4LuSoO5Gr24PA/aQc2+T3Rdy3E+VEYLxUrtZX",
+	"PcbqMSdrnNs0eF7ksaIIwQaYFZYPlBDL+mcQ4l05eGbfBeh76KRDsH5lMFIGy8p2TdojndcG+OqHm9my",
+	"3qgCM1K2XthbcdidOCyfuCCLLYrNl/DqyNqAzRwO34q3XoGVqvGRqNkMvxQfD4Klm3797oQljO/rgdOm",
+	"blOmeZV3Dcshb9ItLosb/9eR7fHl/vCDiuuXresKz+vVl/LwuPI7Hbk+HejffOTAexYtv5MtNeWx2VLj",
+	"jlBG4e/RmxjjsXhqLPYD/XhVf6TEJoc/hlBjfpYR5M+9bWXlqeC1XZdn/+/qMQdfjwZhr9E6XMikR4in",
+	"d/OmDfEH78yW2pzpWPIL3+vNEfTkeaeePfMgTfisbvjN3Nh9ffSM6vgfT9hDL/KaD80c//MNH/TAHtvz",
+	"6PTE7s3QUfOoWfbpJ+zs2fq1be1JPRR3DxktUR4LzfZV7PZpAPcwosOWMfdU/URaz9xcX+/nKhBY3sbi",
+	"cS0wAvBOG+HlOuGx3W4IxRhlYtzOv7UODJolfiIINcGxOK+pnMFZvqWd0Zb4EU9PA/7Ur19HNAZgY6QH",
+	"skonzMnlDxAidIiAE2bOnDtv5JARwULEnDFoyrQJI3CPCDp54JQR+JCOnDRuzojo06eLQzll5sB542aO",
+	"SosiZMCAEXNMSzpl3NCJGQYOHDZpxoShk6blCzVzWsaEKJFizIwbO875GHJkSYc+gQolatTNCzxt2DCN",
+	"OLGijotROQ6kClIkSawiyKgcAxJO0aVs64wZo3KOmTpsQLzZKKfrUocSw8yVMycmlhZF8MBJk3JOiyBm",
+	"csqJOReiXbxuOpIhWgZESBBVqAwBcUeiGxB03qzRCaLM5MowHTY1G9OMQoo8B5LO2aJoG44O1U6t+jYu",
+	"ZCmlWzBJ0yaN8Iue66a567XjUDZs5oAoDALNmzpyQIQJ/+ZOGTIgxOSJLRFEnZecd5d9ilbEbzmC6ygk",
+	"OmaQoSGMNFpLBALLOKMMzkqKiwaaOqMLNO8GSsINO9hLIz78IHQjDOReKOighBYCYY46fgoKPrh2q6MN",
+	"iuTIoyMm3jhjvBDVI/CN+kybIw+qJkKQjjB2FGgLEXoUoYu4XujxBTZ0RA87ER7EkjAID3MjCYYGyvGM",
+	"K6vID0HLWHIJJv/mMiOMwLDUDsO8Htqrr4MAE4xLw0KL0U4aw7ARRx3HuxKEMdJLaScQqjzjwfhQ63FF",
+	"v7xTLknHdGDSSSj7cEjK/F7Yo8cRkevDQjbKyMnCz7jzcyAq0EhjvKFga4kN+sQwjYyWTJsvyEZ1hPQ0",
+	"2Hp0AUE+vQSzIyLKSDUnMyFEsCDDkNss0y2yu9DVDEWI1bRSTaMDDaJAcKMM+MaTTb5dnVUVRodC6qig",
+	"cREMtyNSSUxOhJTiqCO3MD+qo4z9nDorLQWZc+sqk1BSSc2XMr2Iwpra3La7OjfsMCgQ8wt3xRa3gtFT",
+	"ESikgdXtMBZtoGjVc+MNOkD4rQ43GIqLxUAHHajZZ01z8lIlNW3yTCgd0jKmZENbdqAjVG1ZiDyc0Hda",
+	"QfW9dkltW1W5o2/N1be+cs9NNzYgdZVZ1bLIcCG1l+7LLwaZFYpNpaJEWhtBeQeiFw17px4oX+TQLMNf",
+	"gAUSmOCH+Ds4QanYao7hk/h9uKWIY5qp4otu2kknLLUKaqjQkFJq5Yt46+8iElIyo6MRXripDTU5n+MF",
+	"0w16oeU/Pecq9LDG8q/2mFIvY/WBWn899p1mr3123CV0aE5u62SRL7/0HKwwL0lyiGKU6VxZBI097FjE",
+	"r1l0MY2Rt4fhZIu1flWEls2FOW6abSYZ5xpvZFpVtyGUj75J3Qto2BqatIpGkDrI6WLvi9WsEBUGW7kB",
+	"V+wCAa/O9T9gOWpYksrPsRySNK8sDX5wIE4ZcOcQalkNQtjKWsre97FxhQ1d8VmX2ebSM4bE63t761vg",
+	"/uaxqTmMcCkJmBwGVrDe+Gc5jlsYXCLXr4FRRQhvIIP+MocTzvXkfKDziujyUjrFBU91rHPdG2DXq+TR",
+	"TnHMO1NcdMfFo+ChBXegYwsA1IYWpCdVbrjJXMIERoOJcXhkPB4a6aC8Nd6ujSR7o5fAIhayBNI/wiOe",
+	"CIxnRuQdUo0GY6O0nCeXBXarCiQszXpgc5tZ5YRRk0LNuIQkm5RoT3IroRybtPWmOHUvet+bHp7+Epjr",
+	"dclPN5tR/joyyhL2Tz8YwdSSCsiZTt0PQnZYIdaaJAffieAFPknDC+wwA5JEDklByxYo3detIlDTRuOy",
+	"ynrEcKg8oEc9UFCVYxxym82MiA1EeMMYJGZOF3bLCCGJz6HaoJB96bEjaKADHeCggxfQ7g5JepAcXGAU",
+	"Wd5Lb6rSXgu915EgUO8gZAMBPQ8JS9MohDH2FAE+ybfPfv4TelsbyEBrNpgEguCgKXHnoeS5IpQiSKED",
+	"YahDISpRikLoom/IqN88gtCOAvSjA3kC9kIznjC8M6c/E4FGnxnOPgQE",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/multipackage/pruned_deps/deps/deps.gen.go
+++ b/internal/test/references/multipackage/pruned_deps/deps/deps.gen.go
@@ -5,7 +5,7 @@ package deps
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -78,42 +78,50 @@ type N410 = Error
 // DefaultError defines model for DefaultError.
 type DefaultError = Error
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"tJXfj+M0EMf/lZHhMWrT6yKhvBUO0CIBpwOeTquVG0+aOZyxz550t6z6vyM7adMfq1vupH1qE894vvOZ",
-	"H3lSteu8Y2SJqnpSAaN3HDE/3JSL9FM7FmRJf7X3lmot5Hj+MTpO7/BRd97iYGlQVTflolDGdZpYVWrV",
-	"S6sK1WGMeoOqUre81ZYM6F5aZBmvU4UKqPOVB4v71bnFvlCxbrHTKdS3ARtVqW/mk/75cBrnP4Xggtrv",
-	"CyX4KHNvs5KnE++jZvXrgwBFwEdPAY0qlOx8eh8lEG/UPt1iMNaBfBZRqb85KXeB/kUzg1s2SR9GkFYL",
-	"+OC2ZNBAHdAk7drGdD87gZxUyuKmXH4d1+XnuK7qGmOEt8iUEzniHA7ux4NXoXgZ+0WIP7uwJmOQrwgG",
-	"/NRjFKg1J2hrhAl3hrcovwreojyBdwbuF8d4yis/vwqmMdKLdN5j7YIBdmAdbzCA3mqyem2zrrfY6N7K",
-	"EPhlFF+WxpWWMRpgMoDDfoDGBdC8G15HIAZpEVbvbjOK8dYU9Acd8SjVB+cxCA37ZajM00XAv1qEng0G",
-	"uyPeQCviIYqWPkJ2KCag35VloRoXOi2qUsSyfDPhJRbcYEjEDnV/LtRwBg8tBsw5DIlSBBdoQ6wlqWiC",
-	"60BHMNgQo4H1LttGDFuqzzSp6wKfNNulghVESn4wWiSQyBtLsYXBcp3CT7o0mzQaaS4CSh+SGHHZoHYc",
-	"+w7DmZrVBk9GyaYplVYzLL5/XqdooyV3izaGkkpt351V7crpIiPeweQKBkWTjUnjOkvc4g7NgFIwdM/Q",
-	"nMFtAz5gRJYCHsjaMVXotAfXwD+4S8u0R/CaQjzN99hiu991l2SePqaipvWSN/3+mL5bf8Ract8eT6sP",
-	"amy2sXemGt5dORbq2ODa2j8aVX34/LBNM7G/Ky6G4rCGrjtlOMlDANFjTQ3Vh9qP6E7bo49Da1D+DjUD",
-	"YnzUdfrgxR5n8GfremuyLdOnHuGBpCUGDcekp0Z6n6Pf/zhQuVxh/w/dccleM0xXEDcudxhJDvmbM2hT",
-	"ebcY4kDhzayclYm488jak6rUclbOlqpQXkubCKb1gyG55Dr0wapKzdX+bv9fAAAA//8=",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAmnAiIFxIEI6Cul0DAMHDps0Y8LQSYPwhZo5CDuWwRPG",
+	"IJsyHQmSwalDYwwWIsgUDJPGjUMRQerQQSMCaBuJc8Kc4SkiiRs7YU6SARFGKZqQKFWyNAo0YhiYRnVU",
+	"vZo1DZkvSZeCTbkyZh+gc8Z8bROmI4mIZo6OeEHQIMKQc17k3Xv2RRE5ct7IEdHnrgiQeOi8MEk0rcDF",
+	"ZfjKpGmTqpI7dECkmQNiJpw0Eck0vZwHDtU5dOQUPUO5MtCdeXXDqZtWRBU3XZdKTqOnDBkXIKySCQuS",
+	"9VKVIOBEtuPWOYgxscFmZb0ahJs3qbFqpQxU44ycH0OOLHmS7liXaEfXNMlToE6e7v02VFFHxcWUU1BJ",
+	"RVUQY4wBFQhEKJSGc7OZlZ9aDDo4xxxfROjGhLJZBppoD4nwVxmBqTVYYRQhppheoTX2WGST+XbZTJpx",
+	"RmCJI/ZV4kz73VRggw96COJsdNR2W2679WYZcOClMdxYRxkhmRhu7eQGdNJRJxEI16UWURx1SJRaSm6c",
+	"l5oYZXDl1XLNhdheDDDAt5B8JZJkEnX3vRTTj6TxB99ODtFAp4B87SjCbE9tqOBRRxxWYRln/SlCpAmx",
+	"J0KPfgEmGGEFtbhQYj0mNqNkvQGFWY5sdNYRp4AGSRWmOKmq5FG46eYGb5U9KVGUU1oqRRkEybHVeSCw",
+	"gdBUcnCFVRqtiiGkZRGa0RUbdJw6WYkE3bnQfHva15Kfnm0KI4kCnZiiCCuGetioLzJmKmSo9vrbr8IR",
+	"d1S116ZWBr3NRjQRQhaBYIZkXLmRR2sAk+cGmF+BEAQUSaRqrrwdCXFWGdp2pN0btsmx0kXcvkFoiVDm",
+	"S6VaVERchxs7ycFGHruBgAYddMABAm4q1cHaf7MBWZpDNcAAA1AHy8GXSGoVRccMMiB5a9N3MqupUImW",
+	"m7KU+rIcMdadgXDHVxFB3Oa/NKrG2nJnFCXWrgZH1gZXrO1kRlHeibGwXDv/y52DQQcqpFpS24Yrk7tq",
+	"2mhUU3W0dbDFBbFzGqWBsLiCqj2s0BknzYEGCFtjCTffaCMcBszfnQ4CmyBEREcdciS0FR1vmP0dwXU8",
+	"NRlQQguK4VSpp4ne6m3etCHEqseAQ+FL6sorgnSEQYZKPgok/XTEZQVFZCGP3FCJSRquVq5N+hoc1ysj",
+	"pTBXZGA/VlaglxE9tNbVznq3dpSRh3dnxQ+S0njbit5sZxE5/K0MXDJDdgQWEhaIDVpsaJ38YPcwvujs",
+	"DQpcg/5AoJ4yZYcocmgI7wTXHxF8rHt5cEJNqHLCfyVJhU9RmwTJBBsKWSZ8VHmDGNRALJHYaEx1qKFs",
+	"dLAFjxAKUa5CkKMa1wVbiU8EOuThGHwIlI7liQ1seEKKtpAuT6kIVIZJCLxK9QKNWaRjfWiiCbnnwgl9",
+	"DyKUupBAHtc1pEiwUg/7z85sM4Y03G0MYKod3wp4wIRtBU3EA4HPvEM71WhpJWbYW8SANEW1zaFM0JkC",
+	"Gt5QBzYIsE0vSwOZ2nSHNCylKFwB3YDIIoLeDU4Ew8LjF4ZgslrR5onkS9wPy0DD2DikiEBDIoGUyDhb",
+	"WigmasThUaLYQycBpSgH68hK6PDKJtSSDSIUQf5CmD4ZuAAG39QUyBRCkjQcZQbfdMF7gAIHlaDhjSLy",
+	"27++x0URwI4NR3kBZbrQh4AA",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/overlays/external_json_ref/external_json_ref.gen.go
+++ b/internal/test/references/overlays/external_json_ref/external_json_ref.gen.go
@@ -5,7 +5,7 @@ package externaljsonref
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -22,32 +22,33 @@ type Container struct {
 	ObjectB *map[string]any       `json:"object_b,omitempty"`
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"hI/RTsMwDEX/xfDYrZN469vEB8AfVF7qbYbWsRJ3Ypry78hZBwiQ9pRY1/fc6wuEOGkUEsvQXSCHI01Y",
-	"v89RDFko+aApKiVjqlLcvVGwHv3/mGgPHTy036B2obSK4R0PtO2zUuhfqmsLpbkBdvcAX3ul/HLhMLBx",
-	"FBxff1SzNFMDdlaCbln3uP97/DlLcCJ/F3+2xHLwaA9n2ccqso2uQgMnSpmjXIePVTxRGvG8QtWRabgS",
-	"5mBzouEm1uOVBJWhg6f1Zr0B72dHb1DKZwAAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIoYgpBMmTUI5DgXCkfMGThk5dNKUuSjwjRg1ZcbQ+RIm",
+	"pAgScsqYcShixAuCBhEqZPgi4sSKc17ACTNmTZgzZYJ8mWNyzJcnL2PSCSKiDwsRLmHK/CLGJk6dPH0C",
+	"PZhwYVKjFC2+CKuVbNc+XsFmHVsWYxgyZNKkRBiGDRSSJlGqvEhHTp0yX+nkMcmTrsyuX5c2fRp1atWr",
+	"e7faHFnyZMqVNt2EaVPGpmTKOkTMaezxzF28eT2aeeNaMJvWsUV8tXNyThqEPIWLwNPiDXE5bMLkaREG",
+	"Dhw2KsnwnO1YZp2cZJo/j54HM1iTquGk4TnDBQz3ypfSQcMSb0A=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/references/overlays/external_json_ref/packageA/externalref.gen.go
+++ b/internal/test/references/overlays/external_json_ref/packageA/externalref.gen.go
@@ -5,7 +5,7 @@ package packagea
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -20,30 +20,30 @@ type ObjectA struct {
 	Name *string `json:"name,omitempty"`
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"JMnBDQIxDETRXuacCnKjAmoI0cAabWwrNge02t5RlrnMl96BbsNNqRmoB6JvHO3K++PNnreVPs05U3iB",
-	"tsH1+XWiInKKvnCuFYg+DVU/+15gTm0uqECBt9ziL+cvAAD//w==",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIp6IUVNmDJ0gDgXCkfMGThk5dNKUuSjQTZg2ZUKKoJPH",
+	"pEMRc+jISePmjIg+QIGyEMHTzBuHbuqwYTO0pMIwcNLcFDEUThg6aC4mXdonIA==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/schemas/enums/enums.gen.go
+++ b/internal/test/schemas/enums/enums.gen.go
@@ -5,7 +5,7 @@ package schemasenums
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -383,35 +383,36 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"VFLRbtUwDP0Vy/AYbu/GWx+R2ITEHzA0RYl7a9TaUexOukz9d5T0bsCTTxwf+djHr5h0LSokbji+oqWZ",
-	"1tjhl1hbINlWHH8gBnxQxdDzHcM7+nSgu38L4Hi0ABjw+UH1udXgz4B+LYQjmleWC+77HpBl0tYuk6XK",
-	"xVkFR/wq2woWhZ1/x5YbIWmmCwmsmzmUqnlLBC9x4QyPCpxJnCemajBphaa+/W5kT+JzdIiVgNbiVzja",
-	"W4Ck4pEFrMREFmC+lpnEAiwUM8sFMl/YLTzJLTF4jby0n00yVUtaG08rJF0WzgRxcqogWte43KSfngQD",
-	"OvvSZz8WPTSBhgFfqNox893pfDrjHlALSSyMI34+nU/3GLBEn7s3w6R9WxfyFrRQ7T2+ZRzxkfzYfSUr",
-	"Kkadcn8+t9BmJemsWMrCqfOGX9Z6v/nfEDutnfix0oQjfhj+Xsrwpr5Zvb/7GWuN18PO/238zuagUzuY",
-	"mxmtat/3PwEAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIoSEkeNQoMI6bRxuESGChQgjb96UzLhxJco3IDRyNPmy",
+	"hcyVMV6uvGkShM6eL0Gs/PLyC04RXUzSyQOnjEMRc+jISePmjIg+WE1SNaMSI5kyEafCoZMG4dMibkCC",
+	"mBPGTRqyesKQRagDBMGvZxSCaFMnKgg4ct6QqTOmDAg7YdikIQPiCMzFCsmaSVNGzhwQXOWA+NjmcOI6",
+	"YLksRCMXxEbDFMfmWSuV6pk5LOwipBOG6lo4YQrDBoGG6UQ3u9mUCUPGNYjiZ97CFi2cuOsXUmsrrgqi",
+	"jpuvlgnKARv7jWaCbBR/NW2GTmUQbrxXVBx3rhsXoleSpSP8acSJFee84NzQpJ3Kc5TlxlMxuACDgVeZ",
+	"9EZTboQBRxpPzWCgCzKshBsdaFwk0AtcdSVQXnR0JMKClcklYBJkPHVEGXT8JMJ2cxwEHFgiygADDCIS",
+	"tFBkIjoIh2JjmIjQC2rMYRZG91EUhohvUaShCCRsZ8ZTI7xAkEEIRaZfkvm9cFMfSjHllA4ibCRHGHlc",
+	"lZUIX4WVxlgCPsVEGn69YUZMG3nGBmgNYeVnHwEB",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/chi/server.gen.go
+++ b/internal/test/servers/strict/chi/server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -2040,52 +2040,83 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7FndbtvGEn6VweZcnJNDmrbjgwC6S4Igp03rBHZy1eRixB1Jm5C7zO5SPxAE9CH6hH2SYn9I/dGOlEpW",
-	"EPTKFjl/nG9mdmZ2znJVVkqStIb15kyTqZQ05H/0kWv6UpOx7hcnk2tRWaEk67HnyG/iu0XCNNUG+wU1",
-	"7I4+V9KS9KxYVYXI0bFmn4zjnzOTj6hE99+/NA1Yjz3KlqZk4a3JaIplVRBbLBbJhgVvXrOEjQg5aW9t",
-	"+PcifMWXWmjirGd1TcmKLjuriPWYsVrIIXNCA9vlTmxCWhqSdtY41mikI2js7M1ZpVVF2orgwzEWNXVr",
-	"jk9U/xPl3osGS7rGskOKjE/XhSRsmiqsRJorTkOSKU2txtTi0DNVqLFkvcC86NDoHgk5UNvovlDSopAG",
-	"uBgMSJO0EOEEJ8OAqatKaUsc+jNw5uQWDOkxaZYwK6xzBbtdfQ7RRYYlbEzaBEUXZ+dn5+7bVUUSK8F6",
-	"7Il/lLAK7ch/RxsyleqKxJ9v31yDMIC1VSVakWNRzKBEbUZYEAchrXIm1rk1Z8xr0j4Uf+KR+2UEL2Ex",
-	"3J8rPjtGCPtMWUmwy/PzB8qURcKugrIuGa1R2UrKezEDrIsOn7+Xn6WaSCCtlY5flpV1YUWF2q5ite7t",
-	"XxuSXVzeyssGSpcpR4tH8vqhNJ3a8ammAq0rYF8F4CZQ7ofDivijovB39JwUg3gCdNap25GaGBipCVgF",
-	"nLCAibAjaBg3CqyQgGCEHBYEjVFJJ5gFxYP4meQ38VveORlHr2fJmpRpOplMUp9AtS5IukOJf5tYUeKQ",
-	"skoO19mdbLSsx/oz60J2+0g9UCInzNLUZlWBYsMxmyofqKT/4+mDJXZIV6nSCFG60kJ2J+51Swv/vjy/",
-	"+g80gkMCK0+HBaDkIOuicI3wkiaKhz9//wNoSjoXhgzYEVqopSHbEqAmUKWwrqkaaFWCHS3FbOX+tXoR",
-	"bPp/NH8rDq+6vgQi13rr3FgdfbEORPOy6Yq3Y6HxQCf7dsYEBJpmO3U5kfZjhepGIBY4cFSu1Wt4EzAK",
-	"SmFcnQwvzUjVBQcsJjgzoUJv93w3kd31fr40Hr3xSzZmix+7EWyhdbl9Gmjf0dR+Fdo9Ss++8D10Vdsf",
-	"Ij+V8XSo0s80myjNUz8vkiVtsrmzc+FkDalD5NuWEnKU0CdwMyYHHFjS8EpBFGk68Al6X6nXgWQpyo98",
-	"7Y/eb3PmnOfHQJbECTj4L9ljwP94XKgab4b1R7qm6q6AjySN6zQNjGsJuzDu8F/QdLNCcZqh9f7Y3FoI",
-	"PURQGywpdYESQjlFyX31SeMyZZbN3dvFfeAMNRkjlATrqtJAaRDG1ASPLp7+72kPEFw8QhuoUNbGglTW",
-	"IdlXteQfpF84YNO1h+LVWACfHH2fcqwNuRPe1TV38qNPobMPcgvy27gV8pnyTHKH89sobqec8X/2zpnD",
-	"x1S73jpy27yqZzNnX+Yj5dsvWsenj/nnJoxcQbh7gnYnyy5T8wEniO/9MKnDw7t9Frl2cds3DiQ7eHEs",
-	"OKmsrK72lHwyp5qKcjEQxNtRJdh2V/F6oWSuya5vElxP5cpTKwz6Mx/+wQO+zZpQKGMVGgPC+sOoEGHp",
-	"y7dHj/dLy+I08W55Kt+H6uMjYfr4VIhenV/sz/LkyHGzthG4Ix9vfnkZaPZdfR9s9bDnCXA4vSdK54mw",
-	"o6+vGuIwv2wNcxJj11hLDppsrSVxGAts7jO2cjMKWMLa1R7EMb1tEJqbs316hOReWZfs3tuzjz/wTcvp",
-	"7iSTB97jPFTW1FLcd//3Xvp2PRxBmyeVUPI7vd3DwpKWaMWY/nuYtfC2FCXpzcDn/QZ6yY4aPn5/9+7H",
-	"jrpFwsKFdSiYtS5cVbO26mVZuOg+MxMcDkmfCZVhJZyX/goAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWEIRMxTh2JdDCKICNxjJw0cOikQehQhJCNUsp4BCmi",
+	"DwsREevMCSOGTZmIExFaFElwocKQD0WEgQOHTZoxYVQifKFmDsukc8agKdMmjEgSEc20HPGCoEGER+e8",
+	"yLq1q9oyeMIY9Fmzj82RJU+mXOmm5ZMlIm5u3fizYdLBJOXEENmxTpqIZBzSkfPxJluuXpPSyQOnTMs5",
+	"k9O4OVNXcBnCcmQwlukYsmTKZSxrxSxyc+eWoumUOfOzrt27l92KhCu3qeekcOS86SxH5cWkdsKw+Vib",
+	"83ERoE+OLi3C9vU3YtSUGRMSuNwyTs6LTL78p3PDAt2o12z9c+jtN/G0eLM0TQuCJPHmRgtwTRZGC3SE",
+	"cQZ8IsARhhxytSRfG579dpN3LYEnHnm+3SSaGW+IRFJWeknVlw4iDIFQgqLNAQIZaZhhxk9HgVCUbguB",
+	"4J2Lc9TB1BvNlUEGCGLkAUJ2T9Fx5E929HZhGnTQheIUoZG3pBxNygECcXNddFOWc/DVUgwuwFBmTTe1",
+	"Jx8cabQ0Q5ln3uQgHWgwSJVVJwp0EGgi5oWSiS0pMcUTToCQhoth1EFHQVE9JR0bRnYlxxxoSCekoQu9",
+	"ceRkdZA3hwuBidAehCYmERmKghJaRFxdhtoYSEK8QUYeRK14lEhLNeWoiXdeJVBwmQkEVhlioUiWWRSl",
+	"tdZsbr3ApXG+3QUURRYxKAMMMNRq1EK4MuUUVLxW5St2zAYrwrDFinBsQckupBawb7EKrYV4kfinmCj+",
+	"haYINGD7VVhjlcUuWu6+MK1QEr2gEUes0XQXSWYkygZSAo1o0r1XiVCFG2u48cYdbmwph3JyRHvTC23U",
+	"MTFKD1Lc4Bt8JjVqowiZ2lITKqvkYHOrFkfXTa+CFuus2uLocsor70zHCyDK0UYLZERlLrD/EhswsgQz",
+	"tGxbYcTrc4X0HlzRcwJdm21SN96aFNI6t8w0kE9HnaBIVCeF7tUDJ1QwvM7KSxe9FpeIrwj63tXv2cIC",
+	"bKzAZ+mttdjVKrxR0OXdBLHELgeO8Ykac+wxyCKTbLIIKOfMcnMtRMRGVEKuB7PLM5d6qgg4J91yTKvr",
+	"RkbPrQLdsNCy0oq2rdyubbrSBpeRe+tYlVt1uus2rizfz/4dtkTUki2C2UWrLRDbpy+tOuun/uq83Yqr",
+	"y3i7WlPvN9gP+7lXxoXfdPjzeEtfMOQJL0z5vpfLWZ/sNT/ObaxjHwvZT0T3m7uULmlS0tPrBnixArZk",
+	"Cmj4mIsyeAcdaYok0gHBHaCEBhCAzzg2Ip6SdoQpEIThSKI5g09A8L80MYdmbrAZimqnM5/EZCagCYIb",
+	"yBCToIyNCtZpiO+ASIehCU8gaSueQHL1LRz2Kk/k4hr+Foc1x72rXF5rlV1uQsVd8eUF+rmDGlvQtKfV",
+	"QQ4+cQOAmGc+LaLPalzM2/TA2LevcScNXeHNC+CwnebZUSBtjEpLiqSbUGEIRUjazhhFcEK3tRFqUqPb",
+	"+RKHR/V1cY9cC+O87qIbPCytKWEQjSYP2Z36QPI+pGmg74xYLZFwb3jbclkZwXVGcWGxbpyE3vqy9sVQ",
+	"9lGMd9mlFdO4xku+MY5zLF8WaXNHYX5yb3ysHtg8FMgyDLKQdaQmIuGmSBQx0jMXciV2YMmdSjbnbU7D",
+	"5NwMKc5zpS967CsmZkRpvQsVaJCrUyU9u1Kd27xSO7GcpOYsmC/AGM5f1cxfPpNHy/5N7nflodcLPPYf",
+	"FbYAMYVxXcwqJj9AocgJb+hoLkGAgmvRIAU0xB7CREhCECzHRCEMwxBB4AaVra4nZYhpRUEA0kmBQByA",
+	"oMSW8PCTMRxKIjqqlJLqMDYlFRVREbFpG6CkOxCYQTltiGpQ+Req2PFFhyJAqYpyiYTTJEaJOJHp2KwF",
+	"AxpQUHAZQykI1mq0UF1VJD1lw0998lG39mag5grsYI/Dqdi00qDrRCh3bsoX6RQWNaus5yMjG8NoabQx",
+	"jxFSC3zZAjEET6SZK+ngfvgR0BApeIZyEWghw4IjaWqrcwjTaF47qyNlUGVDks4dwpAHFy0QSKCy4U9w",
+	"iFbWhpYMqXKCE12F0enisq9JUWa48JRZgkY0j/prXzbf16G4euS5r/mItORay6TcEooq7JaueDkVX3bX",
+	"XHcD70Td50fAqZZ+DrUfRIMpUWJSNHtq8R9GAUgszN11cy054OcUODIgjS5554UMggpU2tMiZ4JJWahJ",
+	"RcBakPDWSIeKaYaFVFurmPBQuj3DiX37BuC6kA3DLW7okFvWG8quJc6FDBUKNN0ltraJHoZvLmvzT1QK",
+	"NJzeFchmI5nQ9a74VI1db0XpiriBxFczTQ7oLzf52OtQubwiHlz9+DVge3YSnwbmX4IvykQGR0yAIf6v",
+	"AT2XwB2XTJakAwqTRHuGlK6hDHm4A5DI0IKdnUc3k3rBHrzTB5HwJrUEHDEUHvTowthIp0QK6oQuFQYz",
+	"QBoER9DUoRO9aLiatWazK+KgyZDqJSBa0XIgw6YhRCFIw9XRvQ6pDrYgEIE2KCpoCNWoW4IhI6NXB42V",
+	"DSunzE67dGGWCLZlm6PoslKeUsz3LaiZq61QPfvFoZ8tg054Qlg5o/bBDCUxe6EKlZCJYazEctGiUhhe",
+	"tbhbuaQ6a6zVvROgFjHbRoZVkr285Ox6y4z15S5it+hJPWLTmNocnbvd2+b8VrzfB0aYvwnObhpVdF/3",
+	"++7HJypnyTGszvG788TgPWIJ9/m4f9boTijUglE3mtNP0ymjTTurRiuHOZuR9Kgr/eGR1quCI47JGYAS",
+	"JoToyMRNi22PgjqCGNygBjfQgQtBMKcSArsMp06Zaz2mpHu/lqpk4IIbcqOpF1JuxuxBupHUoJO2jydR",
+	"FhGrkSj1oKC+cNQukHuPl/vjKZ0nPRTatVyESAYnQuHo7qGVnICOdmETWwTGLruy5yOCZTvbNdCGjbQ1",
+	"q84zWzvhwCPadb2nlIfT1w1XDLfK4ezFre1zLY9XD6A3XrZtf3mKtreifSe++2H2nm87R4/wy53pwRVB",
+	"K2+AKp3wzcQZa2QMa7iwt98tMx8LvCVDNiXvoAV7JMteydiVcphTOeZpt57ckyT+9ozfcPmbEqD0p3tS",
+	"dn+S5V/VB2Ao13H35HzK0nIKBnOW02B4RlIHuGcIBDo4d2FUdYFYtCewY36wFmF8BjLr9zPmdWTWBX+0",
+	"B0gK4k2ERBrMN05OU04icE6ORICdNXzzxmXdI0UiYAdpQBJvgDJwYFcxKAKJhBQ1mAeNlE6Q5XrUB3Vq",
+	"FmBs1mUex3sNuIMu9z8x52B5VoEiyIF+poEV0RlOZQZpIFrchiCuJEFOl2YZs1Ym0XkptFLeEVs89QZK",
+	"MhHjESNpOCRFIlZHUi4tpil3EFRqpyQOkluGskKaMgZOUSNztHgBF4IosjF8eIZ/yFdHgUS30X4pyHDx",
+	"B3rd9AIqIIBISE5KaINOOG4FeD1bpm1dxm0iAYRCaIqomISLxIToVGb28YrxA4YNlYBWuIDX9Dha+IBH",
+	"loCL0XzHOHJbtoUL9lAzQHFYuD/JSGfL2IUT+HR4ZYETNoaA9gLPpBDRRH4C8Wo5NDtVIAVMUARyJCtC",
+	"UoK9SDmhSIsON1/L1AJqdAdsBDctUI7xSBLSBExuZk0WJ14YR146GIscN4vHV3v6yCvM5I/OBEfmKI8F",
+	"SWZXyIAX93sZZ4BSiIAPVYxv5pHIGI3K6DARKHOYNpLgeHMVlnOT9AIjRCeX9Vbo6I0QhiJthRouUm+h",
+	"FlNjUAZp0CTBtVMRQQdvlBBDAoQvlB2dwhCUyFyz85NvRY+hcna+5hCfZ2xFNXoU0hJFtRinxzzRNk1R",
+	"5osHlYM2UWycE5Y3sWwoUlSqsXpruVm5sRu98XonqHDvJ4q0p129JHFQhl/GmJD61CwhCYvZ9pA9qEvJ",
+	"t13jYpAd+Yy+x5gMGYXfeG5+ZViTIhJluRpXll6OZZDU9oqmgRqqkRSzhZaqp5bmopdGwRs5N5c+VXI5",
+	"eViHCVi5CVSm2Yq/6JY2hFNssJslc4Sp6ZaTlHIEpl9xlo0vt40t6YUUCJNhGI4ZOI43iQYBOXfj4oE0",
+	"Nzgbwxc6Uh8AZ5UiyBdaCYoLh4/IN5GFWZkcmZggx1/IlH87KIuRKV9VxCvSAWnyoRJNsgLL15vOqJiZ",
+	"2TXHNEpkNJnzWX/1hBZPUCyft5ySxALPuXIGhp/z0gUi2ZnDuJo6eRig2YwQwRrPlpaoiYOSdBd2SZqt",
+	"AZuVIZvihhu12Zf04pwHWWC954DayJJ44ZLjmTE2h4Ez6VmWMWihOWwC8UxkSQd0AAc68AJrUSV04AJz",
+	"MFxnYJsusBIv0B81AaIBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/echo/server.gen.go
+++ b/internal/test/servers/strict/echo/server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1759,52 +1759,83 @@ func (sh *strictHandler) UnionExample(ctx echo.Context) error {
 	return nil
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7FndbtvGEn6VweZcnJNDmrbjgwC6S4Igp03rBHZy1eRixB1Jm5C7zO5SPxAE9CH6hH2SYn9I/dGOlEpW",
-	"EPTKFjl/nG9mdmZ2znJVVkqStIb15kyTqZQ05H/0kWv6UpOx7hcnk2tRWaEk67HnyG/iu0XCNNUG+wU1",
-	"7I4+V9KS9KxYVYXI0bFmn4zjnzOTj6hE99+/NA1Yjz3KlqZk4a3JaIplVRBbLBbJhgVvXrOEjQg5aW9t",
-	"+PcifMWXWmjirGd1TcmKLjuriPWYsVrIIXNCA9vlTmxCWhqSdtY41mikI2js7M1ZpVVF2orgwzEWNXVr",
-	"jk9U/xPl3osGS7rGskOKjE/XhSRsmiqsRJorTkOSKU2txtTi0DNVqLFkvcC86NDoHgk5UNvovlDSopAG",
-	"uBgMSJO0EOEEJ8OAqatKaUsc+jNw5uQWDOkxaZYwK6xzBbtdfQ7RRYYlbEzaBEUXZ+dn5+7bVUUSK8F6",
-	"7Il/lLAK7ch/RxsyleqKxJ9v31yDMIC1VSVakWNRzKBEbUZYEAchrXIm1rk1Z8xr0j4Uf+KR+2UEL2Ex",
-	"3J8rPjtGCPtMWUmwy/PzB8qURcKugrIuGa1R2UrKezEDrIsOn7+Xn6WaSCCtlY5flpV1YUWF2q5ite7t",
-	"XxuSXVzeyssGSpcpR4tH8vqhNJ3a8ammAq0rYF8F4CZQ7ofDivijovB39JwUg3gCdNap25GaGBipCVgF",
-	"nLCAibAjaBg3CqyQgGCEHBYEjVFJJ5gFxYP4meQ38VveORlHr2fJmpRpOplMUp9AtS5IukOJf5tYUeKQ",
-	"skoO19mdbLSsx/oz60J2+0g9UCInzNLUZlWBYsMxmyofqKT/4+mDJXZIV6nSCFG60kJ2J+51Swv/vjy/",
-	"+g80gkMCK0+HBaDkIOuicI3wkiaKhz9//wNoSjoXhgzYEVqopSHbEqAmUKWwrqkaaFWCHS3FbOX+tXoR",
-	"bPp/NH8rDq+6vgQi13rr3FgdfbEORPOy6Yq3Y6HxQCf7dsYEBJpmO3U5kfZjhepGIBY4cFSu1Wt4EzAK",
-	"SmFcnQwvzUjVBQcsJjgzoUJv93w3kd31fr40Hr3xSzZmix+7EWyhdbl9Gmjf0dR+Fdo9Ss++8D10Vdsf",
-	"Ij+V8XSo0s80myjNUz8vkiVtsrmzc+FkDalD5NuWEnKU0CdwMyYHHFjS8EpBFGk68Al6X6nXgWQpyo98",
-	"7Y/eb3PmnOfHQJbECTj4L9ljwP94XKgab4b1R7qm6q6AjySN6zQNjGsJuzDu8F/QdLNCcZqh9f7Y3FoI",
-	"PURQGywpdYESQjlFyX31SeMyZZbN3dvFfeAMNRkjlATrqtJAaRDG1ASPLp7+72kPEFw8QhuoUNbGglTW",
-	"IdlXteQfpF84YNO1h+LVWACfHH2fcqwNuRPe1TV38qNPobMPcgvy27gV8pnyTHKH89sobqec8X/2zpnD",
-	"x1S73jpy27yqZzNnX+Yj5dsvWsenj/nnJoxcQbh7gnYnyy5T8wEniO/9MKnDw7t9Frl2cds3DiQ7eHEs",
-	"OKmsrK72lHwyp5qKcjEQxNtRJdh2V/F6oWSuya5vElxP5cpTKwz6Mx/+wQO+zZpQKGMVGgPC+sOoEGHp",
-	"y7dHj/dLy+I08W55Kt+H6uMjYfr4VIhenV/sz/LkyHGzthG4Ix9vfnkZaPZdfR9s9bDnCXA4vSdK54mw",
-	"o6+vGuIwv2wNcxJj11hLDppsrSVxGAts7jO2cjMKWMLa1R7EMb1tEJqbs316hOReWZfs3tuzjz/wTcvp",
-	"7iSTB97jPFTW1FLcd//3Xvp2PRxBmyeVUPI7vd3DwpKWaMWY/nuYtfC2FCXpzcDn/QZ6yY4aPn5/9+7H",
-	"jrpFwsKFdSiYtS5cVbO26mVZuOg+MxMcDkmfCZVhJZyX/goAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWEIRMxTh2JdDCKICNxjJw0cOikQehQhJCNUsp4BCmi",
+	"DwsREevMCSOGTZmIExFaFElwocKQD0WEgQOHTZoxYVQifKFmDsukc8agKdMmjEgSEc20HPGCoEGER+e8",
+	"yLq1q9oyeMIY9Fmzj82RJU+mXOmm5ZMlIm5u3fizYdLBJOXEENmxTpqIZBzSkfPxJluuXpPSyQOnTMs5",
+	"k9O4OVNXcBnCcmQwlukYsmTKZSxrxSxyc+eWoumUOfOzrt27l92KhCu3qeekcOS86SxH5cWkdsKw+Vib",
+	"83ERoE+OLi3C9vU3YtSUGRMSuNwyTs6LTL78p3PDAt2o12z9c+jtN/G0eLM0TQuCJPHmRgtwTRZGC3SE",
+	"cQZ8IsARhhxytSRfG579dpN3LYEnHnm+3SSaGW+IRFJWeknVlw4iDIFQgqLNAQIZaZhhxk9HgVCUbguB",
+	"4J2Lc9TB1BvNlUEGCGLkAUJ2T9Fx5E929HZhGnTQheIUoZG3pBxNygECcXNddFOWc/DVUgwuwFBmTTe1",
+	"Jx8cabQ0Q5ln3uQgHWgwSJVVJwp0EGgi5oWSiS0pMcUTToCQhoth1EFHQVE9JR0bRnYlxxxoSCekoQu9",
+	"ceRkdZA3hwuBidAehCYmERmKghJaRFxdhtoYSEK8QUYeRK14lEhLNeWoiXdeJVBwmQkEVhlioUiWWRSl",
+	"tdZsbr3ApXG+3QUURRYxKAMMMNRq1EK4MuUUVLxW5St2zAYrwrDFinBsQckupBawb7EKrYV4kfinmCj+",
+	"haYINGD7VVhjlcUuWu6+MK1QEr2gEUes0XQXSWYkygZSAo1o0r1XiVCFG2u48cYdbmwph3JyRHvTC23U",
+	"MTFKD1Lc4Bt8JjVqowiZ2lITKqvkYHOrFkfXTa+CFuus2uLocsor70zHCyDK0UYLZERlLrD/EhswsgQz",
+	"tGxbYcTrc4X0HlzRcwJdm21SN96aFNI6t8w0kE9HnaBIVCeF7tUDJ1QwvM7KSxe9FpeIrwj63tXv2cIC",
+	"bKzAZ+mttdjVKrxR0OXdBLHELgeO8Ykac+wxyCKTbLIIKOfMcnMtRMRGVEKuB7PLM5d6qgg4J91yTKvr",
+	"RkbPrQLdsNCy0oq2rdyubbrSBpeRe+tYlVt1uus2rizfz/4dtkTUki2C2UWrLRDbpy+tOuun/uq83Yqr",
+	"y3i7WlPvN9gP+7lXxoXfdPjzeEtfMOQJL0z5vpfLWZ/sNT/ObaxjHwvZT0T3m7uULmlS0tPrBnixArZk",
+	"Cmj4mIsyeAcdaYok0gHBHaCEBhCAzzg2Ip6SdoQpEIThSKI5g09A8L80MYdmbrAZimqnM5/EZCagCYIb",
+	"yBCToIyNCtZpiO+ASIehCU8gaSueQHL1LRz2Kk/k4hr+Foc1x72rXF5rlV1uQsVd8eUF+rmDGlvQtKfV",
+	"QQ4+cQOAmGc+LaLPalzM2/TA2LevcScNXeHNC+CwnebZUSBtjEpLiqSbUGEIRUjazhhFcEK3tRFqUqPb",
+	"+RKHR/V1cY9cC+O87qIbPCytKWEQjSYP2Z36QPI+pGmg74xYLZFwb3jbclkZwXVGcWGxbpyE3vqy9sVQ",
+	"9lGMd9mlFdO4xku+MY5zLF8WaXNHYX5yb3ysHtg8FMgyDLKQdaQmIuGmSBQx0jMXciV2YMmdSjbnbU7D",
+	"5NwMKc5zpS967CsmZkRpvQsVaJCrUyU9u1Kd27xSO7GcpOYsmC/AGM5f1cxfPpNHy/5N7nflodcLPPYf",
+	"FbYAMYVxXcwqJj9AocgJb+hoLkGAgmvRIAU0xB7CREhCECzHRCEMwxBB4AaVra4nZYhpRUEA0kmBQByA",
+	"oMSW8PCTMRxKIjqqlJLqMDYlFRVREbFpG6CkOxCYQTltiGpQ+Req2PFFhyJAqYpyiYTTJEaJOJHp2KwF",
+	"AxpQUHAZQykI1mq0UF1VJD1lw0998lG39mag5grsYI/Dqdi00qDrRCh3bsoX6RQWNaus5yMjG8NoabQx",
+	"jxFSC3zZAjEET6SZK+ngfvgR0BApeIZyEWghw4IjaWqrcwjTaF47qyNlUGVDks4dwpAHFy0QSKCy4U9w",
+	"iFbWhpYMqXKCE12F0enisq9JUWa48JRZgkY0j/prXzbf16G4euS5r/mItORay6TcEooq7JaueDkVX3bX",
+	"XHcD70Td50fAqZZ+DrUfRIMpUWJSNHtq8R9GAUgszN11cy054OcUODIgjS5554UMggpU2tMiZ4JJWahJ",
+	"RcBakPDWSIeKaYaFVFurmPBQuj3DiX37BuC6kA3DLW7okFvWG8quJc6FDBUKNN0ltraJHoZvLmvzT1QK",
+	"NJzeFchmI5nQ9a74VI1db0XpiriBxFczTQ7oLzf52OtQubwiHlz9+DVge3YSnwbmX4IvykQGR0yAIf6v",
+	"AT2XwB2XTJakAwqTRHuGlK6hDHm4A5DI0IKdnUc3k3rBHrzTB5HwJrUEHDEUHvTowthIp0QK6oQuFQYz",
+	"QBoER9DUoRO9aLiatWazK+KgyZDqJSBa0XIgw6YhRCFIw9XRvQ6pDrYgEIE2KCpoCNWoW4IhI6NXB42V",
+	"DSunzE67dGGWCLZlm6PoslKeUsz3LaiZq61QPfvFoZ8tg054Qlg5o/bBDCUxe6EKlZCJYazEctGiUhhe",
+	"tbhbuaQ6a6zVvROgFjHbRoZVkr285Ox6y4z15S5it+hJPWLTmNocnbvd2+b8VrzfB0aYvwnObhpVdF/3",
+	"++7HJypnyTGszvG788TgPWIJ9/m4f9boTijUglE3mtNP0ymjTTurRiuHOZuR9Kgr/eGR1quCI47JGYAS",
+	"JoToyMRNi22PgjqCGNygBjfQgQtBMKcSArsMp06Zaz2mpHu/lqpk4IIbcqOpF1JuxuxBupHUoJO2jydR",
+	"FhGrkSj1oKC+cNQukHuPl/vjKZ0nPRTatVyESAYnQuHo7qGVnICOdmETWwTGLruy5yOCZTvbNdCGjbQ1",
+	"q84zWzvhwCPadb2nlIfT1w1XDLfK4ezFre1zLY9XD6A3XrZtf3mKtreifSe++2H2nm87R4/wy53pwRVB",
+	"K2+AKp3wzcQZa2QMa7iwt98tMx8LvCVDNiXvoAV7JMteydiVcphTOeZpt57ckyT+9ozfcPmbEqD0p3tS",
+	"dn+S5V/VB2Ao13H35HzK0nIKBnOW02B4RlIHuGcIBDo4d2FUdYFYtCewY36wFmF8BjLr9zPmdWTWBX+0",
+	"B0gK4k2ERBrMN05OU04icE6ORICdNXzzxmXdI0UiYAdpQBJvgDJwYFcxKAKJhBQ1mAeNlE6Q5XrUB3Vq",
+	"FmBs1mUex3sNuIMu9z8x52B5VoEiyIF+poEV0RlOZQZpIFrchiCuJEFOl2YZs1Ym0XkptFLeEVs89QZK",
+	"MhHjESNpOCRFIlZHUi4tpil3EFRqpyQOkluGskKaMgZOUSNztHgBF4IosjF8eIZ/yFdHgUS30X4pyHDx",
+	"B3rd9AIqIIBISE5KaINOOG4FeD1bpm1dxm0iAYRCaIqomISLxIToVGb28YrxA4YNlYBWuIDX9Dha+IBH",
+	"loCL0XzHOHJbtoUL9lAzQHFYuD/JSGfL2IUT+HR4ZYETNoaA9gLPpBDRRH4C8Wo5NDtVIAVMUARyJCtC",
+	"UoK9SDmhSIsON1/L1AJqdAdsBDctUI7xSBLSBExuZk0WJ14YR146GIscN4vHV3v6yCvM5I/OBEfmKI8F",
+	"SWZXyIAX93sZZ4BSiIAPVYxv5pHIGI3K6DARKHOYNpLgeHMVlnOT9AIjRCeX9Vbo6I0QhiJthRouUm+h",
+	"FlNjUAZp0CTBtVMRQQdvlBBDAoQvlB2dwhCUyFyz85NvRY+hcna+5hCfZ2xFNXoU0hJFtRinxzzRNk1R",
+	"5osHlYM2UWycE5Y3sWwoUlSqsXpruVm5sRu98XonqHDvJ4q0p129JHFQhl/GmJD61CwhCYvZ9pA9qEvJ",
+	"t13jYpAd+Yy+x5gMGYXfeG5+ZViTIhJluRpXll6OZZDU9oqmgRqqkRSzhZaqp5bmopdGwRs5N5c+VXI5",
+	"eViHCVi5CVSm2Yq/6JY2hFNssJslc4Sp6ZaTlHIEpl9xlo0vt40t6YUUCJNhGI4ZOI43iQYBOXfj4oE0",
+	"Nzgbwxc6Uh8AZ5UiyBdaCYoLh4/IN5GFWZkcmZggx1/IlH87KIuRKV9VxCvSAWnyoRJNsgLL15vOqJiZ",
+	"2TXHNEpkNJnzWX/1hBZPUCyft5ySxALPuXIGhp/z0gUi2ZnDuJo6eRig2YwQwRrPlpaoiYOSdBd2SZqt",
+	"AZuVIZvihhu12Zf04pwHWWC954DayJJ44ZLjmTE2h4Ez6VmWMWihOWwC8UxkSQd0AAc68AJrUSV04AJz",
+	"MFxnYJsusBIv0B81AaIBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/echo5/server.gen.go
+++ b/internal/test/servers/strict/echo5/server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1759,52 +1759,83 @@ func (sh *strictHandler) UnionExample(ctx *echo.Context) error {
 	return nil
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7FndbtvGEn6VweZcnJNDmrbjgwC6S4Igp03rBHZy1eRixB1Jm5C7zO5SPxAE9CH6hH2SYn9I/dGOlEpW",
-	"EPTKFjl/nG9mdmZ2znJVVkqStIb15kyTqZQ05H/0kWv6UpOx7hcnk2tRWaEk67HnyG/iu0XCNNUG+wU1",
-	"7I4+V9KS9KxYVYXI0bFmn4zjnzOTj6hE99+/NA1Yjz3KlqZk4a3JaIplVRBbLBbJhgVvXrOEjQg5aW9t",
-	"+PcifMWXWmjirGd1TcmKLjuriPWYsVrIIXNCA9vlTmxCWhqSdtY41mikI2js7M1ZpVVF2orgwzEWNXVr",
-	"jk9U/xPl3osGS7rGskOKjE/XhSRsmiqsRJorTkOSKU2txtTi0DNVqLFkvcC86NDoHgk5UNvovlDSopAG",
-	"uBgMSJO0EOEEJ8OAqatKaUsc+jNw5uQWDOkxaZYwK6xzBbtdfQ7RRYYlbEzaBEUXZ+dn5+7bVUUSK8F6",
-	"7Il/lLAK7ch/RxsyleqKxJ9v31yDMIC1VSVakWNRzKBEbUZYEAchrXIm1rk1Z8xr0j4Uf+KR+2UEL2Ex",
-	"3J8rPjtGCPtMWUmwy/PzB8qURcKugrIuGa1R2UrKezEDrIsOn7+Xn6WaSCCtlY5flpV1YUWF2q5ite7t",
-	"XxuSXVzeyssGSpcpR4tH8vqhNJ3a8ammAq0rYF8F4CZQ7ofDivijovB39JwUg3gCdNap25GaGBipCVgF",
-	"nLCAibAjaBg3CqyQgGCEHBYEjVFJJ5gFxYP4meQ38VveORlHr2fJmpRpOplMUp9AtS5IukOJf5tYUeKQ",
-	"skoO19mdbLSsx/oz60J2+0g9UCInzNLUZlWBYsMxmyofqKT/4+mDJXZIV6nSCFG60kJ2J+51Swv/vjy/",
-	"+g80gkMCK0+HBaDkIOuicI3wkiaKhz9//wNoSjoXhgzYEVqopSHbEqAmUKWwrqkaaFWCHS3FbOX+tXoR",
-	"bPp/NH8rDq+6vgQi13rr3FgdfbEORPOy6Yq3Y6HxQCf7dsYEBJpmO3U5kfZjhepGIBY4cFSu1Wt4EzAK",
-	"SmFcnQwvzUjVBQcsJjgzoUJv93w3kd31fr40Hr3xSzZmix+7EWyhdbl9Gmjf0dR+Fdo9Ss++8D10Vdsf",
-	"Ij+V8XSo0s80myjNUz8vkiVtsrmzc+FkDalD5NuWEnKU0CdwMyYHHFjS8EpBFGk68Al6X6nXgWQpyo98",
-	"7Y/eb3PmnOfHQJbECTj4L9ljwP94XKgab4b1R7qm6q6AjySN6zQNjGsJuzDu8F/QdLNCcZqh9f7Y3FoI",
-	"PURQGywpdYESQjlFyX31SeMyZZbN3dvFfeAMNRkjlATrqtJAaRDG1ASPLp7+72kPEFw8QhuoUNbGglTW",
-	"IdlXteQfpF84YNO1h+LVWACfHH2fcqwNuRPe1TV38qNPobMPcgvy27gV8pnyTHKH89sobqec8X/2zpnD",
-	"x1S73jpy27yqZzNnX+Yj5dsvWsenj/nnJoxcQbh7gnYnyy5T8wEniO/9MKnDw7t9Frl2cds3DiQ7eHEs",
-	"OKmsrK72lHwyp5qKcjEQxNtRJdh2V/F6oWSuya5vElxP5cpTKwz6Mx/+wQO+zZpQKGMVGgPC+sOoEGHp",
-	"y7dHj/dLy+I08W55Kt+H6uMjYfr4VIhenV/sz/LkyHGzthG4Ix9vfnkZaPZdfR9s9bDnCXA4vSdK54mw",
-	"o6+vGuIwv2wNcxJj11hLDppsrSVxGAts7jO2cjMKWMLa1R7EMb1tEJqbs316hOReWZfs3tuzjz/wTcvp",
-	"7iSTB97jPFTW1FLcd//3Xvp2PRxBmyeVUPI7vd3DwpKWaMWY/nuYtfC2FCXpzcDn/QZ6yY4aPn5/9+7H",
-	"jrpFwsKFdSiYtS5cVbO26mVZuOg+MxMcDkmfCZVhJZyX/goAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWEIRMxTh2JdDCKICNxjJw0cOikQehQhJCNUsp4BCmi",
+	"DwsREevMCSOGTZmIExFaFElwocKQD0WEgQOHTZoxYVQifKFmDsukc8agKdMmjEgSEc20HPGCoEGER+e8",
+	"yLq1q9oyeMIY9Fmzj82RJU+mXOmm5ZMlIm5u3fizYdLBJOXEENmxTpqIZBzSkfPxJluuXpPSyQOnTMs5",
+	"k9O4OVNXcBnCcmQwlukYsmTKZSxrxSxyc+eWoumUOfOzrt27l92KhCu3qeekcOS86SxH5cWkdsKw+Vib",
+	"83ERoE+OLi3C9vU3YtSUGRMSuNwyTs6LTL78p3PDAt2o12z9c+jtN/G0eLM0TQuCJPHmRgtwTRZGC3SE",
+	"cQZ8IsARhhxytSRfG579dpN3LYEnHnm+3SSaGW+IRFJWeknVlw4iDIFQgqLNAQIZaZhhxk9HgVCUbguB",
+	"4J2Lc9TB1BvNlUEGCGLkAUJ2T9Fx5E929HZhGnTQheIUoZG3pBxNygECcXNddFOWc/DVUgwuwFBmTTe1",
+	"Jx8cabQ0Q5ln3uQgHWgwSJVVJwp0EGgi5oWSiS0pMcUTToCQhoth1EFHQVE9JR0bRnYlxxxoSCekoQu9",
+	"ceRkdZA3hwuBidAehCYmERmKghJaRFxdhtoYSEK8QUYeRK14lEhLNeWoiXdeJVBwmQkEVhlioUiWWRSl",
+	"tdZsbr3ApXG+3QUURRYxKAMMMNRq1EK4MuUUVLxW5St2zAYrwrDFinBsQckupBawb7EKrYV4kfinmCj+",
+	"haYINGD7VVhjlcUuWu6+MK1QEr2gEUes0XQXSWYkygZSAo1o0r1XiVCFG2u48cYdbmwph3JyRHvTC23U",
+	"MTFKD1Lc4Bt8JjVqowiZ2lITKqvkYHOrFkfXTa+CFuus2uLocsor70zHCyDK0UYLZERlLrD/EhswsgQz",
+	"tGxbYcTrc4X0HlzRcwJdm21SN96aFNI6t8w0kE9HnaBIVCeF7tUDJ1QwvM7KSxe9FpeIrwj63tXv2cIC",
+	"bKzAZ+mttdjVKrxR0OXdBLHELgeO8Ykac+wxyCKTbLIIKOfMcnMtRMRGVEKuB7PLM5d6qgg4J91yTKvr",
+	"RkbPrQLdsNCy0oq2rdyubbrSBpeRe+tYlVt1uus2rizfz/4dtkTUki2C2UWrLRDbpy+tOuun/uq83Yqr",
+	"y3i7WlPvN9gP+7lXxoXfdPjzeEtfMOQJL0z5vpfLWZ/sNT/ObaxjHwvZT0T3m7uULmlS0tPrBnixArZk",
+	"Cmj4mIsyeAcdaYok0gHBHaCEBhCAzzg2Ip6SdoQpEIThSKI5g09A8L80MYdmbrAZimqnM5/EZCagCYIb",
+	"yBCToIyNCtZpiO+ASIehCU8gaSueQHL1LRz2Kk/k4hr+Foc1x72rXF5rlV1uQsVd8eUF+rmDGlvQtKfV",
+	"QQ4+cQOAmGc+LaLPalzM2/TA2LevcScNXeHNC+CwnebZUSBtjEpLiqSbUGEIRUjazhhFcEK3tRFqUqPb",
+	"+RKHR/V1cY9cC+O87qIbPCytKWEQjSYP2Z36QPI+pGmg74xYLZFwb3jbclkZwXVGcWGxbpyE3vqy9sVQ",
+	"9lGMd9mlFdO4xku+MY5zLF8WaXNHYX5yb3ysHtg8FMgyDLKQdaQmIuGmSBQx0jMXciV2YMmdSjbnbU7D",
+	"5NwMKc5zpS967CsmZkRpvQsVaJCrUyU9u1Kd27xSO7GcpOYsmC/AGM5f1cxfPpNHy/5N7nflodcLPPYf",
+	"FbYAMYVxXcwqJj9AocgJb+hoLkGAgmvRIAU0xB7CREhCECzHRCEMwxBB4AaVra4nZYhpRUEA0kmBQByA",
+	"oMSW8PCTMRxKIjqqlJLqMDYlFRVREbFpG6CkOxCYQTltiGpQ+Req2PFFhyJAqYpyiYTTJEaJOJHp2KwF",
+	"AxpQUHAZQykI1mq0UF1VJD1lw0998lG39mag5grsYI/Dqdi00qDrRCh3bsoX6RQWNaus5yMjG8NoabQx",
+	"jxFSC3zZAjEET6SZK+ngfvgR0BApeIZyEWghw4IjaWqrcwjTaF47qyNlUGVDks4dwpAHFy0QSKCy4U9w",
+	"iFbWhpYMqXKCE12F0enisq9JUWa48JRZgkY0j/prXzbf16G4euS5r/mItORay6TcEooq7JaueDkVX3bX",
+	"XHcD70Td50fAqZZ+DrUfRIMpUWJSNHtq8R9GAUgszN11cy054OcUODIgjS5554UMggpU2tMiZ4JJWahJ",
+	"RcBakPDWSIeKaYaFVFurmPBQuj3DiX37BuC6kA3DLW7okFvWG8quJc6FDBUKNN0ltraJHoZvLmvzT1QK",
+	"NJzeFchmI5nQ9a74VI1db0XpiriBxFczTQ7oLzf52OtQubwiHlz9+DVge3YSnwbmX4IvykQGR0yAIf6v",
+	"AT2XwB2XTJakAwqTRHuGlK6hDHm4A5DI0IKdnUc3k3rBHrzTB5HwJrUEHDEUHvTowthIp0QK6oQuFQYz",
+	"QBoER9DUoRO9aLiatWazK+KgyZDqJSBa0XIgw6YhRCFIw9XRvQ6pDrYgEIE2KCpoCNWoW4IhI6NXB42V",
+	"DSunzE67dGGWCLZlm6PoslKeUsz3LaiZq61QPfvFoZ8tg054Qlg5o/bBDCUxe6EKlZCJYazEctGiUhhe",
+	"tbhbuaQ6a6zVvROgFjHbRoZVkr285Ox6y4z15S5it+hJPWLTmNocnbvd2+b8VrzfB0aYvwnObhpVdF/3",
+	"++7HJypnyTGszvG788TgPWIJ9/m4f9boTijUglE3mtNP0ymjTTurRiuHOZuR9Kgr/eGR1quCI47JGYAS",
+	"JoToyMRNi22PgjqCGNygBjfQgQtBMKcSArsMp06Zaz2mpHu/lqpk4IIbcqOpF1JuxuxBupHUoJO2jydR",
+	"FhGrkSj1oKC+cNQukHuPl/vjKZ0nPRTatVyESAYnQuHo7qGVnICOdmETWwTGLruy5yOCZTvbNdCGjbQ1",
+	"q84zWzvhwCPadb2nlIfT1w1XDLfK4ezFre1zLY9XD6A3XrZtf3mKtreifSe++2H2nm87R4/wy53pwRVB",
+	"K2+AKp3wzcQZa2QMa7iwt98tMx8LvCVDNiXvoAV7JMteydiVcphTOeZpt57ckyT+9ozfcPmbEqD0p3tS",
+	"dn+S5V/VB2Ao13H35HzK0nIKBnOW02B4RlIHuGcIBDo4d2FUdYFYtCewY36wFmF8BjLr9zPmdWTWBX+0",
+	"B0gK4k2ERBrMN05OU04icE6ORICdNXzzxmXdI0UiYAdpQBJvgDJwYFcxKAKJhBQ1mAeNlE6Q5XrUB3Vq",
+	"FmBs1mUex3sNuIMu9z8x52B5VoEiyIF+poEV0RlOZQZpIFrchiCuJEFOl2YZs1Ym0XkptFLeEVs89QZK",
+	"MhHjESNpOCRFIlZHUi4tpil3EFRqpyQOkluGskKaMgZOUSNztHgBF4IosjF8eIZ/yFdHgUS30X4pyHDx",
+	"B3rd9AIqIIBISE5KaINOOG4FeD1bpm1dxm0iAYRCaIqomISLxIToVGb28YrxA4YNlYBWuIDX9Dha+IBH",
+	"loCL0XzHOHJbtoUL9lAzQHFYuD/JSGfL2IUT+HR4ZYETNoaA9gLPpBDRRH4C8Wo5NDtVIAVMUARyJCtC",
+	"UoK9SDmhSIsON1/L1AJqdAdsBDctUI7xSBLSBExuZk0WJ14YR146GIscN4vHV3v6yCvM5I/OBEfmKI8F",
+	"SWZXyIAX93sZZ4BSiIAPVYxv5pHIGI3K6DARKHOYNpLgeHMVlnOT9AIjRCeX9Vbo6I0QhiJthRouUm+h",
+	"FlNjUAZp0CTBtVMRQQdvlBBDAoQvlB2dwhCUyFyz85NvRY+hcna+5hCfZ2xFNXoU0hJFtRinxzzRNk1R",
+	"5osHlYM2UWycE5Y3sWwoUlSqsXpruVm5sRu98XonqHDvJ4q0p129JHFQhl/GmJD61CwhCYvZ9pA9qEvJ",
+	"t13jYpAd+Yy+x5gMGYXfeG5+ZViTIhJluRpXll6OZZDU9oqmgRqqkRSzhZaqp5bmopdGwRs5N5c+VXI5",
+	"eViHCVi5CVSm2Yq/6JY2hFNssJslc4Sp6ZaTlHIEpl9xlo0vt40t6YUUCJNhGI4ZOI43iQYBOXfj4oE0",
+	"Nzgbwxc6Uh8AZ5UiyBdaCYoLh4/IN5GFWZkcmZggx1/IlH87KIuRKV9VxCvSAWnyoRJNsgLL15vOqJiZ",
+	"2TXHNEpkNJnzWX/1hBZPUCyft5ySxALPuXIGhp/z0gUi2ZnDuJo6eRig2YwQwRrPlpaoiYOSdBd2SZqt",
+	"AZuVIZvihhu12Zf04pwHWWC954DayJJ44ZLjmTE2h4Ez6VmWMWihOWwC8UxkSQd0AAc68AJrUSV04AJz",
+	"MFxnYJsusBIv0B81AaIBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/fiber/server.gen.go
+++ b/internal/test/servers/strict/fiber/server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -1800,52 +1800,83 @@ func (sh *strictHandler) UnionExample(ctx *fiber.Ctx) error {
 	return nil
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7FndbtvGEn6VweZcnJNDmrbjgwC6S4Igp03rBHZy1eRixB1Jm5C7zO5SPxAE9CH6hH2SYn9I/dGOlEpW",
-	"EPTKFjl/nG9mdmZ2znJVVkqStIb15kyTqZQ05H/0kWv6UpOx7hcnk2tRWaEk67HnyG/iu0XCNNUG+wU1",
-	"7I4+V9KS9KxYVYXI0bFmn4zjnzOTj6hE99+/NA1Yjz3KlqZk4a3JaIplVRBbLBbJhgVvXrOEjQg5aW9t",
-	"+PcifMWXWmjirGd1TcmKLjuriPWYsVrIIXNCA9vlTmxCWhqSdtY41mikI2js7M1ZpVVF2orgwzEWNXVr",
-	"jk9U/xPl3osGS7rGskOKjE/XhSRsmiqsRJorTkOSKU2txtTi0DNVqLFkvcC86NDoHgk5UNvovlDSopAG",
-	"uBgMSJO0EOEEJ8OAqatKaUsc+jNw5uQWDOkxaZYwK6xzBbtdfQ7RRYYlbEzaBEUXZ+dn5+7bVUUSK8F6",
-	"7Il/lLAK7ch/RxsyleqKxJ9v31yDMIC1VSVakWNRzKBEbUZYEAchrXIm1rk1Z8xr0j4Uf+KR+2UEL2Ex",
-	"3J8rPjtGCPtMWUmwy/PzB8qURcKugrIuGa1R2UrKezEDrIsOn7+Xn6WaSCCtlY5flpV1YUWF2q5ite7t",
-	"XxuSXVzeyssGSpcpR4tH8vqhNJ3a8ammAq0rYF8F4CZQ7ofDivijovB39JwUg3gCdNap25GaGBipCVgF",
-	"nLCAibAjaBg3CqyQgGCEHBYEjVFJJ5gFxYP4meQ38VveORlHr2fJmpRpOplMUp9AtS5IukOJf5tYUeKQ",
-	"skoO19mdbLSsx/oz60J2+0g9UCInzNLUZlWBYsMxmyofqKT/4+mDJXZIV6nSCFG60kJ2J+51Swv/vjy/",
-	"+g80gkMCK0+HBaDkIOuicI3wkiaKhz9//wNoSjoXhgzYEVqopSHbEqAmUKWwrqkaaFWCHS3FbOX+tXoR",
-	"bPp/NH8rDq+6vgQi13rr3FgdfbEORPOy6Yq3Y6HxQCf7dsYEBJpmO3U5kfZjhepGIBY4cFSu1Wt4EzAK",
-	"SmFcnQwvzUjVBQcsJjgzoUJv93w3kd31fr40Hr3xSzZmix+7EWyhdbl9Gmjf0dR+Fdo9Ss++8D10Vdsf",
-	"Ij+V8XSo0s80myjNUz8vkiVtsrmzc+FkDalD5NuWEnKU0CdwMyYHHFjS8EpBFGk68Al6X6nXgWQpyo98",
-	"7Y/eb3PmnOfHQJbECTj4L9ljwP94XKgab4b1R7qm6q6AjySN6zQNjGsJuzDu8F/QdLNCcZqh9f7Y3FoI",
-	"PURQGywpdYESQjlFyX31SeMyZZbN3dvFfeAMNRkjlATrqtJAaRDG1ASPLp7+72kPEFw8QhuoUNbGglTW",
-	"IdlXteQfpF84YNO1h+LVWACfHH2fcqwNuRPe1TV38qNPobMPcgvy27gV8pnyTHKH89sobqec8X/2zpnD",
-	"x1S73jpy27yqZzNnX+Yj5dsvWsenj/nnJoxcQbh7gnYnyy5T8wEniO/9MKnDw7t9Frl2cds3DiQ7eHEs",
-	"OKmsrK72lHwyp5qKcjEQxNtRJdh2V/F6oWSuya5vElxP5cpTKwz6Mx/+wQO+zZpQKGMVGgPC+sOoEGHp",
-	"y7dHj/dLy+I08W55Kt+H6uMjYfr4VIhenV/sz/LkyHGzthG4Ix9vfnkZaPZdfR9s9bDnCXA4vSdK54mw",
-	"o6+vGuIwv2wNcxJj11hLDppsrSVxGAts7jO2cjMKWMLa1R7EMb1tEJqbs316hOReWZfs3tuzjz/wTcvp",
-	"7iSTB97jPFTW1FLcd//3Xvp2PRxBmyeVUPI7vd3DwpKWaMWY/nuYtfC2FCXpzcDn/QZ6yY4aPn5/9+7H",
-	"jrpFwsKFdSiYtS5cVbO26mVZuOg+MxMcDkmfCZVhJZyX/goAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWEIRMxTh2JdDCKICNxjJw0cOikQehQhJCNUsp4BCmi",
+	"DwsREevMCSOGTZmIExFaFElwocKQD0WEgQOHTZoxYVQifKFmDsukc8agKdMmjEgSEc20HPGCoEGER+e8",
+	"yLq1q9oyeMIY9Fmzj82RJU+mXOmm5ZMlIm5u3fizYdLBJOXEENmxTpqIZBzSkfPxJluuXpPSyQOnTMs5",
+	"k9O4OVNXcBnCcmQwlukYsmTKZSxrxSxyc+eWoumUOfOzrt27l92KhCu3qeekcOS86SxH5cWkdsKw+Vib",
+	"83ERoE+OLi3C9vU3YtSUGRMSuNwyTs6LTL78p3PDAt2o12z9c+jtN/G0eLM0TQuCJPHmRgtwTRZGC3SE",
+	"cQZ8IsARhhxytSRfG579dpN3LYEnHnm+3SSaGW+IRFJWeknVlw4iDIFQgqLNAQIZaZhhxk9HgVCUbguB",
+	"4J2Lc9TB1BvNlUEGCGLkAUJ2T9Fx5E929HZhGnTQheIUoZG3pBxNygECcXNddFOWc/DVUgwuwFBmTTe1",
+	"Jx8cabQ0Q5ln3uQgHWgwSJVVJwp0EGgi5oWSiS0pMcUTToCQhoth1EFHQVE9JR0bRnYlxxxoSCekoQu9",
+	"ceRkdZA3hwuBidAehCYmERmKghJaRFxdhtoYSEK8QUYeRK14lEhLNeWoiXdeJVBwmQkEVhlioUiWWRSl",
+	"tdZsbr3ApXG+3QUURRYxKAMMMNRq1EK4MuUUVLxW5St2zAYrwrDFinBsQckupBawb7EKrYV4kfinmCj+",
+	"haYINGD7VVhjlcUuWu6+MK1QEr2gEUes0XQXSWYkygZSAo1o0r1XiVCFG2u48cYdbmwph3JyRHvTC23U",
+	"MTFKD1Lc4Bt8JjVqowiZ2lITKqvkYHOrFkfXTa+CFuus2uLocsor70zHCyDK0UYLZERlLrD/EhswsgQz",
+	"tGxbYcTrc4X0HlzRcwJdm21SN96aFNI6t8w0kE9HnaBIVCeF7tUDJ1QwvM7KSxe9FpeIrwj63tXv2cIC",
+	"bKzAZ+mttdjVKrxR0OXdBLHELgeO8Ykac+wxyCKTbLIIKOfMcnMtRMRGVEKuB7PLM5d6qgg4J91yTKvr",
+	"RkbPrQLdsNCy0oq2rdyubbrSBpeRe+tYlVt1uus2rizfz/4dtkTUki2C2UWrLRDbpy+tOuun/uq83Yqr",
+	"y3i7WlPvN9gP+7lXxoXfdPjzeEtfMOQJL0z5vpfLWZ/sNT/ObaxjHwvZT0T3m7uULmlS0tPrBnixArZk",
+	"Cmj4mIsyeAcdaYok0gHBHaCEBhCAzzg2Ip6SdoQpEIThSKI5g09A8L80MYdmbrAZimqnM5/EZCagCYIb",
+	"yBCToIyNCtZpiO+ASIehCU8gaSueQHL1LRz2Kk/k4hr+Foc1x72rXF5rlV1uQsVd8eUF+rmDGlvQtKfV",
+	"QQ4+cQOAmGc+LaLPalzM2/TA2LevcScNXeHNC+CwnebZUSBtjEpLiqSbUGEIRUjazhhFcEK3tRFqUqPb",
+	"+RKHR/V1cY9cC+O87qIbPCytKWEQjSYP2Z36QPI+pGmg74xYLZFwb3jbclkZwXVGcWGxbpyE3vqy9sVQ",
+	"9lGMd9mlFdO4xku+MY5zLF8WaXNHYX5yb3ysHtg8FMgyDLKQdaQmIuGmSBQx0jMXciV2YMmdSjbnbU7D",
+	"5NwMKc5zpS967CsmZkRpvQsVaJCrUyU9u1Kd27xSO7GcpOYsmC/AGM5f1cxfPpNHy/5N7nflodcLPPYf",
+	"FbYAMYVxXcwqJj9AocgJb+hoLkGAgmvRIAU0xB7CREhCECzHRCEMwxBB4AaVra4nZYhpRUEA0kmBQByA",
+	"oMSW8PCTMRxKIjqqlJLqMDYlFRVREbFpG6CkOxCYQTltiGpQ+Req2PFFhyJAqYpyiYTTJEaJOJHp2KwF",
+	"AxpQUHAZQykI1mq0UF1VJD1lw0998lG39mag5grsYI/Dqdi00qDrRCh3bsoX6RQWNaus5yMjG8NoabQx",
+	"jxFSC3zZAjEET6SZK+ngfvgR0BApeIZyEWghw4IjaWqrcwjTaF47qyNlUGVDks4dwpAHFy0QSKCy4U9w",
+	"iFbWhpYMqXKCE12F0enisq9JUWa48JRZgkY0j/prXzbf16G4euS5r/mItORay6TcEooq7JaueDkVX3bX",
+	"XHcD70Td50fAqZZ+DrUfRIMpUWJSNHtq8R9GAUgszN11cy054OcUODIgjS5554UMggpU2tMiZ4JJWahJ",
+	"RcBakPDWSIeKaYaFVFurmPBQuj3DiX37BuC6kA3DLW7okFvWG8quJc6FDBUKNN0ltraJHoZvLmvzT1QK",
+	"NJzeFchmI5nQ9a74VI1db0XpiriBxFczTQ7oLzf52OtQubwiHlz9+DVge3YSnwbmX4IvykQGR0yAIf6v",
+	"AT2XwB2XTJakAwqTRHuGlK6hDHm4A5DI0IKdnUc3k3rBHrzTB5HwJrUEHDEUHvTowthIp0QK6oQuFQYz",
+	"QBoER9DUoRO9aLiatWazK+KgyZDqJSBa0XIgw6YhRCFIw9XRvQ6pDrYgEIE2KCpoCNWoW4IhI6NXB42V",
+	"DSunzE67dGGWCLZlm6PoslKeUsz3LaiZq61QPfvFoZ8tg054Qlg5o/bBDCUxe6EKlZCJYazEctGiUhhe",
+	"tbhbuaQ6a6zVvROgFjHbRoZVkr285Ox6y4z15S5it+hJPWLTmNocnbvd2+b8VrzfB0aYvwnObhpVdF/3",
+	"++7HJypnyTGszvG788TgPWIJ9/m4f9boTijUglE3mtNP0ymjTTurRiuHOZuR9Kgr/eGR1quCI47JGYAS",
+	"JoToyMRNi22PgjqCGNygBjfQgQtBMKcSArsMp06Zaz2mpHu/lqpk4IIbcqOpF1JuxuxBupHUoJO2jydR",
+	"FhGrkSj1oKC+cNQukHuPl/vjKZ0nPRTatVyESAYnQuHo7qGVnICOdmETWwTGLruy5yOCZTvbNdCGjbQ1",
+	"q84zWzvhwCPadb2nlIfT1w1XDLfK4ezFre1zLY9XD6A3XrZtf3mKtreifSe++2H2nm87R4/wy53pwRVB",
+	"K2+AKp3wzcQZa2QMa7iwt98tMx8LvCVDNiXvoAV7JMteydiVcphTOeZpt57ckyT+9ozfcPmbEqD0p3tS",
+	"dn+S5V/VB2Ao13H35HzK0nIKBnOW02B4RlIHuGcIBDo4d2FUdYFYtCewY36wFmF8BjLr9zPmdWTWBX+0",
+	"B0gK4k2ERBrMN05OU04icE6ORICdNXzzxmXdI0UiYAdpQBJvgDJwYFcxKAKJhBQ1mAeNlE6Q5XrUB3Vq",
+	"FmBs1mUex3sNuIMu9z8x52B5VoEiyIF+poEV0RlOZQZpIFrchiCuJEFOl2YZs1Ym0XkptFLeEVs89QZK",
+	"MhHjESNpOCRFIlZHUi4tpil3EFRqpyQOkluGskKaMgZOUSNztHgBF4IosjF8eIZ/yFdHgUS30X4pyHDx",
+	"B3rd9AIqIIBISE5KaINOOG4FeD1bpm1dxm0iAYRCaIqomISLxIToVGb28YrxA4YNlYBWuIDX9Dha+IBH",
+	"loCL0XzHOHJbtoUL9lAzQHFYuD/JSGfL2IUT+HR4ZYETNoaA9gLPpBDRRH4C8Wo5NDtVIAVMUARyJCtC",
+	"UoK9SDmhSIsON1/L1AJqdAdsBDctUI7xSBLSBExuZk0WJ14YR146GIscN4vHV3v6yCvM5I/OBEfmKI8F",
+	"SWZXyIAX93sZZ4BSiIAPVYxv5pHIGI3K6DARKHOYNpLgeHMVlnOT9AIjRCeX9Vbo6I0QhiJthRouUm+h",
+	"FlNjUAZp0CTBtVMRQQdvlBBDAoQvlB2dwhCUyFyz85NvRY+hcna+5hCfZ2xFNXoU0hJFtRinxzzRNk1R",
+	"5osHlYM2UWycE5Y3sWwoUlSqsXpruVm5sRu98XonqHDvJ4q0p129JHFQhl/GmJD61CwhCYvZ9pA9qEvJ",
+	"t13jYpAd+Yy+x5gMGYXfeG5+ZViTIhJluRpXll6OZZDU9oqmgRqqkRSzhZaqp5bmopdGwRs5N5c+VXI5",
+	"eViHCVi5CVSm2Yq/6JY2hFNssJslc4Sp6ZaTlHIEpl9xlo0vt40t6YUUCJNhGI4ZOI43iQYBOXfj4oE0",
+	"Nzgbwxc6Uh8AZ5UiyBdaCYoLh4/IN5GFWZkcmZggx1/IlH87KIuRKV9VxCvSAWnyoRJNsgLL15vOqJiZ",
+	"2TXHNEpkNJnzWX/1hBZPUCyft5ySxALPuXIGhp/z0gUi2ZnDuJo6eRig2YwQwRrPlpaoiYOSdBd2SZqt",
+	"AZuVIZvihhu12Zf04pwHWWC954DayJJ44ZLjmTE2h4Ez6VmWMWihOWwC8UxkSQd0AAc68AJrUSV04AJz",
+	"MFxnYJsusBIv0B81AaIBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/fiberv3/server.gen.go
+++ b/internal/test/servers/strict/fiberv3/server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -1800,52 +1800,83 @@ func (sh *strictHandler) UnionExample(ctx fiber.Ctx) error {
 	return nil
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7FndbtvGEn6VweZcnJNDmrbjgwC6S4Igp03rBHZy1eRixB1Jm5C7zO5SPxAE9CH6hH2SYn9I/dGOlEpW",
-	"EPTKFjl/nG9mdmZ2znJVVkqStIb15kyTqZQ05H/0kWv6UpOx7hcnk2tRWaEk67HnyG/iu0XCNNUG+wU1",
-	"7I4+V9KS9KxYVYXI0bFmn4zjnzOTj6hE99+/NA1Yjz3KlqZk4a3JaIplVRBbLBbJhgVvXrOEjQg5aW9t",
-	"+PcifMWXWmjirGd1TcmKLjuriPWYsVrIIXNCA9vlTmxCWhqSdtY41mikI2js7M1ZpVVF2orgwzEWNXVr",
-	"jk9U/xPl3osGS7rGskOKjE/XhSRsmiqsRJorTkOSKU2txtTi0DNVqLFkvcC86NDoHgk5UNvovlDSopAG",
-	"uBgMSJO0EOEEJ8OAqatKaUsc+jNw5uQWDOkxaZYwK6xzBbtdfQ7RRYYlbEzaBEUXZ+dn5+7bVUUSK8F6",
-	"7Il/lLAK7ch/RxsyleqKxJ9v31yDMIC1VSVakWNRzKBEbUZYEAchrXIm1rk1Z8xr0j4Uf+KR+2UEL2Ex",
-	"3J8rPjtGCPtMWUmwy/PzB8qURcKugrIuGa1R2UrKezEDrIsOn7+Xn6WaSCCtlY5flpV1YUWF2q5ite7t",
-	"XxuSXVzeyssGSpcpR4tH8vqhNJ3a8ammAq0rYF8F4CZQ7ofDivijovB39JwUg3gCdNap25GaGBipCVgF",
-	"nLCAibAjaBg3CqyQgGCEHBYEjVFJJ5gFxYP4meQ38VveORlHr2fJmpRpOplMUp9AtS5IukOJf5tYUeKQ",
-	"skoO19mdbLSsx/oz60J2+0g9UCInzNLUZlWBYsMxmyofqKT/4+mDJXZIV6nSCFG60kJ2J+51Swv/vjy/",
-	"+g80gkMCK0+HBaDkIOuicI3wkiaKhz9//wNoSjoXhgzYEVqopSHbEqAmUKWwrqkaaFWCHS3FbOX+tXoR",
-	"bPp/NH8rDq+6vgQi13rr3FgdfbEORPOy6Yq3Y6HxQCf7dsYEBJpmO3U5kfZjhepGIBY4cFSu1Wt4EzAK",
-	"SmFcnQwvzUjVBQcsJjgzoUJv93w3kd31fr40Hr3xSzZmix+7EWyhdbl9Gmjf0dR+Fdo9Ss++8D10Vdsf",
-	"Ij+V8XSo0s80myjNUz8vkiVtsrmzc+FkDalD5NuWEnKU0CdwMyYHHFjS8EpBFGk68Al6X6nXgWQpyo98",
-	"7Y/eb3PmnOfHQJbECTj4L9ljwP94XKgab4b1R7qm6q6AjySN6zQNjGsJuzDu8F/QdLNCcZqh9f7Y3FoI",
-	"PURQGywpdYESQjlFyX31SeMyZZbN3dvFfeAMNRkjlATrqtJAaRDG1ASPLp7+72kPEFw8QhuoUNbGglTW",
-	"IdlXteQfpF84YNO1h+LVWACfHH2fcqwNuRPe1TV38qNPobMPcgvy27gV8pnyTHKH89sobqec8X/2zpnD",
-	"x1S73jpy27yqZzNnX+Yj5dsvWsenj/nnJoxcQbh7gnYnyy5T8wEniO/9MKnDw7t9Frl2cds3DiQ7eHEs",
-	"OKmsrK72lHwyp5qKcjEQxNtRJdh2V/F6oWSuya5vElxP5cpTKwz6Mx/+wQO+zZpQKGMVGgPC+sOoEGHp",
-	"y7dHj/dLy+I08W55Kt+H6uMjYfr4VIhenV/sz/LkyHGzthG4Ix9vfnkZaPZdfR9s9bDnCXA4vSdK54mw",
-	"o6+vGuIwv2wNcxJj11hLDppsrSVxGAts7jO2cjMKWMLa1R7EMb1tEJqbs316hOReWZfs3tuzjz/wTcvp",
-	"7iSTB97jPFTW1FLcd//3Xvp2PRxBmyeVUPI7vd3DwpKWaMWY/nuYtfC2FCXpzcDn/QZ6yY4aPn5/9+7H",
-	"jrpFwsKFdSiYtS5cVbO26mVZuOg+MxMcDkmfCZVhJZyX/goAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWEIRMxTh2JdDCKICNxjJw0cOikQehQhJCNUsp4BCmi",
+	"DwsREevMCSOGTZmIExFaFElwocKQD0WEgQOHTZoxYVQifKFmDsukc8agKdMmjEgSEc20HPGCoEGER+e8",
+	"yLq1q9oyeMIY9Fmzj82RJU+mXOmm5ZMlIm5u3fizYdLBJOXEENmxTpqIZBzSkfPxJluuXpPSyQOnTMs5",
+	"k9O4OVNXcBnCcmQwlukYsmTKZSxrxSxyc+eWoumUOfOzrt27l92KhCu3qeekcOS86SxH5cWkdsKw+Vib",
+	"83ERoE+OLi3C9vU3YtSUGRMSuNwyTs6LTL78p3PDAt2o12z9c+jtN/G0eLM0TQuCJPHmRgtwTRZGC3SE",
+	"cQZ8IsARhhxytSRfG579dpN3LYEnHnm+3SSaGW+IRFJWeknVlw4iDIFQgqLNAQIZaZhhxk9HgVCUbguB",
+	"4J2Lc9TB1BvNlUEGCGLkAUJ2T9Fx5E929HZhGnTQheIUoZG3pBxNygECcXNddFOWc/DVUgwuwFBmTTe1",
+	"Jx8cabQ0Q5ln3uQgHWgwSJVVJwp0EGgi5oWSiS0pMcUTToCQhoth1EFHQVE9JR0bRnYlxxxoSCekoQu9",
+	"ceRkdZA3hwuBidAehCYmERmKghJaRFxdhtoYSEK8QUYeRK14lEhLNeWoiXdeJVBwmQkEVhlioUiWWRSl",
+	"tdZsbr3ApXG+3QUURRYxKAMMMNRq1EK4MuUUVLxW5St2zAYrwrDFinBsQckupBawb7EKrYV4kfinmCj+",
+	"haYINGD7VVhjlcUuWu6+MK1QEr2gEUes0XQXSWYkygZSAo1o0r1XiVCFG2u48cYdbmwph3JyRHvTC23U",
+	"MTFKD1Lc4Bt8JjVqowiZ2lITKqvkYHOrFkfXTa+CFuus2uLocsor70zHCyDK0UYLZERlLrD/EhswsgQz",
+	"tGxbYcTrc4X0HlzRcwJdm21SN96aFNI6t8w0kE9HnaBIVCeF7tUDJ1QwvM7KSxe9FpeIrwj63tXv2cIC",
+	"bKzAZ+mttdjVKrxR0OXdBLHELgeO8Ykac+wxyCKTbLIIKOfMcnMtRMRGVEKuB7PLM5d6qgg4J91yTKvr",
+	"RkbPrQLdsNCy0oq2rdyubbrSBpeRe+tYlVt1uus2rizfz/4dtkTUki2C2UWrLRDbpy+tOuun/uq83Yqr",
+	"y3i7WlPvN9gP+7lXxoXfdPjzeEtfMOQJL0z5vpfLWZ/sNT/ObaxjHwvZT0T3m7uULmlS0tPrBnixArZk",
+	"Cmj4mIsyeAcdaYok0gHBHaCEBhCAzzg2Ip6SdoQpEIThSKI5g09A8L80MYdmbrAZimqnM5/EZCagCYIb",
+	"yBCToIyNCtZpiO+ASIehCU8gaSueQHL1LRz2Kk/k4hr+Foc1x72rXF5rlV1uQsVd8eUF+rmDGlvQtKfV",
+	"QQ4+cQOAmGc+LaLPalzM2/TA2LevcScNXeHNC+CwnebZUSBtjEpLiqSbUGEIRUjazhhFcEK3tRFqUqPb",
+	"+RKHR/V1cY9cC+O87qIbPCytKWEQjSYP2Z36QPI+pGmg74xYLZFwb3jbclkZwXVGcWGxbpyE3vqy9sVQ",
+	"9lGMd9mlFdO4xku+MY5zLF8WaXNHYX5yb3ysHtg8FMgyDLKQdaQmIuGmSBQx0jMXciV2YMmdSjbnbU7D",
+	"5NwMKc5zpS967CsmZkRpvQsVaJCrUyU9u1Kd27xSO7GcpOYsmC/AGM5f1cxfPpNHy/5N7nflodcLPPYf",
+	"FbYAMYVxXcwqJj9AocgJb+hoLkGAgmvRIAU0xB7CREhCECzHRCEMwxBB4AaVra4nZYhpRUEA0kmBQByA",
+	"oMSW8PCTMRxKIjqqlJLqMDYlFRVREbFpG6CkOxCYQTltiGpQ+Req2PFFhyJAqYpyiYTTJEaJOJHp2KwF",
+	"AxpQUHAZQykI1mq0UF1VJD1lw0998lG39mag5grsYI/Dqdi00qDrRCh3bsoX6RQWNaus5yMjG8NoabQx",
+	"jxFSC3zZAjEET6SZK+ngfvgR0BApeIZyEWghw4IjaWqrcwjTaF47qyNlUGVDks4dwpAHFy0QSKCy4U9w",
+	"iFbWhpYMqXKCE12F0enisq9JUWa48JRZgkY0j/prXzbf16G4euS5r/mItORay6TcEooq7JaueDkVX3bX",
+	"XHcD70Td50fAqZZ+DrUfRIMpUWJSNHtq8R9GAUgszN11cy054OcUODIgjS5554UMggpU2tMiZ4JJWahJ",
+	"RcBakPDWSIeKaYaFVFurmPBQuj3DiX37BuC6kA3DLW7okFvWG8quJc6FDBUKNN0ltraJHoZvLmvzT1QK",
+	"NJzeFchmI5nQ9a74VI1db0XpiriBxFczTQ7oLzf52OtQubwiHlz9+DVge3YSnwbmX4IvykQGR0yAIf6v",
+	"AT2XwB2XTJakAwqTRHuGlK6hDHm4A5DI0IKdnUc3k3rBHrzTB5HwJrUEHDEUHvTowthIp0QK6oQuFQYz",
+	"QBoER9DUoRO9aLiatWazK+KgyZDqJSBa0XIgw6YhRCFIw9XRvQ6pDrYgEIE2KCpoCNWoW4IhI6NXB42V",
+	"DSunzE67dGGWCLZlm6PoslKeUsz3LaiZq61QPfvFoZ8tg054Qlg5o/bBDCUxe6EKlZCJYazEctGiUhhe",
+	"tbhbuaQ6a6zVvROgFjHbRoZVkr285Ox6y4z15S5it+hJPWLTmNocnbvd2+b8VrzfB0aYvwnObhpVdF/3",
+	"++7HJypnyTGszvG788TgPWIJ9/m4f9boTijUglE3mtNP0ymjTTurRiuHOZuR9Kgr/eGR1quCI47JGYAS",
+	"JoToyMRNi22PgjqCGNygBjfQgQtBMKcSArsMp06Zaz2mpHu/lqpk4IIbcqOpF1JuxuxBupHUoJO2jydR",
+	"FhGrkSj1oKC+cNQukHuPl/vjKZ0nPRTatVyESAYnQuHo7qGVnICOdmETWwTGLruy5yOCZTvbNdCGjbQ1",
+	"q84zWzvhwCPadb2nlIfT1w1XDLfK4ezFre1zLY9XD6A3XrZtf3mKtreifSe++2H2nm87R4/wy53pwRVB",
+	"K2+AKp3wzcQZa2QMa7iwt98tMx8LvCVDNiXvoAV7JMteydiVcphTOeZpt57ckyT+9ozfcPmbEqD0p3tS",
+	"dn+S5V/VB2Ao13H35HzK0nIKBnOW02B4RlIHuGcIBDo4d2FUdYFYtCewY36wFmF8BjLr9zPmdWTWBX+0",
+	"B0gK4k2ERBrMN05OU04icE6ORICdNXzzxmXdI0UiYAdpQBJvgDJwYFcxKAKJhBQ1mAeNlE6Q5XrUB3Vq",
+	"FmBs1mUex3sNuIMu9z8x52B5VoEiyIF+poEV0RlOZQZpIFrchiCuJEFOl2YZs1Ym0XkptFLeEVs89QZK",
+	"MhHjESNpOCRFIlZHUi4tpil3EFRqpyQOkluGskKaMgZOUSNztHgBF4IosjF8eIZ/yFdHgUS30X4pyHDx",
+	"B3rd9AIqIIBISE5KaINOOG4FeD1bpm1dxm0iAYRCaIqomISLxIToVGb28YrxA4YNlYBWuIDX9Dha+IBH",
+	"loCL0XzHOHJbtoUL9lAzQHFYuD/JSGfL2IUT+HR4ZYETNoaA9gLPpBDRRH4C8Wo5NDtVIAVMUARyJCtC",
+	"UoK9SDmhSIsON1/L1AJqdAdsBDctUI7xSBLSBExuZk0WJ14YR146GIscN4vHV3v6yCvM5I/OBEfmKI8F",
+	"SWZXyIAX93sZZ4BSiIAPVYxv5pHIGI3K6DARKHOYNpLgeHMVlnOT9AIjRCeX9Vbo6I0QhiJthRouUm+h",
+	"FlNjUAZp0CTBtVMRQQdvlBBDAoQvlB2dwhCUyFyz85NvRY+hcna+5hCfZ2xFNXoU0hJFtRinxzzRNk1R",
+	"5osHlYM2UWycE5Y3sWwoUlSqsXpruVm5sRu98XonqHDvJ4q0p129JHFQhl/GmJD61CwhCYvZ9pA9qEvJ",
+	"t13jYpAd+Yy+x5gMGYXfeG5+ZViTIhJluRpXll6OZZDU9oqmgRqqkRSzhZaqp5bmopdGwRs5N5c+VXI5",
+	"eViHCVi5CVSm2Yq/6JY2hFNssJslc4Sp6ZaTlHIEpl9xlo0vt40t6YUUCJNhGI4ZOI43iQYBOXfj4oE0",
+	"Nzgbwxc6Uh8AZ5UiyBdaCYoLh4/IN5GFWZkcmZggx1/IlH87KIuRKV9VxCvSAWnyoRJNsgLL15vOqJiZ",
+	"2TXHNEpkNJnzWX/1hBZPUCyft5ySxALPuXIGhp/z0gUi2ZnDuJo6eRig2YwQwRrPlpaoiYOSdBd2SZqt",
+	"AZuVIZvihhu12Zf04pwHWWC954DayJJ44ZLjmTE2h4Ez6VmWMWihOWwC8UxkSQd0AAc68AJrUSV04AJz",
+	"MFxnYJsusBIv0B81AaIBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/gin/server.gen.go
+++ b/internal/test/servers/strict/gin/server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1836,52 +1836,83 @@ func (sh *strictHandler) UnionExample(ctx *gin.Context) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7FndbtvGEn6VweZcnJNDmrbjgwC6S4Igp03rBHZy1eRixB1Jm5C7zO5SPxAE9CH6hH2SYn9I/dGOlEpW",
-	"EPTKFjl/nG9mdmZ2znJVVkqStIb15kyTqZQ05H/0kWv6UpOx7hcnk2tRWaEk67HnyG/iu0XCNNUG+wU1",
-	"7I4+V9KS9KxYVYXI0bFmn4zjnzOTj6hE99+/NA1Yjz3KlqZk4a3JaIplVRBbLBbJhgVvXrOEjQg5aW9t",
-	"+PcifMWXWmjirGd1TcmKLjuriPWYsVrIIXNCA9vlTmxCWhqSdtY41mikI2js7M1ZpVVF2orgwzEWNXVr",
-	"jk9U/xPl3osGS7rGskOKjE/XhSRsmiqsRJorTkOSKU2txtTi0DNVqLFkvcC86NDoHgk5UNvovlDSopAG",
-	"uBgMSJO0EOEEJ8OAqatKaUsc+jNw5uQWDOkxaZYwK6xzBbtdfQ7RRYYlbEzaBEUXZ+dn5+7bVUUSK8F6",
-	"7Il/lLAK7ch/RxsyleqKxJ9v31yDMIC1VSVakWNRzKBEbUZYEAchrXIm1rk1Z8xr0j4Uf+KR+2UEL2Ex",
-	"3J8rPjtGCPtMWUmwy/PzB8qURcKugrIuGa1R2UrKezEDrIsOn7+Xn6WaSCCtlY5flpV1YUWF2q5ite7t",
-	"XxuSXVzeyssGSpcpR4tH8vqhNJ3a8ammAq0rYF8F4CZQ7ofDivijovB39JwUg3gCdNap25GaGBipCVgF",
-	"nLCAibAjaBg3CqyQgGCEHBYEjVFJJ5gFxYP4meQ38VveORlHr2fJmpRpOplMUp9AtS5IukOJf5tYUeKQ",
-	"skoO19mdbLSsx/oz60J2+0g9UCInzNLUZlWBYsMxmyofqKT/4+mDJXZIV6nSCFG60kJ2J+51Swv/vjy/",
-	"+g80gkMCK0+HBaDkIOuicI3wkiaKhz9//wNoSjoXhgzYEVqopSHbEqAmUKWwrqkaaFWCHS3FbOX+tXoR",
-	"bPp/NH8rDq+6vgQi13rr3FgdfbEORPOy6Yq3Y6HxQCf7dsYEBJpmO3U5kfZjhepGIBY4cFSu1Wt4EzAK",
-	"SmFcnQwvzUjVBQcsJjgzoUJv93w3kd31fr40Hr3xSzZmix+7EWyhdbl9Gmjf0dR+Fdo9Ss++8D10Vdsf",
-	"Ij+V8XSo0s80myjNUz8vkiVtsrmzc+FkDalD5NuWEnKU0CdwMyYHHFjS8EpBFGk68Al6X6nXgWQpyo98",
-	"7Y/eb3PmnOfHQJbECTj4L9ljwP94XKgab4b1R7qm6q6AjySN6zQNjGsJuzDu8F/QdLNCcZqh9f7Y3FoI",
-	"PURQGywpdYESQjlFyX31SeMyZZbN3dvFfeAMNRkjlATrqtJAaRDG1ASPLp7+72kPEFw8QhuoUNbGglTW",
-	"IdlXteQfpF84YNO1h+LVWACfHH2fcqwNuRPe1TV38qNPobMPcgvy27gV8pnyTHKH89sobqec8X/2zpnD",
-	"x1S73jpy27yqZzNnX+Yj5dsvWsenj/nnJoxcQbh7gnYnyy5T8wEniO/9MKnDw7t9Frl2cds3DiQ7eHEs",
-	"OKmsrK72lHwyp5qKcjEQxNtRJdh2V/F6oWSuya5vElxP5cpTKwz6Mx/+wQO+zZpQKGMVGgPC+sOoEGHp",
-	"y7dHj/dLy+I08W55Kt+H6uMjYfr4VIhenV/sz/LkyHGzthG4Ix9vfnkZaPZdfR9s9bDnCXA4vSdK54mw",
-	"o6+vGuIwv2wNcxJj11hLDppsrSVxGAts7jO2cjMKWMLa1R7EMb1tEJqbs316hOReWZfs3tuzjz/wTcvp",
-	"7iSTB97jPFTW1FLcd//3Xvp2PRxBmyeVUPI7vd3DwpKWaMWY/nuYtfC2FCXpzcDn/QZ6yY4aPn5/9+7H",
-	"jrpFwsKFdSiYtS5cVbO26mVZuOg+MxMcDkmfCZVhJZyX/goAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWEIRMxTh2JdDCKICNxjJw0cOikQehQhJCNUsp4BCmi",
+	"DwsREevMCSOGTZmIExFaFElwocKQD0WEgQOHTZoxYVQifKFmDsukc8agKdMmjEgSEc20HPGCoEGER+e8",
+	"yLq1q9oyeMIY9Fmzj82RJU+mXOmm5ZMlIm5u3fizYdLBJOXEENmxTpqIZBzSkfPxJluuXpPSyQOnTMs5",
+	"k9O4OVNXcBnCcmQwlukYsmTKZSxrxSxyc+eWoumUOfOzrt27l92KhCu3qeekcOS86SxH5cWkdsKw+Vib",
+	"83ERoE+OLi3C9vU3YtSUGRMSuNwyTs6LTL78p3PDAt2o12z9c+jtN/G0eLM0TQuCJPHmRgtwTRZGC3SE",
+	"cQZ8IsARhhxytSRfG579dpN3LYEnHnm+3SSaGW+IRFJWeknVlw4iDIFQgqLNAQIZaZhhxk9HgVCUbguB",
+	"4J2Lc9TB1BvNlUEGCGLkAUJ2T9Fx5E929HZhGnTQheIUoZG3pBxNygECcXNddFOWc/DVUgwuwFBmTTe1",
+	"Jx8cabQ0Q5ln3uQgHWgwSJVVJwp0EGgi5oWSiS0pMcUTToCQhoth1EFHQVE9JR0bRnYlxxxoSCekoQu9",
+	"ceRkdZA3hwuBidAehCYmERmKghJaRFxdhtoYSEK8QUYeRK14lEhLNeWoiXdeJVBwmQkEVhlioUiWWRSl",
+	"tdZsbr3ApXG+3QUURRYxKAMMMNRq1EK4MuUUVLxW5St2zAYrwrDFinBsQckupBawb7EKrYV4kfinmCj+",
+	"haYINGD7VVhjlcUuWu6+MK1QEr2gEUes0XQXSWYkygZSAo1o0r1XiVCFG2u48cYdbmwph3JyRHvTC23U",
+	"MTFKD1Lc4Bt8JjVqowiZ2lITKqvkYHOrFkfXTa+CFuus2uLocsor70zHCyDK0UYLZERlLrD/EhswsgQz",
+	"tGxbYcTrc4X0HlzRcwJdm21SN96aFNI6t8w0kE9HnaBIVCeF7tUDJ1QwvM7KSxe9FpeIrwj63tXv2cIC",
+	"bKzAZ+mttdjVKrxR0OXdBLHELgeO8Ykac+wxyCKTbLIIKOfMcnMtRMRGVEKuB7PLM5d6qgg4J91yTKvr",
+	"RkbPrQLdsNCy0oq2rdyubbrSBpeRe+tYlVt1uus2rizfz/4dtkTUki2C2UWrLRDbpy+tOuun/uq83Yqr",
+	"y3i7WlPvN9gP+7lXxoXfdPjzeEtfMOQJL0z5vpfLWZ/sNT/ObaxjHwvZT0T3m7uULmlS0tPrBnixArZk",
+	"Cmj4mIsyeAcdaYok0gHBHaCEBhCAzzg2Ip6SdoQpEIThSKI5g09A8L80MYdmbrAZimqnM5/EZCagCYIb",
+	"yBCToIyNCtZpiO+ASIehCU8gaSueQHL1LRz2Kk/k4hr+Foc1x72rXF5rlV1uQsVd8eUF+rmDGlvQtKfV",
+	"QQ4+cQOAmGc+LaLPalzM2/TA2LevcScNXeHNC+CwnebZUSBtjEpLiqSbUGEIRUjazhhFcEK3tRFqUqPb",
+	"+RKHR/V1cY9cC+O87qIbPCytKWEQjSYP2Z36QPI+pGmg74xYLZFwb3jbclkZwXVGcWGxbpyE3vqy9sVQ",
+	"9lGMd9mlFdO4xku+MY5zLF8WaXNHYX5yb3ysHtg8FMgyDLKQdaQmIuGmSBQx0jMXciV2YMmdSjbnbU7D",
+	"5NwMKc5zpS967CsmZkRpvQsVaJCrUyU9u1Kd27xSO7GcpOYsmC/AGM5f1cxfPpNHy/5N7nflodcLPPYf",
+	"FbYAMYVxXcwqJj9AocgJb+hoLkGAgmvRIAU0xB7CREhCECzHRCEMwxBB4AaVra4nZYhpRUEA0kmBQByA",
+	"oMSW8PCTMRxKIjqqlJLqMDYlFRVREbFpG6CkOxCYQTltiGpQ+Req2PFFhyJAqYpyiYTTJEaJOJHp2KwF",
+	"AxpQUHAZQykI1mq0UF1VJD1lw0998lG39mag5grsYI/Dqdi00qDrRCh3bsoX6RQWNaus5yMjG8NoabQx",
+	"jxFSC3zZAjEET6SZK+ngfvgR0BApeIZyEWghw4IjaWqrcwjTaF47qyNlUGVDks4dwpAHFy0QSKCy4U9w",
+	"iFbWhpYMqXKCE12F0enisq9JUWa48JRZgkY0j/prXzbf16G4euS5r/mItORay6TcEooq7JaueDkVX3bX",
+	"XHcD70Td50fAqZZ+DrUfRIMpUWJSNHtq8R9GAUgszN11cy054OcUODIgjS5554UMggpU2tMiZ4JJWahJ",
+	"RcBakPDWSIeKaYaFVFurmPBQuj3DiX37BuC6kA3DLW7okFvWG8quJc6FDBUKNN0ltraJHoZvLmvzT1QK",
+	"NJzeFchmI5nQ9a74VI1db0XpiriBxFczTQ7oLzf52OtQubwiHlz9+DVge3YSnwbmX4IvykQGR0yAIf6v",
+	"AT2XwB2XTJakAwqTRHuGlK6hDHm4A5DI0IKdnUc3k3rBHrzTB5HwJrUEHDEUHvTowthIp0QK6oQuFQYz",
+	"QBoER9DUoRO9aLiatWazK+KgyZDqJSBa0XIgw6YhRCFIw9XRvQ6pDrYgEIE2KCpoCNWoW4IhI6NXB42V",
+	"DSunzE67dGGWCLZlm6PoslKeUsz3LaiZq61QPfvFoZ8tg054Qlg5o/bBDCUxe6EKlZCJYazEctGiUhhe",
+	"tbhbuaQ6a6zVvROgFjHbRoZVkr285Ox6y4z15S5it+hJPWLTmNocnbvd2+b8VrzfB0aYvwnObhpVdF/3",
+	"++7HJypnyTGszvG788TgPWIJ9/m4f9boTijUglE3mtNP0ymjTTurRiuHOZuR9Kgr/eGR1quCI47JGYAS",
+	"JoToyMRNi22PgjqCGNygBjfQgQtBMKcSArsMp06Zaz2mpHu/lqpk4IIbcqOpF1JuxuxBupHUoJO2jydR",
+	"FhGrkSj1oKC+cNQukHuPl/vjKZ0nPRTatVyESAYnQuHo7qGVnICOdmETWwTGLruy5yOCZTvbNdCGjbQ1",
+	"q84zWzvhwCPadb2nlIfT1w1XDLfK4ezFre1zLY9XD6A3XrZtf3mKtreifSe++2H2nm87R4/wy53pwRVB",
+	"K2+AKp3wzcQZa2QMa7iwt98tMx8LvCVDNiXvoAV7JMteydiVcphTOeZpt57ckyT+9ozfcPmbEqD0p3tS",
+	"dn+S5V/VB2Ao13H35HzK0nIKBnOW02B4RlIHuGcIBDo4d2FUdYFYtCewY36wFmF8BjLr9zPmdWTWBX+0",
+	"B0gK4k2ERBrMN05OU04icE6ORICdNXzzxmXdI0UiYAdpQBJvgDJwYFcxKAKJhBQ1mAeNlE6Q5XrUB3Vq",
+	"FmBs1mUex3sNuIMu9z8x52B5VoEiyIF+poEV0RlOZQZpIFrchiCuJEFOl2YZs1Ym0XkptFLeEVs89QZK",
+	"MhHjESNpOCRFIlZHUi4tpil3EFRqpyQOkluGskKaMgZOUSNztHgBF4IosjF8eIZ/yFdHgUS30X4pyHDx",
+	"B3rd9AIqIIBISE5KaINOOG4FeD1bpm1dxm0iAYRCaIqomISLxIToVGb28YrxA4YNlYBWuIDX9Dha+IBH",
+	"loCL0XzHOHJbtoUL9lAzQHFYuD/JSGfL2IUT+HR4ZYETNoaA9gLPpBDRRH4C8Wo5NDtVIAVMUARyJCtC",
+	"UoK9SDmhSIsON1/L1AJqdAdsBDctUI7xSBLSBExuZk0WJ14YR146GIscN4vHV3v6yCvM5I/OBEfmKI8F",
+	"SWZXyIAX93sZZ4BSiIAPVYxv5pHIGI3K6DARKHOYNpLgeHMVlnOT9AIjRCeX9Vbo6I0QhiJthRouUm+h",
+	"FlNjUAZp0CTBtVMRQQdvlBBDAoQvlB2dwhCUyFyz85NvRY+hcna+5hCfZ2xFNXoU0hJFtRinxzzRNk1R",
+	"5osHlYM2UWycE5Y3sWwoUlSqsXpruVm5sRu98XonqHDvJ4q0p129JHFQhl/GmJD61CwhCYvZ9pA9qEvJ",
+	"t13jYpAd+Yy+x5gMGYXfeG5+ZViTIhJluRpXll6OZZDU9oqmgRqqkRSzhZaqp5bmopdGwRs5N5c+VXI5",
+	"eViHCVi5CVSm2Yq/6JY2hFNssJslc4Sp6ZaTlHIEpl9xlo0vt40t6YUUCJNhGI4ZOI43iQYBOXfj4oE0",
+	"Nzgbwxc6Uh8AZ5UiyBdaCYoLh4/IN5GFWZkcmZggx1/IlH87KIuRKV9VxCvSAWnyoRJNsgLL15vOqJiZ",
+	"2TXHNEpkNJnzWX/1hBZPUCyft5ySxALPuXIGhp/z0gUi2ZnDuJo6eRig2YwQwRrPlpaoiYOSdBd2SZqt",
+	"AZuVIZvihhu12Zf04pwHWWC954DayJJ44ZLjmTE2h4Ez6VmWMWihOWwC8UxkSQd0AAc68AJrUSV04AJz",
+	"MFxnYJsusBIv0B81AaIBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/gorilla/server.gen.go
+++ b/internal/test/servers/strict/gorilla/server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1939,52 +1939,83 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7FndbtvGEn6VweZcnJNDmrbjgwC6S4Igp03rBHZy1eRixB1Jm5C7zO5SPxAE9CH6hH2SYn9I/dGOlEpW",
-	"EPTKFjl/nG9mdmZ2znJVVkqStIb15kyTqZQ05H/0kWv6UpOx7hcnk2tRWaEk67HnyG/iu0XCNNUG+wU1",
-	"7I4+V9KS9KxYVYXI0bFmn4zjnzOTj6hE99+/NA1Yjz3KlqZk4a3JaIplVRBbLBbJhgVvXrOEjQg5aW9t",
-	"+PcifMWXWmjirGd1TcmKLjuriPWYsVrIIXNCA9vlTmxCWhqSdtY41mikI2js7M1ZpVVF2orgwzEWNXVr",
-	"jk9U/xPl3osGS7rGskOKjE/XhSRsmiqsRJorTkOSKU2txtTi0DNVqLFkvcC86NDoHgk5UNvovlDSopAG",
-	"uBgMSJO0EOEEJ8OAqatKaUsc+jNw5uQWDOkxaZYwK6xzBbtdfQ7RRYYlbEzaBEUXZ+dn5+7bVUUSK8F6",
-	"7Il/lLAK7ch/RxsyleqKxJ9v31yDMIC1VSVakWNRzKBEbUZYEAchrXIm1rk1Z8xr0j4Uf+KR+2UEL2Ex",
-	"3J8rPjtGCPtMWUmwy/PzB8qURcKugrIuGa1R2UrKezEDrIsOn7+Xn6WaSCCtlY5flpV1YUWF2q5ite7t",
-	"XxuSXVzeyssGSpcpR4tH8vqhNJ3a8ammAq0rYF8F4CZQ7ofDivijovB39JwUg3gCdNap25GaGBipCVgF",
-	"nLCAibAjaBg3CqyQgGCEHBYEjVFJJ5gFxYP4meQ38VveORlHr2fJmpRpOplMUp9AtS5IukOJf5tYUeKQ",
-	"skoO19mdbLSsx/oz60J2+0g9UCInzNLUZlWBYsMxmyofqKT/4+mDJXZIV6nSCFG60kJ2J+51Swv/vjy/",
-	"+g80gkMCK0+HBaDkIOuicI3wkiaKhz9//wNoSjoXhgzYEVqopSHbEqAmUKWwrqkaaFWCHS3FbOX+tXoR",
-	"bPp/NH8rDq+6vgQi13rr3FgdfbEORPOy6Yq3Y6HxQCf7dsYEBJpmO3U5kfZjhepGIBY4cFSu1Wt4EzAK",
-	"SmFcnQwvzUjVBQcsJjgzoUJv93w3kd31fr40Hr3xSzZmix+7EWyhdbl9Gmjf0dR+Fdo9Ss++8D10Vdsf",
-	"Ij+V8XSo0s80myjNUz8vkiVtsrmzc+FkDalD5NuWEnKU0CdwMyYHHFjS8EpBFGk68Al6X6nXgWQpyo98",
-	"7Y/eb3PmnOfHQJbECTj4L9ljwP94XKgab4b1R7qm6q6AjySN6zQNjGsJuzDu8F/QdLNCcZqh9f7Y3FoI",
-	"PURQGywpdYESQjlFyX31SeMyZZbN3dvFfeAMNRkjlATrqtJAaRDG1ASPLp7+72kPEFw8QhuoUNbGglTW",
-	"IdlXteQfpF84YNO1h+LVWACfHH2fcqwNuRPe1TV38qNPobMPcgvy27gV8pnyTHKH89sobqec8X/2zpnD",
-	"x1S73jpy27yqZzNnX+Yj5dsvWsenj/nnJoxcQbh7gnYnyy5T8wEniO/9MKnDw7t9Frl2cds3DiQ7eHEs",
-	"OKmsrK72lHwyp5qKcjEQxNtRJdh2V/F6oWSuya5vElxP5cpTKwz6Mx/+wQO+zZpQKGMVGgPC+sOoEGHp",
-	"y7dHj/dLy+I08W55Kt+H6uMjYfr4VIhenV/sz/LkyHGzthG4Ix9vfnkZaPZdfR9s9bDnCXA4vSdK54mw",
-	"o6+vGuIwv2wNcxJj11hLDppsrSVxGAts7jO2cjMKWMLa1R7EMb1tEJqbs316hOReWZfs3tuzjz/wTcvp",
-	"7iSTB97jPFTW1FLcd//3Xvp2PRxBmyeVUPI7vd3DwpKWaMWY/nuYtfC2FCXpzcDn/QZ6yY4aPn5/9+7H",
-	"jrpFwsKFdSiYtS5cVbO26mVZuOg+MxMcDkmfCZVhJZyX/goAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWEIRMxTh2JdDCKICNxjJw0cOikQehQhJCNUsp4BCmi",
+	"DwsREevMCSOGTZmIExFaFElwocKQD0WEgQOHTZoxYVQifKFmDsukc8agKdMmjEgSEc20HPGCoEGER+e8",
+	"yLq1q9oyeMIY9Fmzj82RJU+mXOmm5ZMlIm5u3fizYdLBJOXEENmxTpqIZBzSkfPxJluuXpPSyQOnTMs5",
+	"k9O4OVNXcBnCcmQwlukYsmTKZSxrxSxyc+eWoumUOfOzrt27l92KhCu3qeekcOS86SxH5cWkdsKw+Vib",
+	"83ERoE+OLi3C9vU3YtSUGRMSuNwyTs6LTL78p3PDAt2o12z9c+jtN/G0eLM0TQuCJPHmRgtwTRZGC3SE",
+	"cQZ8IsARhhxytSRfG579dpN3LYEnHnm+3SSaGW+IRFJWeknVlw4iDIFQgqLNAQIZaZhhxk9HgVCUbguB",
+	"4J2Lc9TB1BvNlUEGCGLkAUJ2T9Fx5E929HZhGnTQheIUoZG3pBxNygECcXNddFOWc/DVUgwuwFBmTTe1",
+	"Jx8cabQ0Q5ln3uQgHWgwSJVVJwp0EGgi5oWSiS0pMcUTToCQhoth1EFHQVE9JR0bRnYlxxxoSCekoQu9",
+	"ceRkdZA3hwuBidAehCYmERmKghJaRFxdhtoYSEK8QUYeRK14lEhLNeWoiXdeJVBwmQkEVhlioUiWWRSl",
+	"tdZsbr3ApXG+3QUURRYxKAMMMNRq1EK4MuUUVLxW5St2zAYrwrDFinBsQckupBawb7EKrYV4kfinmCj+",
+	"haYINGD7VVhjlcUuWu6+MK1QEr2gEUes0XQXSWYkygZSAo1o0r1XiVCFG2u48cYdbmwph3JyRHvTC23U",
+	"MTFKD1Lc4Bt8JjVqowiZ2lITKqvkYHOrFkfXTa+CFuus2uLocsor70zHCyDK0UYLZERlLrD/EhswsgQz",
+	"tGxbYcTrc4X0HlzRcwJdm21SN96aFNI6t8w0kE9HnaBIVCeF7tUDJ1QwvM7KSxe9FpeIrwj63tXv2cIC",
+	"bKzAZ+mttdjVKrxR0OXdBLHELgeO8Ykac+wxyCKTbLIIKOfMcnMtRMRGVEKuB7PLM5d6qgg4J91yTKvr",
+	"RkbPrQLdsNCy0oq2rdyubbrSBpeRe+tYlVt1uus2rizfz/4dtkTUki2C2UWrLRDbpy+tOuun/uq83Yqr",
+	"y3i7WlPvN9gP+7lXxoXfdPjzeEtfMOQJL0z5vpfLWZ/sNT/ObaxjHwvZT0T3m7uULmlS0tPrBnixArZk",
+	"Cmj4mIsyeAcdaYok0gHBHaCEBhCAzzg2Ip6SdoQpEIThSKI5g09A8L80MYdmbrAZimqnM5/EZCagCYIb",
+	"yBCToIyNCtZpiO+ASIehCU8gaSueQHL1LRz2Kk/k4hr+Foc1x72rXF5rlV1uQsVd8eUF+rmDGlvQtKfV",
+	"QQ4+cQOAmGc+LaLPalzM2/TA2LevcScNXeHNC+CwnebZUSBtjEpLiqSbUGEIRUjazhhFcEK3tRFqUqPb",
+	"+RKHR/V1cY9cC+O87qIbPCytKWEQjSYP2Z36QPI+pGmg74xYLZFwb3jbclkZwXVGcWGxbpyE3vqy9sVQ",
+	"9lGMd9mlFdO4xku+MY5zLF8WaXNHYX5yb3ysHtg8FMgyDLKQdaQmIuGmSBQx0jMXciV2YMmdSjbnbU7D",
+	"5NwMKc5zpS967CsmZkRpvQsVaJCrUyU9u1Kd27xSO7GcpOYsmC/AGM5f1cxfPpNHy/5N7nflodcLPPYf",
+	"FbYAMYVxXcwqJj9AocgJb+hoLkGAgmvRIAU0xB7CREhCECzHRCEMwxBB4AaVra4nZYhpRUEA0kmBQByA",
+	"oMSW8PCTMRxKIjqqlJLqMDYlFRVREbFpG6CkOxCYQTltiGpQ+Req2PFFhyJAqYpyiYTTJEaJOJHp2KwF",
+	"AxpQUHAZQykI1mq0UF1VJD1lw0998lG39mag5grsYI/Dqdi00qDrRCh3bsoX6RQWNaus5yMjG8NoabQx",
+	"jxFSC3zZAjEET6SZK+ngfvgR0BApeIZyEWghw4IjaWqrcwjTaF47qyNlUGVDks4dwpAHFy0QSKCy4U9w",
+	"iFbWhpYMqXKCE12F0enisq9JUWa48JRZgkY0j/prXzbf16G4euS5r/mItORay6TcEooq7JaueDkVX3bX",
+	"XHcD70Td50fAqZZ+DrUfRIMpUWJSNHtq8R9GAUgszN11cy054OcUODIgjS5554UMggpU2tMiZ4JJWahJ",
+	"RcBakPDWSIeKaYaFVFurmPBQuj3DiX37BuC6kA3DLW7okFvWG8quJc6FDBUKNN0ltraJHoZvLmvzT1QK",
+	"NJzeFchmI5nQ9a74VI1db0XpiriBxFczTQ7oLzf52OtQubwiHlz9+DVge3YSnwbmX4IvykQGR0yAIf6v",
+	"AT2XwB2XTJakAwqTRHuGlK6hDHm4A5DI0IKdnUc3k3rBHrzTB5HwJrUEHDEUHvTowthIp0QK6oQuFQYz",
+	"QBoER9DUoRO9aLiatWazK+KgyZDqJSBa0XIgw6YhRCFIw9XRvQ6pDrYgEIE2KCpoCNWoW4IhI6NXB42V",
+	"DSunzE67dGGWCLZlm6PoslKeUsz3LaiZq61QPfvFoZ8tg054Qlg5o/bBDCUxe6EKlZCJYazEctGiUhhe",
+	"tbhbuaQ6a6zVvROgFjHbRoZVkr285Ox6y4z15S5it+hJPWLTmNocnbvd2+b8VrzfB0aYvwnObhpVdF/3",
+	"++7HJypnyTGszvG788TgPWIJ9/m4f9boTijUglE3mtNP0ymjTTurRiuHOZuR9Kgr/eGR1quCI47JGYAS",
+	"JoToyMRNi22PgjqCGNygBjfQgQtBMKcSArsMp06Zaz2mpHu/lqpk4IIbcqOpF1JuxuxBupHUoJO2jydR",
+	"FhGrkSj1oKC+cNQukHuPl/vjKZ0nPRTatVyESAYnQuHo7qGVnICOdmETWwTGLruy5yOCZTvbNdCGjbQ1",
+	"q84zWzvhwCPadb2nlIfT1w1XDLfK4ezFre1zLY9XD6A3XrZtf3mKtreifSe++2H2nm87R4/wy53pwRVB",
+	"K2+AKp3wzcQZa2QMa7iwt98tMx8LvCVDNiXvoAV7JMteydiVcphTOeZpt57ckyT+9ozfcPmbEqD0p3tS",
+	"dn+S5V/VB2Ao13H35HzK0nIKBnOW02B4RlIHuGcIBDo4d2FUdYFYtCewY36wFmF8BjLr9zPmdWTWBX+0",
+	"B0gK4k2ERBrMN05OU04icE6ORICdNXzzxmXdI0UiYAdpQBJvgDJwYFcxKAKJhBQ1mAeNlE6Q5XrUB3Vq",
+	"FmBs1mUex3sNuIMu9z8x52B5VoEiyIF+poEV0RlOZQZpIFrchiCuJEFOl2YZs1Ym0XkptFLeEVs89QZK",
+	"MhHjESNpOCRFIlZHUi4tpil3EFRqpyQOkluGskKaMgZOUSNztHgBF4IosjF8eIZ/yFdHgUS30X4pyHDx",
+	"B3rd9AIqIIBISE5KaINOOG4FeD1bpm1dxm0iAYRCaIqomISLxIToVGb28YrxA4YNlYBWuIDX9Dha+IBH",
+	"loCL0XzHOHJbtoUL9lAzQHFYuD/JSGfL2IUT+HR4ZYETNoaA9gLPpBDRRH4C8Wo5NDtVIAVMUARyJCtC",
+	"UoK9SDmhSIsON1/L1AJqdAdsBDctUI7xSBLSBExuZk0WJ14YR146GIscN4vHV3v6yCvM5I/OBEfmKI8F",
+	"SWZXyIAX93sZZ4BSiIAPVYxv5pHIGI3K6DARKHOYNpLgeHMVlnOT9AIjRCeX9Vbo6I0QhiJthRouUm+h",
+	"FlNjUAZp0CTBtVMRQQdvlBBDAoQvlB2dwhCUyFyz85NvRY+hcna+5hCfZ2xFNXoU0hJFtRinxzzRNk1R",
+	"5osHlYM2UWycE5Y3sWwoUlSqsXpruVm5sRu98XonqHDvJ4q0p129JHFQhl/GmJD61CwhCYvZ9pA9qEvJ",
+	"t13jYpAd+Yy+x5gMGYXfeG5+ZViTIhJluRpXll6OZZDU9oqmgRqqkRSzhZaqp5bmopdGwRs5N5c+VXI5",
+	"eViHCVi5CVSm2Yq/6JY2hFNssJslc4Sp6ZaTlHIEpl9xlo0vt40t6YUUCJNhGI4ZOI43iQYBOXfj4oE0",
+	"Nzgbwxc6Uh8AZ5UiyBdaCYoLh4/IN5GFWZkcmZggx1/IlH87KIuRKV9VxCvSAWnyoRJNsgLL15vOqJiZ",
+	"2TXHNEpkNJnzWX/1hBZPUCyft5ySxALPuXIGhp/z0gUi2ZnDuJo6eRig2YwQwRrPlpaoiYOSdBd2SZqt",
+	"AZuVIZvihhu12Zf04pwHWWC954DayJJ44ZLjmTE2h4Ez6VmWMWihOWwC8UxkSQd0AAc68AJrUSV04AJz",
+	"MFxnYJsusBIv0B81AaIBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/iris/server.gen.go
+++ b/internal/test/servers/strict/iris/server.gen.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -1689,52 +1689,83 @@ func (sh *strictHandler) UnionExample(ctx iris.Context) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7FndbtvGEn6VweZcnJNDmrbjgwC6S4Igp03rBHZy1eRixB1Jm5C7zO5SPxAE9CH6hH2SYn9I/dGOlEpW",
-	"EPTKFjl/nG9mdmZ2znJVVkqStIb15kyTqZQ05H/0kWv6UpOx7hcnk2tRWaEk67HnyG/iu0XCNNUG+wU1",
-	"7I4+V9KS9KxYVYXI0bFmn4zjnzOTj6hE99+/NA1Yjz3KlqZk4a3JaIplVRBbLBbJhgVvXrOEjQg5aW9t",
-	"+PcifMWXWmjirGd1TcmKLjuriPWYsVrIIXNCA9vlTmxCWhqSdtY41mikI2js7M1ZpVVF2orgwzEWNXVr",
-	"jk9U/xPl3osGS7rGskOKjE/XhSRsmiqsRJorTkOSKU2txtTi0DNVqLFkvcC86NDoHgk5UNvovlDSopAG",
-	"uBgMSJO0EOEEJ8OAqatKaUsc+jNw5uQWDOkxaZYwK6xzBbtdfQ7RRYYlbEzaBEUXZ+dn5+7bVUUSK8F6",
-	"7Il/lLAK7ch/RxsyleqKxJ9v31yDMIC1VSVakWNRzKBEbUZYEAchrXIm1rk1Z8xr0j4Uf+KR+2UEL2Ex",
-	"3J8rPjtGCPtMWUmwy/PzB8qURcKugrIuGa1R2UrKezEDrIsOn7+Xn6WaSCCtlY5flpV1YUWF2q5ite7t",
-	"XxuSXVzeyssGSpcpR4tH8vqhNJ3a8ammAq0rYF8F4CZQ7ofDivijovB39JwUg3gCdNap25GaGBipCVgF",
-	"nLCAibAjaBg3CqyQgGCEHBYEjVFJJ5gFxYP4meQ38VveORlHr2fJmpRpOplMUp9AtS5IukOJf5tYUeKQ",
-	"skoO19mdbLSsx/oz60J2+0g9UCInzNLUZlWBYsMxmyofqKT/4+mDJXZIV6nSCFG60kJ2J+51Swv/vjy/",
-	"+g80gkMCK0+HBaDkIOuicI3wkiaKhz9//wNoSjoXhgzYEVqopSHbEqAmUKWwrqkaaFWCHS3FbOX+tXoR",
-	"bPp/NH8rDq+6vgQi13rr3FgdfbEORPOy6Yq3Y6HxQCf7dsYEBJpmO3U5kfZjhepGIBY4cFSu1Wt4EzAK",
-	"SmFcnQwvzUjVBQcsJjgzoUJv93w3kd31fr40Hr3xSzZmix+7EWyhdbl9Gmjf0dR+Fdo9Ss++8D10Vdsf",
-	"Ij+V8XSo0s80myjNUz8vkiVtsrmzc+FkDalD5NuWEnKU0CdwMyYHHFjS8EpBFGk68Al6X6nXgWQpyo98",
-	"7Y/eb3PmnOfHQJbECTj4L9ljwP94XKgab4b1R7qm6q6AjySN6zQNjGsJuzDu8F/QdLNCcZqh9f7Y3FoI",
-	"PURQGywpdYESQjlFyX31SeMyZZbN3dvFfeAMNRkjlATrqtJAaRDG1ASPLp7+72kPEFw8QhuoUNbGglTW",
-	"IdlXteQfpF84YNO1h+LVWACfHH2fcqwNuRPe1TV38qNPobMPcgvy27gV8pnyTHKH89sobqec8X/2zpnD",
-	"x1S73jpy27yqZzNnX+Yj5dsvWsenj/nnJoxcQbh7gnYnyy5T8wEniO/9MKnDw7t9Frl2cds3DiQ7eHEs",
-	"OKmsrK72lHwyp5qKcjEQxNtRJdh2V/F6oWSuya5vElxP5cpTKwz6Mx/+wQO+zZpQKGMVGgPC+sOoEGHp",
-	"y7dHj/dLy+I08W55Kt+H6uMjYfr4VIhenV/sz/LkyHGzthG4Ix9vfnkZaPZdfR9s9bDnCXA4vSdK54mw",
-	"o6+vGuIwv2wNcxJj11hLDppsrSVxGAts7jO2cjMKWMLa1R7EMb1tEJqbs316hOReWZfs3tuzjz/wTcvp",
-	"7iSTB97jPFTW1FLcd//3Xvp2PRxBmyeVUPI7vd3DwpKWaMWY/nuYtfC2FCXpzcDn/QZ6yY4aPn5/9+7H",
-	"jrpFwsKFdSiYtS5cVbO26mVZuOg+MxMcDkmfCZVhJZyX/goAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWEIRMxTh2JdDCKICNxjJw0cOikQehQhJCNUsp4BCmi",
+	"DwsREevMCSOGTZmIExFaFElwocKQD0WEgQOHTZoxYVQifKFmDsukc8agKdMmjEgSEc20HPGCoEGER+e8",
+	"yLq1q9oyeMIY9Fmzj82RJU+mXOmm5ZMlIm5u3fizYdLBJOXEENmxTpqIZBzSkfPxJluuXpPSyQOnTMs5",
+	"k9O4OVNXcBnCcmQwlukYsmTKZSxrxSxyc+eWoumUOfOzrt27l92KhCu3qeekcOS86SxH5cWkdsKw+Vib",
+	"83ERoE+OLi3C9vU3YtSUGRMSuNwyTs6LTL78p3PDAt2o12z9c+jtN/G0eLM0TQuCJPHmRgtwTRZGC3SE",
+	"cQZ8IsARhhxytSRfG579dpN3LYEnHnm+3SSaGW+IRFJWeknVlw4iDIFQgqLNAQIZaZhhxk9HgVCUbguB",
+	"4J2Lc9TB1BvNlUEGCGLkAUJ2T9Fx5E929HZhGnTQheIUoZG3pBxNygECcXNddFOWc/DVUgwuwFBmTTe1",
+	"Jx8cabQ0Q5ln3uQgHWgwSJVVJwp0EGgi5oWSiS0pMcUTToCQhoth1EFHQVE9JR0bRnYlxxxoSCekoQu9",
+	"ceRkdZA3hwuBidAehCYmERmKghJaRFxdhtoYSEK8QUYeRK14lEhLNeWoiXdeJVBwmQkEVhlioUiWWRSl",
+	"tdZsbr3ApXG+3QUURRYxKAMMMNRq1EK4MuUUVLxW5St2zAYrwrDFinBsQckupBawb7EKrYV4kfinmCj+",
+	"haYINGD7VVhjlcUuWu6+MK1QEr2gEUes0XQXSWYkygZSAo1o0r1XiVCFG2u48cYdbmwph3JyRHvTC23U",
+	"MTFKD1Lc4Bt8JjVqowiZ2lITKqvkYHOrFkfXTa+CFuus2uLocsor70zHCyDK0UYLZERlLrD/EhswsgQz",
+	"tGxbYcTrc4X0HlzRcwJdm21SN96aFNI6t8w0kE9HnaBIVCeF7tUDJ1QwvM7KSxe9FpeIrwj63tXv2cIC",
+	"bKzAZ+mttdjVKrxR0OXdBLHELgeO8Ykac+wxyCKTbLIIKOfMcnMtRMRGVEKuB7PLM5d6qgg4J91yTKvr",
+	"RkbPrQLdsNCy0oq2rdyubbrSBpeRe+tYlVt1uus2rizfz/4dtkTUki2C2UWrLRDbpy+tOuun/uq83Yqr",
+	"y3i7WlPvN9gP+7lXxoXfdPjzeEtfMOQJL0z5vpfLWZ/sNT/ObaxjHwvZT0T3m7uULmlS0tPrBnixArZk",
+	"Cmj4mIsyeAcdaYok0gHBHaCEBhCAzzg2Ip6SdoQpEIThSKI5g09A8L80MYdmbrAZimqnM5/EZCagCYIb",
+	"yBCToIyNCtZpiO+ASIehCU8gaSueQHL1LRz2Kk/k4hr+Foc1x72rXF5rlV1uQsVd8eUF+rmDGlvQtKfV",
+	"QQ4+cQOAmGc+LaLPalzM2/TA2LevcScNXeHNC+CwnebZUSBtjEpLiqSbUGEIRUjazhhFcEK3tRFqUqPb",
+	"+RKHR/V1cY9cC+O87qIbPCytKWEQjSYP2Z36QPI+pGmg74xYLZFwb3jbclkZwXVGcWGxbpyE3vqy9sVQ",
+	"9lGMd9mlFdO4xku+MY5zLF8WaXNHYX5yb3ysHtg8FMgyDLKQdaQmIuGmSBQx0jMXciV2YMmdSjbnbU7D",
+	"5NwMKc5zpS967CsmZkRpvQsVaJCrUyU9u1Kd27xSO7GcpOYsmC/AGM5f1cxfPpNHy/5N7nflodcLPPYf",
+	"FbYAMYVxXcwqJj9AocgJb+hoLkGAgmvRIAU0xB7CREhCECzHRCEMwxBB4AaVra4nZYhpRUEA0kmBQByA",
+	"oMSW8PCTMRxKIjqqlJLqMDYlFRVREbFpG6CkOxCYQTltiGpQ+Req2PFFhyJAqYpyiYTTJEaJOJHp2KwF",
+	"AxpQUHAZQykI1mq0UF1VJD1lw0998lG39mag5grsYI/Dqdi00qDrRCh3bsoX6RQWNaus5yMjG8NoabQx",
+	"jxFSC3zZAjEET6SZK+ngfvgR0BApeIZyEWghw4IjaWqrcwjTaF47qyNlUGVDks4dwpAHFy0QSKCy4U9w",
+	"iFbWhpYMqXKCE12F0enisq9JUWa48JRZgkY0j/prXzbf16G4euS5r/mItORay6TcEooq7JaueDkVX3bX",
+	"XHcD70Td50fAqZZ+DrUfRIMpUWJSNHtq8R9GAUgszN11cy054OcUODIgjS5554UMggpU2tMiZ4JJWahJ",
+	"RcBakPDWSIeKaYaFVFurmPBQuj3DiX37BuC6kA3DLW7okFvWG8quJc6FDBUKNN0ltraJHoZvLmvzT1QK",
+	"NJzeFchmI5nQ9a74VI1db0XpiriBxFczTQ7oLzf52OtQubwiHlz9+DVge3YSnwbmX4IvykQGR0yAIf6v",
+	"AT2XwB2XTJakAwqTRHuGlK6hDHm4A5DI0IKdnUc3k3rBHrzTB5HwJrUEHDEUHvTowthIp0QK6oQuFQYz",
+	"QBoER9DUoRO9aLiatWazK+KgyZDqJSBa0XIgw6YhRCFIw9XRvQ6pDrYgEIE2KCpoCNWoW4IhI6NXB42V",
+	"DSunzE67dGGWCLZlm6PoslKeUsz3LaiZq61QPfvFoZ8tg054Qlg5o/bBDCUxe6EKlZCJYazEctGiUhhe",
+	"tbhbuaQ6a6zVvROgFjHbRoZVkr285Ox6y4z15S5it+hJPWLTmNocnbvd2+b8VrzfB0aYvwnObhpVdF/3",
+	"++7HJypnyTGszvG788TgPWIJ9/m4f9boTijUglE3mtNP0ymjTTurRiuHOZuR9Kgr/eGR1quCI47JGYAS",
+	"JoToyMRNi22PgjqCGNygBjfQgQtBMKcSArsMp06Zaz2mpHu/lqpk4IIbcqOpF1JuxuxBupHUoJO2jydR",
+	"FhGrkSj1oKC+cNQukHuPl/vjKZ0nPRTatVyESAYnQuHo7qGVnICOdmETWwTGLruy5yOCZTvbNdCGjbQ1",
+	"q84zWzvhwCPadb2nlIfT1w1XDLfK4ezFre1zLY9XD6A3XrZtf3mKtreifSe++2H2nm87R4/wy53pwRVB",
+	"K2+AKp3wzcQZa2QMa7iwt98tMx8LvCVDNiXvoAV7JMteydiVcphTOeZpt57ckyT+9ozfcPmbEqD0p3tS",
+	"dn+S5V/VB2Ao13H35HzK0nIKBnOW02B4RlIHuGcIBDo4d2FUdYFYtCewY36wFmF8BjLr9zPmdWTWBX+0",
+	"B0gK4k2ERBrMN05OU04icE6ORICdNXzzxmXdI0UiYAdpQBJvgDJwYFcxKAKJhBQ1mAeNlE6Q5XrUB3Vq",
+	"FmBs1mUex3sNuIMu9z8x52B5VoEiyIF+poEV0RlOZQZpIFrchiCuJEFOl2YZs1Ym0XkptFLeEVs89QZK",
+	"MhHjESNpOCRFIlZHUi4tpil3EFRqpyQOkluGskKaMgZOUSNztHgBF4IosjF8eIZ/yFdHgUS30X4pyHDx",
+	"B3rd9AIqIIBISE5KaINOOG4FeD1bpm1dxm0iAYRCaIqomISLxIToVGb28YrxA4YNlYBWuIDX9Dha+IBH",
+	"loCL0XzHOHJbtoUL9lAzQHFYuD/JSGfL2IUT+HR4ZYETNoaA9gLPpBDRRH4C8Wo5NDtVIAVMUARyJCtC",
+	"UoK9SDmhSIsON1/L1AJqdAdsBDctUI7xSBLSBExuZk0WJ14YR146GIscN4vHV3v6yCvM5I/OBEfmKI8F",
+	"SWZXyIAX93sZZ4BSiIAPVYxv5pHIGI3K6DARKHOYNpLgeHMVlnOT9AIjRCeX9Vbo6I0QhiJthRouUm+h",
+	"FlNjUAZp0CTBtVMRQQdvlBBDAoQvlB2dwhCUyFyz85NvRY+hcna+5hCfZ2xFNXoU0hJFtRinxzzRNk1R",
+	"5osHlYM2UWycE5Y3sWwoUlSqsXpruVm5sRu98XonqHDvJ4q0p129JHFQhl/GmJD61CwhCYvZ9pA9qEvJ",
+	"t13jYpAd+Yy+x5gMGYXfeG5+ZViTIhJluRpXll6OZZDU9oqmgRqqkRSzhZaqp5bmopdGwRs5N5c+VXI5",
+	"eViHCVi5CVSm2Yq/6JY2hFNssJslc4Sp6ZaTlHIEpl9xlo0vt40t6YUUCJNhGI4ZOI43iQYBOXfj4oE0",
+	"Nzgbwxc6Uh8AZ5UiyBdaCYoLh4/IN5GFWZkcmZggx1/IlH87KIuRKV9VxCvSAWnyoRJNsgLL15vOqJiZ",
+	"2TXHNEpkNJnzWX/1hBZPUCyft5ySxALPuXIGhp/z0gUi2ZnDuJo6eRig2YwQwRrPlpaoiYOSdBd2SZqt",
+	"AZuVIZvihhu12Zf04pwHWWC954DayJJ44ZLjmTE2h4Ez6VmWMWihOWwC8UxkSQd0AAc68AJrUSV04AJz",
+	"MFxnYJsusBIv0B81AaIBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/multicontent/echo/serversstrictmulticontentecho.gen.go
+++ b/internal/test/servers/strict/multicontent/echo/serversstrictmulticontentecho.gen.go
@@ -5,7 +5,7 @@ package serversstrictmulticontentecho
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -460,32 +460,33 @@ func (sh *strictHandler) Test(ctx echo.Context) error {
 	return nil
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"rM8xSwQxEAXgvyJPy3BZtYvYWAj2ltfEOOvlyM0MyVjIsv9dEhcWLMVp3jTvY2ZBkosKE1tDWNDSiS5x",
-	"rK/UrKd9KSFA3s6UDOu6OmSeBYE/S3EQJY6aEXB/mA63cNBopyF424gPGiFKNVoWfnlH+PEdKjUVbjQa",
-	"d9PUIwkb8ehE1ZLTaPlzE96P7NtNpRkB137/wm8v+OH3a38TD1daZc6FHo94ivWIfzafRf5gbvMdAAD/",
-	"/w==",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIqiUmUPHoUA6eeCUcSjijRg1ZcZ07MOShYg0bsy8ceim",
+	"Dhs2Lt+IdBMGThqSM1zAcBFDhEs4YeiguSjwBZ2NHTGeKRNVoM4ycpKmQZiEDEmNHI2KkLPxoJs5Gz2K",
+	"kAEDhlqCCxVWFdETDps0Y7QifKFmDkK1ESdWVEuCrBmSI14QNIhQ7pwXgSlafAF2ZR+Xde/mpbPVDV+/",
+	"bnaAgCPnjZk0bMr04CJCSBg5rAFLlEzYMGLFBc06hjy74uPKIlrShWMXr17PfRGKJm0atWrWRt68iY0x",
+	"8mCMhcsc1iEi8WLdCx9bnwycpfnzAQE=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/multicontent/fiber/serversstrictmulticontentfiber.gen.go
+++ b/internal/test/servers/strict/multicontent/fiber/serversstrictmulticontentfiber.gen.go
@@ -5,7 +5,7 @@ package serversstrictmulticontentfiber
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -436,32 +436,33 @@ func (sh *strictHandler) Test(ctx *fiber.Ctx) error {
 	return nil
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"rM8xSwQxEAXgvyJPy3BZtYvYWAj2ltfEOOvlyM0MyVjIsv9dEhcWLMVp3jTvY2ZBkosKE1tDWNDSiS5x",
-	"rK/UrKd9KSFA3s6UDOu6OmSeBYE/S3EQJY6aEXB/mA63cNBopyF424gPGiFKNVoWfnlH+PEdKjUVbjQa",
-	"d9PUIwkb8ehE1ZLTaPlzE96P7NtNpRkB137/wm8v+OH3a38TD1daZc6FHo94ivWIfzafRf5gbvMdAAD/",
-	"/w==",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIqiUmUPHoUA6eeCUcSjijRg1ZcZ07MOShYg0bsy8ceim",
+	"Dhs2Lt+IdBMGThqSM1zAcBFDhEs4YeiguSjwBZ2NHTGeKRNVoM4ycpKmQZiEDEmNHI2KkLPxoJs5Gz2K",
+	"kAEDhlqCCxVWFdETDps0Y7QifKFmDkK1ESdWVEuCrBmSI14QNIhQ7pwXgSlafAF2ZR+Xde/mpbPVDV+/",
+	"bnaAgCPnjZk0bMr04CJCSBg5rAFLlEzYMGLFBc06hjy74uPKIlrShWMXr17PfRGKJm0atWrWRt68iY0x",
+	"8mCMhcsc1iEi8WLdCx9bnwycpfnzAQE=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/multicontent/iris/serversstrictmulticontentiris.gen.go
+++ b/internal/test/servers/strict/multicontent/iris/serversstrictmulticontentiris.gen.go
@@ -5,7 +5,7 @@ package serversstrictmulticontentiris
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -424,32 +424,33 @@ func (sh *strictHandler) Test(ctx iris.Context) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"rM8xSwQxEAXgvyJPy3BZtYvYWAj2ltfEOOvlyM0MyVjIsv9dEhcWLMVp3jTvY2ZBkosKE1tDWNDSiS5x",
-	"rK/UrKd9KSFA3s6UDOu6OmSeBYE/S3EQJY6aEXB/mA63cNBopyF424gPGiFKNVoWfnlH+PEdKjUVbjQa",
-	"d9PUIwkb8ehE1ZLTaPlzE96P7NtNpRkB137/wm8v+OH3a38TD1daZc6FHo94ivWIfzafRf5gbvMdAAD/",
-	"/w==",
+	"APeIGPOmDZw3bsq4oTNHhA6Bc8agKdMmTMOHIqiUmUPHoUA6eeCUcSjijRg1ZcZ07MOShYg0bsy8ceim",
+	"Dhs2Lt+IdBMGThqSM1zAcBFDhEs4YeiguSjwBZ2NHTGeKRNVoM4ycpKmQZiEDEmNHI2KkLPxoJs5Gz2K",
+	"kAEDhlqCCxVWFdETDps0Y7QifKFmDkK1ESdWVEuCrBmSI14QNIhQ7pwXgSlafAF2ZR+Xde/mpbPVDV+/",
+	"bnaAgCPnjZk0bMr04CJCSBg5rAFLlEzYMGLFBc06hjy74uPKIlrShWMXr17PfRGKJm0atWrWRt68iY0x",
+	"8mCMhcsc1iEi8WLdCx9bnwycpfnzAQE=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/test/servers/strict/stdhttp/server.gen.go
+++ b/internal/test/servers/strict/stdhttp/server.gen.go
@@ -7,7 +7,7 @@ package api
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1931,52 +1931,83 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7FndbtvGEn6VweZcnJNDmrbjgwC6S4Igp03rBHZy1eRixB1Jm5C7zO5SPxAE9CH6hH2SYn9I/dGOlEpW",
-	"EPTKFjl/nG9mdmZ2znJVVkqStIb15kyTqZQ05H/0kWv6UpOx7hcnk2tRWaEk67HnyG/iu0XCNNUG+wU1",
-	"7I4+V9KS9KxYVYXI0bFmn4zjnzOTj6hE99+/NA1Yjz3KlqZk4a3JaIplVRBbLBbJhgVvXrOEjQg5aW9t",
-	"+PcifMWXWmjirGd1TcmKLjuriPWYsVrIIXNCA9vlTmxCWhqSdtY41mikI2js7M1ZpVVF2orgwzEWNXVr",
-	"jk9U/xPl3osGS7rGskOKjE/XhSRsmiqsRJorTkOSKU2txtTi0DNVqLFkvcC86NDoHgk5UNvovlDSopAG",
-	"uBgMSJO0EOEEJ8OAqatKaUsc+jNw5uQWDOkxaZYwK6xzBbtdfQ7RRYYlbEzaBEUXZ+dn5+7bVUUSK8F6",
-	"7Il/lLAK7ch/RxsyleqKxJ9v31yDMIC1VSVakWNRzKBEbUZYEAchrXIm1rk1Z8xr0j4Uf+KR+2UEL2Ex",
-	"3J8rPjtGCPtMWUmwy/PzB8qURcKugrIuGa1R2UrKezEDrIsOn7+Xn6WaSCCtlY5flpV1YUWF2q5ite7t",
-	"XxuSXVzeyssGSpcpR4tH8vqhNJ3a8ammAq0rYF8F4CZQ7ofDivijovB39JwUg3gCdNap25GaGBipCVgF",
-	"nLCAibAjaBg3CqyQgGCEHBYEjVFJJ5gFxYP4meQ38VveORlHr2fJmpRpOplMUp9AtS5IukOJf5tYUeKQ",
-	"skoO19mdbLSsx/oz60J2+0g9UCInzNLUZlWBYsMxmyofqKT/4+mDJXZIV6nSCFG60kJ2J+51Swv/vjy/",
-	"+g80gkMCK0+HBaDkIOuicI3wkiaKhz9//wNoSjoXhgzYEVqopSHbEqAmUKWwrqkaaFWCHS3FbOX+tXoR",
-	"bPp/NH8rDq+6vgQi13rr3FgdfbEORPOy6Yq3Y6HxQCf7dsYEBJpmO3U5kfZjhepGIBY4cFSu1Wt4EzAK",
-	"SmFcnQwvzUjVBQcsJjgzoUJv93w3kd31fr40Hr3xSzZmix+7EWyhdbl9Gmjf0dR+Fdo9Ss++8D10Vdsf",
-	"Ij+V8XSo0s80myjNUz8vkiVtsrmzc+FkDalD5NuWEnKU0CdwMyYHHFjS8EpBFGk68Al6X6nXgWQpyo98",
-	"7Y/eb3PmnOfHQJbECTj4L9ljwP94XKgab4b1R7qm6q6AjySN6zQNjGsJuzDu8F/QdLNCcZqh9f7Y3FoI",
-	"PURQGywpdYESQjlFyX31SeMyZZbN3dvFfeAMNRkjlATrqtJAaRDG1ASPLp7+72kPEFw8QhuoUNbGglTW",
-	"IdlXteQfpF84YNO1h+LVWACfHH2fcqwNuRPe1TV38qNPobMPcgvy27gV8pnyTHKH89sobqec8X/2zpnD",
-	"x1S73jpy27yqZzNnX+Yj5dsvWsenj/nnJoxcQbh7gnYnyy5T8wEniO/9MKnDw7t9Frl2cds3DiQ7eHEs",
-	"OKmsrK72lHwyp5qKcjEQxNtRJdh2V/F6oWSuya5vElxP5cpTKwz6Mx/+wQO+zZpQKGMVGgPC+sOoEGHp",
-	"y7dHj/dLy+I08W55Kt+H6uMjYfr4VIhenV/sz/LkyHGzthG4Ix9vfnkZaPZdfR9s9bDnCXA4vSdK54mw",
-	"o6+vGuIwv2wNcxJj11hLDppsrSVxGAts7jO2cjMKWMLa1R7EMb1tEJqbs316hOReWZfs3tuzjz/wTcvp",
-	"7iSTB97jPFTW1FLcd//3Xvp2PRxBmyeVUPI7vd3DwpKWaMWY/nuYtfC2FCXpzcDn/QZ6yY4aPn5/9+7H",
-	"jrpFwsKFdSiYtS5cVbO26mVZuOg+MxMcDkmfCZVhJZyX/goAAP//",
+	"APeIGPOmDZw3bsq4oTNHhA6BcsrMOehmjkSHAsWEIRMxTh2JdDCKICNxjJw0cOikQehQhJCNUsp4BCmi",
+	"DwsREevMCSOGTZmIExFaFElwocKQD0WEgQOHTZoxYVQifKFmDsukc8agKdMmjEgSEc20HPGCoEGER+e8",
+	"yLq1q9oyeMIY9Fmzj82RJU+mXOmm5ZMlIm5u3fizYdLBJOXEENmxTpqIZBzSkfPxJluuXpPSyQOnTMs5",
+	"k9O4OVNXcBnCcmQwlukYsmTKZSxrxSxyc+eWoumUOfOzrt27l92KhCu3qeekcOS86SxH5cWkdsKw+Vib",
+	"83ERoE+OLi3C9vU3YtSUGRMSuNwyTs6LTL78p3PDAt2o12z9c+jtN/G0eLM0TQuCJPHmRgtwTRZGC3SE",
+	"cQZ8IsARhhxytSRfG579dpN3LYEnHnm+3SSaGW+IRFJWeknVlw4iDIFQgqLNAQIZaZhhxk9HgVCUbguB",
+	"4J2Lc9TB1BvNlUEGCGLkAUJ2T9Fx5E929HZhGnTQheIUoZG3pBxNygECcXNddFOWc/DVUgwuwFBmTTe1",
+	"Jx8cabQ0Q5ln3uQgHWgwSJVVJwp0EGgi5oWSiS0pMcUTToCQhoth1EFHQVE9JR0bRnYlxxxoSCekoQu9",
+	"ceRkdZA3hwuBidAehCYmERmKghJaRFxdhtoYSEK8QUYeRK14lEhLNeWoiXdeJVBwmQkEVhlioUiWWRSl",
+	"tdZsbr3ApXG+3QUURRYxKAMMMNRq1EK4MuUUVLxW5St2zAYrwrDFinBsQckupBawb7EKrYV4kfinmCj+",
+	"haYINGD7VVhjlcUuWu6+MK1QEr2gEUes0XQXSWYkygZSAo1o0r1XiVCFG2u48cYdbmwph3JyRHvTC23U",
+	"MTFKD1Lc4Bt8JjVqowiZ2lITKqvkYHOrFkfXTa+CFuus2uLocsor70zHCyDK0UYLZERlLrD/EhswsgQz",
+	"tGxbYcTrc4X0HlzRcwJdm21SN96aFNI6t8w0kE9HnaBIVCeF7tUDJ1QwvM7KSxe9FpeIrwj63tXv2cIC",
+	"bKzAZ+mttdjVKrxR0OXdBLHELgeO8Ykac+wxyCKTbLIIKOfMcnMtRMRGVEKuB7PLM5d6qgg4J91yTKvr",
+	"RkbPrQLdsNCy0oq2rdyubbrSBpeRe+tYlVt1uus2rizfz/4dtkTUki2C2UWrLRDbpy+tOuun/uq83Yqr",
+	"y3i7WlPvN9gP+7lXxoXfdPjzeEtfMOQJL0z5vpfLWZ/sNT/ObaxjHwvZT0T3m7uULmlS0tPrBnixArZk",
+	"Cmj4mIsyeAcdaYok0gHBHaCEBhCAzzg2Ip6SdoQpEIThSKI5g09A8L80MYdmbrAZimqnM5/EZCagCYIb",
+	"yBCToIyNCtZpiO+ASIehCU8gaSueQHL1LRz2Kk/k4hr+Foc1x72rXF5rlV1uQsVd8eUF+rmDGlvQtKfV",
+	"QQ4+cQOAmGc+LaLPalzM2/TA2LevcScNXeHNC+CwnebZUSBtjEpLiqSbUGEIRUjazhhFcEK3tRFqUqPb",
+	"+RKHR/V1cY9cC+O87qIbPCytKWEQjSYP2Z36QPI+pGmg74xYLZFwb3jbclkZwXVGcWGxbpyE3vqy9sVQ",
+	"9lGMd9mlFdO4xku+MY5zLF8WaXNHYX5yb3ysHtg8FMgyDLKQdaQmIuGmSBQx0jMXciV2YMmdSjbnbU7D",
+	"5NwMKc5zpS967CsmZkRpvQsVaJCrUyU9u1Kd27xSO7GcpOYsmC/AGM5f1cxfPpNHy/5N7nflodcLPPYf",
+	"FbYAMYVxXcwqJj9AocgJb+hoLkGAgmvRIAU0xB7CREhCECzHRCEMwxBB4AaVra4nZYhpRUEA0kmBQByA",
+	"oMSW8PCTMRxKIjqqlJLqMDYlFRVREbFpG6CkOxCYQTltiGpQ+Req2PFFhyJAqYpyiYTTJEaJOJHp2KwF",
+	"AxpQUHAZQykI1mq0UF1VJD1lw0998lG39mag5grsYI/Dqdi00qDrRCh3bsoX6RQWNaus5yMjG8NoabQx",
+	"jxFSC3zZAjEET6SZK+ngfvgR0BApeIZyEWghw4IjaWqrcwjTaF47qyNlUGVDks4dwpAHFy0QSKCy4U9w",
+	"iFbWhpYMqXKCE12F0enisq9JUWa48JRZgkY0j/prXzbf16G4euS5r/mItORay6TcEooq7JaueDkVX3bX",
+	"XHcD70Td50fAqZZ+DrUfRIMpUWJSNHtq8R9GAUgszN11cy054OcUODIgjS5554UMggpU2tMiZ4JJWahJ",
+	"RcBakPDWSIeKaYaFVFurmPBQuj3DiX37BuC6kA3DLW7okFvWG8quJc6FDBUKNN0ltraJHoZvLmvzT1QK",
+	"NJzeFchmI5nQ9a74VI1db0XpiriBxFczTQ7oLzf52OtQubwiHlz9+DVge3YSnwbmX4IvykQGR0yAIf6v",
+	"AT2XwB2XTJakAwqTRHuGlK6hDHm4A5DI0IKdnUc3k3rBHrzTB5HwJrUEHDEUHvTowthIp0QK6oQuFQYz",
+	"QBoER9DUoRO9aLiatWazK+KgyZDqJSBa0XIgw6YhRCFIw9XRvQ6pDrYgEIE2KCpoCNWoW4IhI6NXB42V",
+	"DSunzE67dGGWCLZlm6PoslKeUsz3LaiZq61QPfvFoZ8tg054Qlg5o/bBDCUxe6EKlZCJYazEctGiUhhe",
+	"tbhbuaQ6a6zVvROgFjHbRoZVkr285Ox6y4z15S5it+hJPWLTmNocnbvd2+b8VrzfB0aYvwnObhpVdF/3",
+	"++7HJypnyTGszvG788TgPWIJ9/m4f9boTijUglE3mtNP0ymjTTurRiuHOZuR9Kgr/eGR1quCI47JGYAS",
+	"JoToyMRNi22PgjqCGNygBjfQgQtBMKcSArsMp06Zaz2mpHu/lqpk4IIbcqOpF1JuxuxBupHUoJO2jydR",
+	"FhGrkSj1oKC+cNQukHuPl/vjKZ0nPRTatVyESAYnQuHo7qGVnICOdmETWwTGLruy5yOCZTvbNdCGjbQ1",
+	"q84zWzvhwCPadb2nlIfT1w1XDLfK4ezFre1zLY9XD6A3XrZtf3mKtreifSe++2H2nm87R4/wy53pwRVB",
+	"K2+AKp3wzcQZa2QMa7iwt98tMx8LvCVDNiXvoAV7JMteydiVcphTOeZpt57ckyT+9ozfcPmbEqD0p3tS",
+	"dn+S5V/VB2Ao13H35HzK0nIKBnOW02B4RlIHuGcIBDo4d2FUdYFYtCewY36wFmF8BjLr9zPmdWTWBX+0",
+	"B0gK4k2ERBrMN05OU04icE6ORICdNXzzxmXdI0UiYAdpQBJvgDJwYFcxKAKJhBQ1mAeNlE6Q5XrUB3Vq",
+	"FmBs1mUex3sNuIMu9z8x52B5VoEiyIF+poEV0RlOZQZpIFrchiCuJEFOl2YZs1Ym0XkptFLeEVs89QZK",
+	"MhHjESNpOCRFIlZHUi4tpil3EFRqpyQOkluGskKaMgZOUSNztHgBF4IosjF8eIZ/yFdHgUS30X4pyHDx",
+	"B3rd9AIqIIBISE5KaINOOG4FeD1bpm1dxm0iAYRCaIqomISLxIToVGb28YrxA4YNlYBWuIDX9Dha+IBH",
+	"loCL0XzHOHJbtoUL9lAzQHFYuD/JSGfL2IUT+HR4ZYETNoaA9gLPpBDRRH4C8Wo5NDtVIAVMUARyJCtC",
+	"UoK9SDmhSIsON1/L1AJqdAdsBDctUI7xSBLSBExuZk0WJ14YR146GIscN4vHV3v6yCvM5I/OBEfmKI8F",
+	"SWZXyIAX93sZZ4BSiIAPVYxv5pHIGI3K6DARKHOYNpLgeHMVlnOT9AIjRCeX9Vbo6I0QhiJthRouUm+h",
+	"FlNjUAZp0CTBtVMRQQdvlBBDAoQvlB2dwhCUyFyz85NvRY+hcna+5hCfZ2xFNXoU0hJFtRinxzzRNk1R",
+	"5osHlYM2UWycE5Y3sWwoUlSqsXpruVm5sRu98XonqHDvJ4q0p129JHFQhl/GmJD61CwhCYvZ9pA9qEvJ",
+	"t13jYpAd+Yy+x5gMGYXfeG5+ZViTIhJluRpXll6OZZDU9oqmgRqqkRSzhZaqp5bmopdGwRs5N5c+VXI5",
+	"eViHCVi5CVSm2Yq/6JY2hFNssJslc4Sp6ZaTlHIEpl9xlo0vt40t6YUUCJNhGI4ZOI43iQYBOXfj4oE0",
+	"Nzgbwxc6Uh8AZ5UiyBdaCYoLh4/IN5GFWZkcmZggx1/IlH87KIuRKV9VxCvSAWnyoRJNsgLL15vOqJiZ",
+	"2TXHNEpkNJnzWX/1hBZPUCyft5ySxALPuXIGhp/z0gUi2ZnDuJo6eRig2YwQwRrPlpaoiYOSdBd2SZqt",
+	"AZuVIZvihhu12Zf04pwHWWC954DayJJ44ZLjmTE2h4Ez6VmWMWihOWwC8UxkSQd0AAc68AJrUSV04AJz",
+	"MFxnYJsusBIv0B81AaIBAQ==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
 	encoded := strings.Join(swaggerSpec, "")
 	compressed, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("error base64 decoding spec: %w", err)
 	}
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(zr); err != nil {
-		return nil, fmt.Errorf("read flate: %w", err)
+		return nil, fmt.Errorf("read lzw: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("close flate reader: %w", err)
+		return nil, fmt.Errorf("close lzw reader: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/pkg/codegen/inline.go
+++ b/pkg/codegen/inline.go
@@ -24,7 +24,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// GenerateInlinedSpec generates a gzipped, base64 encoded JSON representation of the
+// GenerateInlinedSpec generates a flate-compressed, base64 encoded JSON representation of the
 // swagger definition, which we embed inside the generated code.
 func GenerateInlinedSpec(t *template.Template, importMapping importMap, swagger *openapi3.T) (string, error) {
 	// ensure that any external file references are embedded into the embedded spec
@@ -35,22 +35,10 @@ func GenerateInlinedSpec(t *template.Template, importMapping importMap, swagger 
 		return "", fmt.Errorf("error marshaling swagger: %w", err)
 	}
 
-	// flate
-	var buf bytes.Buffer
-	zw, err := flate.NewWriter(&buf, flate.BestCompression)
+	str, err := compressSpec(encoded)
 	if err != nil {
-		return "", fmt.Errorf("new flate writer: %w", err)
+		return "", err
 	}
-
-	if _, err := zw.Write(encoded); err != nil {
-		return "", fmt.Errorf("write flate: %w", err)
-	}
-
-	if err := zw.Close(); err != nil {
-		return "", fmt.Errorf("close flate writer: %w", err)
-	}
-
-	str := base64.StdEncoding.EncodeToString(buf.Bytes())
 
 	var parts []string
 	const width = 80
@@ -75,4 +63,26 @@ func GenerateInlinedSpec(t *template.Template, importMapping importMap, swagger 
 			SpecParts:     parts,
 			ImportMapping: importMapping,
 		})
+}
+
+// compressSpec flate-compresses data and base64-encodes the result. The
+// compression settings here must match the flate.NewReader call in
+// inline.tmpl's decodeSpec, otherwise generated code will fail to
+// decompress its own embedded spec.
+func compressSpec(data []byte) (string, error) {
+	var buf bytes.Buffer
+	zw, err := flate.NewWriter(&buf, flate.BestCompression)
+	if err != nil {
+		return "", fmt.Errorf("new flate writer: %w", err)
+	}
+
+	if _, err := zw.Write(data); err != nil {
+		return "", fmt.Errorf("write flate: %w", err)
+	}
+
+	if err := zw.Close(); err != nil {
+		return "", fmt.Errorf("close flate writer: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }

--- a/pkg/codegen/inline.go
+++ b/pkg/codegen/inline.go
@@ -15,7 +15,7 @@ package codegen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -24,7 +24,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// GenerateInlinedSpec generates a flate-compressed, base64 encoded JSON representation of the
+// GenerateInlinedSpec generates an LZW-compressed, base64 encoded JSON representation of the
 // swagger definition, which we embed inside the generated code.
 func GenerateInlinedSpec(t *template.Template, importMapping importMap, swagger *openapi3.T) (string, error) {
 	// ensure that any external file references are embedded into the embedded spec
@@ -65,23 +65,20 @@ func GenerateInlinedSpec(t *template.Template, importMapping importMap, swagger 
 		})
 }
 
-// compressSpec flate-compresses data and base64-encodes the result. The
-// compression settings here must match the flate.NewReader call in
-// inline.tmpl's decodeSpec, otherwise generated code will fail to
-// decompress its own embedded spec.
+// compressSpec LZW-compresses data and base64-encodes the result. The order
+// and litWidth here must match the lzw.NewReader call in inline.tmpl's
+// decodeSpec, otherwise generated code will fail to decompress its own
+// embedded spec.
 func compressSpec(data []byte) (string, error) {
 	var buf bytes.Buffer
-	zw, err := flate.NewWriter(&buf, flate.BestCompression)
-	if err != nil {
-		return "", fmt.Errorf("new flate writer: %w", err)
-	}
+	zw := lzw.NewWriter(&buf, lzw.LSB, 8)
 
 	if _, err := zw.Write(data); err != nil {
-		return "", fmt.Errorf("write flate: %w", err)
+		return "", fmt.Errorf("write lzw: %w", err)
 	}
 
 	if err := zw.Close(); err != nil {
-		return "", fmt.Errorf("close flate writer: %w", err)
+		return "", fmt.Errorf("close lzw writer: %w", err)
 	}
 
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil

--- a/pkg/codegen/inline_test.go
+++ b/pkg/codegen/inline_test.go
@@ -1,0 +1,67 @@
+// Copyright 2019 DeepMap, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package codegen
+
+import (
+	"bytes"
+	"compress/flate"
+	"encoding/base64"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rawSpecFixture and compressedSpecFixture are a known-good pair: rawSpecFixture
+// compressed with compressSpec must always produce exactly compressedSpecFixture.
+//
+// compress/flate makes no promise that its compressed output is byte-stable
+// across Go versions - only that the format remains valid and round-trips
+// correctly. If a future Go release changes that output, this test - not a
+// `go generate` diff in some unrelated repo - is what should catch it.
+const rawSpecFixture = `{"openapi":"3.0.3","info":{"title":"Test API","version":"1.0.0"},"paths":{"/ping":{"get":{"operationId":"getPing","responses":{"200":{"description":"pong","content":{"application/json":{"schema":{"type":"object","properties":{"message":{"type":"string"}}}}}}}}}}}`
+
+const compressedSpecFixture = "TI6xbgMxDEN/peBsXNxm89YxW4b+gOuoFwWJJVhCgeKQfy/kG1ovNKQnkhtEqVdlFByXvByRwP1LUDY4+51Q8EHmL+/nExK+aRhLR8HrkpeMZ4JWv1rgB+W+xmclDxGlUZ2lny4oMTzHPmGQqXSjefSWc8iFrA1W371VJtikO/XpVVXv3Kbb4WYBbbB2pUedRX80esrnjZojQUdkO+8RDzKrK/0DzUdUef693wAAAP//"
+
+// TestCompressSpec_KnownGood pins compressSpec's output for a fixed input.
+// If this test starts failing after a Go toolchain upgrade, that confirms
+// compress/flate's output has changed underneath us, and any regenerated
+// *.gen.go embedding a spec will show a spurious diff.
+func TestCompressSpec_KnownGood(t *testing.T) {
+	got, err := compressSpec([]byte(rawSpecFixture))
+	require.NoError(t, err)
+	assert.Equal(t, compressedSpecFixture, got)
+}
+
+// TestCompressSpec_RoundTrip confirms the known-good compressed fixture
+// decodes back to the known-good raw fixture, using the same flate.Reader
+// settings as the decodeSpec function generated into *.gen.go by
+// inline.tmpl. If these settings ever drift apart, decoding a real embedded
+// spec at runtime would fail, and this is where that would first show up.
+func TestCompressSpec_RoundTrip(t *testing.T) {
+	compressed, err := base64.StdEncoding.DecodeString(compressedSpecFixture)
+	require.NoError(t, err)
+
+	zr := flate.NewReader(bytes.NewReader(compressed))
+	defer func() {
+		require.NoError(t, zr.Close())
+	}()
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, zr)
+	require.NoError(t, err)
+
+	assert.Equal(t, rawSpecFixture, buf.String())
+}

--- a/pkg/codegen/inline_test.go
+++ b/pkg/codegen/inline_test.go
@@ -15,7 +15,7 @@ package codegen
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"encoding/base64"
 	"io"
 	"testing"
@@ -27,17 +27,18 @@ import (
 // rawSpecFixture and compressedSpecFixture are a known-good pair: rawSpecFixture
 // compressed with compressSpec must always produce exactly compressedSpecFixture.
 //
-// compress/flate makes no promise that its compressed output is byte-stable
-// across Go versions - only that the format remains valid and round-trips
-// correctly. If a future Go release changes that output, this test - not a
-// `go generate` diff in some unrelated repo - is what should catch it.
+// compress/lzw (like compress/flate before it) makes no promise that its
+// compressed output is byte-stable across Go versions - only that the format
+// remains valid and round-trips correctly. If a future Go release changes
+// that output, this test - not a `go generate` diff in some unrelated repo -
+// is what should catch it.
 const rawSpecFixture = `{"openapi":"3.0.3","info":{"title":"Test API","version":"1.0.0"},"paths":{"/ping":{"get":{"operationId":"getPing","responses":{"200":{"description":"pong","content":{"application/json":{"schema":{"type":"object","properties":{"message":{"type":"string"}}}}}}}}}}}`
 
-const compressedSpecFixture = "TI6xbgMxDEN/peBsXNxm89YxW4b+gOuoFwWJJVhCgeKQfy/kG1ovNKQnkhtEqVdlFByXvByRwP1LUDY4+51Q8EHmL+/nExK+aRhLR8HrkpeMZ4JWv1rgB+W+xmclDxGlUZ2lny4oMTzHPmGQqXSjefSWc8iFrA1W371VJtikO/XpVVXv3Kbb4WYBbbB2pUedRX80esrnjZojQUdkO+8RDzKrK/0DzUdUef693wAAAP//"
+const compressedSpecFixture = "APeIeAOnjJswcNKI0CFihgsYLmaIYCEijRszbxYKpJOGDpsyC0VQKTOHDoggUJJMFGGnjJw5ad64CRnj4UMRfSjCCUMHzRyNIl4kdHMG6JkydIASdMkzppskZEIepQPFYlGKckjCkTmHJFAZMGAAJUNyjJw0cDjKDLmV6MoxMukYTKpDIEI4bNKMaSrzhZo5a+uKmDMGTZk2YYDSyVMw5BsxasqMSapTzlI5HL0KbkNyTpijihmDZFjyrNs+qFOr7hMQ"
 
 // TestCompressSpec_KnownGood pins compressSpec's output for a fixed input.
 // If this test starts failing after a Go toolchain upgrade, that confirms
-// compress/flate's output has changed underneath us, and any regenerated
+// compress/lzw's output has changed underneath us, and any regenerated
 // *.gen.go embedding a spec will show a spurious diff.
 func TestCompressSpec_KnownGood(t *testing.T) {
 	got, err := compressSpec([]byte(rawSpecFixture))
@@ -46,15 +47,16 @@ func TestCompressSpec_KnownGood(t *testing.T) {
 }
 
 // TestCompressSpec_RoundTrip confirms the known-good compressed fixture
-// decodes back to the known-good raw fixture, using the same flate.Reader
-// settings as the decodeSpec function generated into *.gen.go by
-// inline.tmpl. If these settings ever drift apart, decoding a real embedded
-// spec at runtime would fail, and this is where that would first show up.
+// decodes back to the known-good raw fixture, using the same lzw.Reader
+// settings (order, litWidth) as the decodeSpec function generated into
+// *.gen.go by inline.tmpl. If these settings ever drift apart, decoding a
+// real embedded spec at runtime would panic/error, and this is where that
+// would first show up.
 func TestCompressSpec_RoundTrip(t *testing.T) {
 	compressed, err := base64.StdEncoding.DecodeString(compressedSpecFixture)
 	require.NoError(t, err)
 
-	zr := flate.NewReader(bytes.NewReader(compressed))
+	zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
 	defer func() {
 		require.NoError(t, zr.Close())
 	}()

--- a/pkg/codegen/templates/imports.tmpl
+++ b/pkg/codegen/templates/imports.tmpl
@@ -8,7 +8,7 @@ package {{.PackageName}}
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/lzw"
 	"context"
 	"encoding/base64"
 	"encoding/json"

--- a/pkg/codegen/templates/inline.tmpl
+++ b/pkg/codegen/templates/inline.tmpl
@@ -1,4 +1,4 @@
-// Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
+// Base64 encoded, compressed with lzw, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
@@ -7,20 +7,20 @@ var swaggerSpec = []string{
 {{end}}}
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,
-// after base64-decoding and flate-decompressing the embedded blob.
+// after base64-decoding and lzw-decompressing the embedded blob.
 func decodeSpec() ([]byte, error) {
     encoded := strings.Join(swaggerSpec, "")
     compressed, err := base64.StdEncoding.DecodeString(encoded)
     if err != nil {
         return nil, fmt.Errorf("error base64 decoding spec: %w", err)
     }
-    zr := flate.NewReader(bytes.NewReader(compressed))
+    zr := lzw.NewReader(bytes.NewReader(compressed), lzw.LSB, 8)
     var buf bytes.Buffer
     if _, err := buf.ReadFrom(zr); err != nil {
-        return nil, fmt.Errorf("read flate: %w", err)
+        return nil, fmt.Errorf("read lzw: %w", err)
     }
     if err := zr.Close(); err != nil {
-        return nil, fmt.Errorf("close flate reader: %w", err)
+        return nil, fmt.Errorf("close lzw reader: %w", err)
     }
 
     return buf.Bytes(), nil


### PR DESCRIPTION
- refactor(codegen): extract `compressSpec` helper from `GenerateInlinedSpec`

  When we embed the OpenAPI spec as an "embedded spec" in the generated
  code, we compress its JSON form (with `compress/flate`) and then
  Base64-encode the output.

  While upgrading to Go 1.27, #2536 noticed that there is now a diff in
  the generated code, due to a slight compression improvement in
  `compress/flate`, which means that any Go 1.27 users will now see a
  diff.

  To provide a more stable output across Go versions, we can change our
  compression algorithm.

  Before we do this, we can extract a `compressSpec` helper function and
  add a test to cover the existing compression, which will fail on Go
  1.27.



- feat(codegen): migrate embedded spec compression to `compress/lzw`

  When we embed the OpenAPI spec as an "embedded spec" in the generated
  code, we compress its JSON form (with `compress/flate`) and then
  Base64-encode the output.

  While upgrading to Go 1.27, #2536 noticed that there is now a diff in
  the generated code, due to a slight compression improvement in
  `compress/flate`, which means that any Go 1.27 users will now see a
  diff.

  To provide a more stable output across Go versions, we can change our
  compression algorithm.

  Through testing, `compress/lzw` appears to be stable across Go 1.26 and
  Go 1.27, so we can switch this over.

  Closes #2536.
