### PR TITLE
ci(readme-toc): use our `go.mod` for installing `go` version

### DIFF
--- a/.github/workflows/readme-toc.yml
+++ b/.github/workflows/readme-toc.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26"
+          go-version-file: 'go.mod'
 
       - name: Verify the README Table of Contents is up-to-date
         run: make readme-toc-check


### PR DESCRIPTION
As we don't need to specify an explicit Go version, we can instead rely
on our `go.mod`'s `go` (or `toolchain`) directives to enforce this.

This then avoids us getting unnecessary Go version bumps.
