### PR TITLE
docs: fix invalid client example schema type

### DIFF
--- a/examples/client/api.yaml
+++ b/examples/client/api.yaml
@@ -44,4 +44,4 @@ components:
         - id
       properties:
         id:
-          type: int
+          type: integer


### PR DESCRIPTION
Fixes #1976.\n\nThe client example used the invalid OpenAPI schema type \int\. Replace it with the OpenAPI 3.0 primitive \integer\, so generating all example schemas with \skip-prune\ succeeds.\n\nValidation: \git diff --check\ passed. The repository-required \make tidy\, \make test\, \make generate\, and \make lint\ commands could not be run because this environment does not provide \make\ or Go.